### PR TITLE
Plane mission planning label for loiter param4=Exit tangent

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -272,7 +272,7 @@
       <P1>Turns</P1>
       <P2>Heading req</P2>
       <P3>Radius</P3>
-      <P4></P4>
+      <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
       <Z>Alt</Z>
@@ -281,7 +281,7 @@
       <P1>Time s</P1>
       <P2>Heading req</P2>
       <P3>Dir 1=CW</P3>
-      <P4></P4>
+      <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
       <Z>Alt</Z>
@@ -290,7 +290,7 @@
       <P1>Heading req</P1>
       <P2>Radius</P2>
       <P3></P3>
-      <P4></P4>
+      <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
       <Z>Alt</Z>


### PR DESCRIPTION
![loiter_exit_xtrack](https://cloud.githubusercontent.com/assets/4782875/15301793/7101aa3a-1b64-11e6-9995-49e16a4a4553.png)
label update for param4 for plane Loiter_turns, Loiter_time, Loiter_to_alt:

param4 would now show: "1=Exit Tangent"

Merged Ardupilot functionality: https://github.com/ArduPilot/ardupilot/pull/3750
Merged Mavlink documentation:  https://github.com/mavlink/mavlink/pull/531
