### PR TITLE
Fix for non DTR, RTS bluetooth radios

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -894,10 +894,13 @@ namespace MissionPlanner
                         log.Error(exp); 
                     }
 
-                    log.Info("set dtr rts to false");
-                    // false here
-                    comPort.BaseStream.DtrEnable = false;
-                    comPort.BaseStream.RtsEnable = false;
+                    // apm reset preset
+                    if (config["CHK_resetapmonconnect"] == null || bool.Parse(config["CHK_resetapmonconnect"].ToString()) == true)
+                    {
+                        log.Info("set dtr rts to false");
+                        comPort.BaseStream.DtrEnable = false;
+                        comPort.BaseStream.RtsEnable = false;
+                    }
 
                     // prevent serialreader from doing anything
                     comPort.giveComport = true;


### PR DESCRIPTION
Currently connection via DTR, RTS disabled BT modules is almost
impossible. This is happening due to resetting DTR line which makes the
connection impossible on some modules.

To use this fix please add following line to your config.xml:
<CHK_resetapmonconnect>false</CHK_resetapmonconnect>
