### PR TITLE
Added AOA indicator to HUD, AOA and SSA logs and flight variables

### DIFF
--- a/CurrentState.cs
+++ b/CurrentState.cs
@@ -75,6 +75,12 @@ namespace MissionPlanner
 
         private float _yaw = 0;
 
+        [DisplayText("SSA (deg)")]
+        public float SSA { get; set; }
+
+        [DisplayText("AOA (deg)")]
+        public float AOA { get; set; }
+
         [DisplayText("GroundCourse (deg)")]
         public float groundcourse
         {
@@ -434,6 +440,33 @@ namespace MissionPlanner
         public int rxrssi { get; set; }
 
         float _ch3percent = -1;
+
+	public float crit_AOA
+        {
+            get
+            {
+                try
+                {
+                    if (MainV2.comPort.MAV.param.ContainsKey("AOA_CRIT"))
+                    {
+                        return
+                            (int)
+                                (MainV2.comPort.MAV.param["AOA_CRIT"].Value);
+                    }
+                    else
+                    {
+                        return 25;
+                    }
+                }
+                catch
+                {
+                    return 0;
+                }
+            }
+
+            set { _crit_aoa = value; }
+        }
+	float _crit_aoa = 25;
 
         public bool lowgroundspeed { get; set; }
         float _airspeed;
@@ -2330,6 +2363,15 @@ namespace MissionPlanner
                         var mem = mavLinkMessage.ToStructure<MAVLink.mavlink_meminfo_t>();
                         freemem = mem.freemem;
                         brklevel = mem.brkval;
+                    }
+
+                    mavLinkMessage = MAV.getPacket((uint)MAVLink.MAVLINK_MSG_ID.AOA_SSA);
+                    if (mavLinkMessage != null)
+                    {
+                        var aoa_ssa = mavLinkMessage.ToStructure<MAVLink.mavlink_aoa_ssa_t>();
+
+                        AOA = aoa_ssa.AOA;
+                        SSA = aoa_ssa.SSA;
                     }
                 }
 

--- a/ExtLibs/Mavlink/Mavlink.cs
+++ b/ExtLibs/Mavlink/Mavlink.cs
@@ -203,7 +203,8 @@ public partial class MAVLink
 		new message_info(218, "GOPRO_SET_REQUEST", 17, 7, 7, typeof( mavlink_gopro_set_request_t )),
 		new message_info(219, "GOPRO_SET_RESPONSE", 162, 2, 2, typeof( mavlink_gopro_set_response_t )),
 		new message_info(226, "RPM", 207, 8, 8, typeof( mavlink_rpm_t )),
-		new message_info(230, "ESTIMATOR_STATUS", 163, 42, 42, typeof( mavlink_estimator_status_t )),
+        new message_info(227, "AOA_SSA", 164, 8, 8, typeof( mavlink_aoa_ssa_t )),
+        new message_info(230, "ESTIMATOR_STATUS", 163, 42, 42, typeof( mavlink_estimator_status_t )),
 		new message_info(231, "WIND_COV", 105, 40, 40, typeof( mavlink_wind_cov_t )),
 		new message_info(232, "GPS_INPUT", 151, 63, 63, typeof( mavlink_gps_input_t )),
 		new message_info(233, "GPS_RTCM_DATA", 35, 182, 182, typeof( mavlink_gps_rtcm_data_t )),
@@ -444,6 +445,7 @@ GOPRO_GET_RESPONSE = 217,
 GOPRO_SET_REQUEST = 218,
 GOPRO_SET_RESPONSE = 219,
 RPM = 226,
+AOA_SSA = 227,
 ESTIMATOR_STATUS = 230,
 WIND_COV = 231,
 GPS_INPUT = 232,
@@ -3724,8 +3726,17 @@ ADAP_TUNING = 11010,
     
     };
 
+    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 8)]
+    public struct mavlink_aoa_ssa_t
+    {
+        /// <summary> AOA </summary>
+        public Single AOA;
+            /// <summary> SSA </summary>
+        public Single SSA;
+    
+    };
 
-    [StructLayout(LayoutKind.Sequential,Pack=1,Size=51)]
+[StructLayout(LayoutKind.Sequential,Pack=1,Size=51)]
     public struct mavlink_device_op_read_t
     {
         /// <summary> request ID - copied to reply </summary>

--- a/ExtLibs/Mavlink/message_definitions/common.xml
+++ b/ExtLibs/Mavlink/message_definitions/common.xml
@@ -3956,5 +3956,11 @@
                <field type="uint8_t" name="target_component">component ID of the target</field>
                <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
           </message>
+          <message id="270" name="AOA_SSA">
+               <description>AOA and SSA</description>
+               <field name="AOA" type="float">AOA</field>
+               <field name="SSA" type="float">SSA</field>
+          </message>
+
     </messages>
 </mavlink>

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -285,6 +285,11 @@
             this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibez", this.bindingSourceHud, "vibez", true));
             this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("wpno", this.bindingSourceHud, "wpno", true));
             this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("xtrack_error", this.bindingSourceHud, "xtrack_error", true));
+
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("AOA", this.bindingSourceHud, "AOA", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("SSA", this.bindingSourceHud, "SSA", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("critAOA", this.bindingSourceHud, "crit_AOA", true));
+
             this.hud1.datetime = new System.DateTime(((long)(0)));
             this.hud1.disttowp = 0F;
             resources.ApplyResources(this.hud1, "hud1");
@@ -329,6 +334,12 @@
             this.hud1.vibeclick += new System.EventHandler(this.hud1_vibeclick);
             this.hud1.DoubleClick += new System.EventHandler(this.hud1_DoubleClick);
             this.hud1.Resize += new System.EventHandler(this.hud1_Resize);
+
+            this.hud1.AOA = 0F;
+            this.hud1.SSA = 0F;
+            this.hud1.critAOA = 25F;
+            this.hud1.displayAOASSA = false;
+
             // 
             // contextMenuStripHud
             // 

--- a/ParameterFactMetaData.xml
+++ b/ParameterFactMetaData.xml
@@ -4941,5 +4941,11 @@ Maps the change of airspeed error to the acceleration setpoint</short_desc>
       <min>0</min>
       <max>18</max>
     </parameter>
+    <parameter default="25" name="AOA_CRIT" type="FLOAT">
+      <short_desc>Critical Angel of Atack</short_desc>
+      <long_desc>Angle of attack which produces maximum lift coefficient. This is also called the "stall angle of attack". Above this critical angle of attack, the aircraft is said to be in a stall. A fixed-wing aircraft by definition is stalled at or above the critical angle of attack rather than at or below a particular airspeed.</long_desc>
+      <min>0</min>
+      <max>40</max>
+    </parameter>
   </group>
 </parameters>

--- a/ParameterMetaDataBackup.xml
+++ b/ParameterMetaDataBackup.xml
@@ -19721,5 +19721,11 @@
       <Range>1 255</Range>
       <User>Advanced</User>
     </CMD_TOTAL>
+    <AOA_CRIT>
+      <DisplayName>Critical Angel of Atack</DisplayName>
+      <Description>Angle of attack which produces maximum lift coefficient. This is also called the "stall angle of attack". Above this critical angle of attack, the aircraft is said to be in a stall. A fixed-wing aircraft by definition is stalled at or above the critical angle of attack rather than at or below a particular airspeed.</Description>
+      <Range>0 40</Range>
+      <User>Advanced</User>
+    </AOA_CRIT>
   </ArduTracker>
 </Params>


### PR DESCRIPTION
New mavlink message with AOA and SSA was added.
If this message is received, AOA indicator is switched on in HUD.
AOA and SSA is also present in tuning variables, quick variables and logs.

![image](https://cloud.githubusercontent.com/assets/7996972/21275224/5f86bc78-c3d4-11e6-9937-f5d196054275.png)

![image](https://cloud.githubusercontent.com/assets/7996972/21275242/7fe70f7c-c3d4-11e6-94a1-c93b1cd81d36.png)

