### PR TITLE
Remove NAV_LOITER 'Heading req' param text, its always enforced

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -288,7 +288,7 @@
     </LOITER_UNLIM>
     <LOITER_TURNS>
       <P1>Turns</P1>
-      <P2>Heading req</P2>
+      <P2></P2>
       <P3>Radius</P3>
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
@@ -297,7 +297,7 @@
     </LOITER_TURNS>
     <LOITER_TIME>
       <P1>Time s</P1>
-      <P2>Heading req</P2>
+      <P2></P2>
       <P3>Dir 1=CW</P3>
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
@@ -305,7 +305,7 @@
       <Z>Alt</Z>
     </LOITER_TIME>
     <LOITER_TO_ALT>
-      <P1>Heading req</P1>
+      <P1></P1>
       <P2>Radius</P2>
       <P3></P3>
       <P4>1=Exit Tangent</P4>


### PR DESCRIPTION
This label is old and needs to be removed. It is not parsed, always treated as 1 internal to ArduPilot.

See https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Mission/AP_Mission.cpp#L550 as an example where P2 is ignored in LOITER_TURNS and LOITER_TIME and it's P1 in LOITER_TO_ALT.