### PR TITLE
Added DefaultWebProxy to WebRequest to use IE default settings.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -83,6 +83,9 @@ namespace MissionPlanner
             GMap.NET.MapProviders.GMapProvider.WebProxy = WebRequest.GetSystemWebProxy();
             GMap.NET.MapProviders.GMapProvider.WebProxy.Credentials = CredentialCache.DefaultCredentials;
 
+            WebRequest.DefaultWebProxy = WebRequest.GetSystemWebProxy();
+            WebRequest.DefaultWebProxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+
             string name = "Mission Planner";
 
             if (File.Exists(Application.StartupPath + Path.DirectorySeparatorChar + "logo.txt"))


### PR DESCRIPTION
This commit will allow the use of Mission Planner through a proxy server with authentication.
It uses Internet Explorer configuration together with the default system credentials.

Works over proxies on NT domains.

It does not affect people not behind a proxy.
