### PR TITLE
Adds attitude information to the georef image function.

### DIFF
--- a/georefimage.cs
+++ b/georefimage.cs
@@ -357,6 +357,7 @@ namespace ArdupilotMega
 
                                 tstamp.When = photodt;
 
+                                /*
                                 kml.AddFeature(
                                     new Placemark()
                                     {
@@ -375,7 +376,7 @@ namespace ArdupilotMega
                                             Balloon = new BalloonStyle() { Text = "$[name]<br>$[description]" }
                                         }
                                     }
-                                );
+                                );*/
 
                                 double lat = double.Parse(arr[latpos]) ;
                                 double lng = double.Parse(arr[lngpos]) ;


### PR DESCRIPTION
Use the data from the first ATT line after the GPS line used for location information.

Also adds a small header to the  txt file, so it's easier for a human to parse the data.

Correct orientation on groundOverlay images (KML file).
