### PR TITLE
Improve Parrot firmware install process

### DIFF
--- a/ExtLibs/SharpAdbClient/AdbSocket.cs
+++ b/ExtLibs/SharpAdbClient/AdbSocket.cs
@@ -123,7 +123,7 @@ namespace SharpAdbClient
         /// <inheritdoc/>
         public virtual void SendSyncRequest(SyncCommand command, string path, int permissions)
         {
-            this.SendSyncRequest(command, $"{path},{permissions}");
+            this.SendSyncRequest(command, $"{path},0{permissions}");
         }
 
         /// <inheritdoc/>

--- a/Utilities/BoardDetect.cs
+++ b/Utilities/BoardDetect.cs
@@ -31,7 +31,8 @@ namespace MissionPlanner.Utilities
             vrcorev10,
             vrubrainv51,
             vrubrainv52,
-            bebop2
+            bebop2,
+            disco
         }
 
         /// <summary>
@@ -186,6 +187,11 @@ namespace MissionPlanner.Utilities
                 if (DialogResult.Yes == CustomMessageBox.Show("Is this Bebop2?", "Bebop2", MessageBoxButtons.YesNo))
                 {
                     return boards.bebop2;
+                }
+
+                if (DialogResult.Yes == CustomMessageBox.Show("Is this Disco?", "Disco", MessageBoxButtons.YesNo))
+                {
+                    return boards.disco;
                 }
             }
 

--- a/temp.cs
+++ b/temp.cs
@@ -343,6 +343,9 @@ namespace MissionPlanner
                     if (software.urlbebop2 != "")
                         xmlwriter.WriteElementString("urlbebop2",
                             new Uri(software.urlbebop2).LocalPath.TrimStart('/', '\\'));
+                    if (software.urldisco != "")
+                        xmlwriter.WriteElementString("urldisco",
+                            new Uri(software.urldisco).LocalPath.TrimStart('/', '\\'));
                     xmlwriter.WriteElementString("name", software.name);
                     xmlwriter.WriteElementString("desc", software.desc);
                     xmlwriter.WriteElementString("format_version", software.k_format_version.ToString());
@@ -417,6 +420,11 @@ namespace MissionPlanner
                     {
                         Common.getFilefromNet(software.urlbebop2,
                             basedir + new Uri(software.urlbebop2).LocalPath);
+                    }
+                    if (software.urldisco != "")
+                    {
+                        Common.getFilefromNet(software.urldisco,
+                            basedir + new Uri(software.urldisco).LocalPath);
                     }
                 }
 


### PR DESCRIPTION
This changes the firmware installation in Bebop2. It will now install the binary in /data/ftp/internal_000/APM (instead of /usr/bin) - not only this allows bigger binaries but you can change the binary with FTP, no need for adb and remount. Also the init scripts have been changed to:

- have a startup_ardupilot.sh script in the APM folder that starts the fan, logs the start of ArduPilot, and puts the running of ArduPilot in a cycle so that we can reboot with MAVLink
- test if the startup_ardupilot.sh script as well as the arducopter binary are present in the APM folder
- run the startup_ardupilot.sh script if last check is true
- run Dragon if any of them isn't (this guarantees you always have an autopilot running)

The backup of the init (rcS_mode_default) script was also changed to only be done if a backup doesn't exist already. The startup_ardupilot.sh is only uploaded if non-existent or it was modified before the current version in MP - this allows you to change this script as you wish without having MP overwrite it (unless MP itself is updated with a new script).

All has been done so that the old script is correctly changed and the binary in /usr/bin removed.

Support for Disco has been added - it only upload the binary since the Disco already has scripts to run ArduPilot, although at the moment it will always default to Dragon on reboot.

@rmackay9 @jschall @tridge 