### PR TITLE
CurrentState: fix battery2 mavlink packet scaling

### DIFF
--- a/CurrentState.cs
+++ b/CurrentState.cs
@@ -1580,8 +1580,8 @@ namespace MissionPlanner
                     if (mavLinkMessage != null)
                     {
                         var bat = mavLinkMessage.ToStructure<MAVLink.mavlink_battery2_t>();
-                        _battery_voltage2 = bat.voltage;
-                        current2 = bat.current_battery;
+                        _battery_voltage2 = bat.voltage / 1000.0f;
+                        current2 = bat.current_battery / 100.0f;
                     }
 
                     mavLinkMessage = MAV.getPacket((uint) MAVLink.MAVLINK_MSG_ID.SCALED_PRESSURE);


### PR DESCRIPTION
Battery2 mavlink packet units is same as battery1 units: volts(mV) and current (10*mA). Batt1 was scaled correctly, batt2 had no scaling.