### PR TITLE
Removed extra slash in URI link to ChangeLog.txt from upgrade message

### DIFF
--- a/Utilities/Update.cs
+++ b/Utilities/Update.cs
@@ -170,7 +170,7 @@ new System.Net.Security.RemoteCertificateValidationCallback((sender, certificate
                     DialogResult dr = DialogResult.Cancel;
 
 
-                    dr = CustomMessageBox.Show(extra + "Update Found\n\nDo you wish to update now? [link;" + baseurl + "/ChangeLog.txt;ChangeLog]", "Update Now", MessageBoxButtons.YesNo);
+                    dr = CustomMessageBox.Show(extra + "Update Found\n\nDo you wish to update now? [link;" + baseurl + "ChangeLog.txt;ChangeLog]", "Update Now", MessageBoxButtons.YesNo);
 
                     if (dr == DialogResult.Yes)
                     {


### PR DESCRIPTION
Unneeded slash on ChangeLog.txt added two slashes to upgrade message's link to change log which will cause issues on some browsers.
