### PR TITLE
TelemetryLogGraph: Fix some messages not being graphed

### DIFF
--- a/Log/MavlinkLog.cs
+++ b/Log/MavlinkLog.cs
@@ -748,6 +748,17 @@ namespace MissionPlanner.Log
 
         // Form selectform;
 
+        private static string ReplaceLastOccurrence(string Source, string Find, string Replace)
+        {
+            int place = Source.LastIndexOf(Find);
+
+            if (place == -1)
+                return Source;
+
+            string result = Source.Remove(place, Find.Length).Insert(place, Replace);
+            return result;
+        }
+
         private List<string> GetLogFileValidFields(string logfile)
         {
             // if (selectform != null && !selectform.IsDisposed)
@@ -827,7 +838,8 @@ namespace MissionPlanner.Log
 
                     if (true)
                     {
-                        string packetname = test.Name.Replace("mavlink_", "").Replace("_t", "").ToUpper();
+                        string packetname = ReplaceLastOccurrence(test.Name, "_t", "");
+                        packetname = packetname.Replace("mavlink_", "").ToUpper();
 
                         if (!packetdata.ContainsKey(packetname))
                         {
@@ -1206,7 +1218,8 @@ namespace MissionPlanner.Log
             {
                 var items = item.Split('.');
 
-                var item1text = items[0].Replace("mavlink_", "").Replace("_t", "").ToUpper();
+                var item1text = ReplaceLastOccurrence(items[0], "_t", "");
+                item1text = item1text.Replace("mavlink_", "").ToUpper();
                 var item2text = items[1];
 
                 if (!addedrootnodes.ContainsKey(item1text))


### PR DESCRIPTION
This bug is caused when mavlink message name has _t in it. For example mavlink_pid_tuning_t. Old code would remove both _t which would result in name PIDUNING

Before fix:
![image](https://cloud.githubusercontent.com/assets/5657918/22364703/f4c071d6-e47b-11e6-9d85-0f60c0e04fc8.png)

After fix:
![image](https://cloud.githubusercontent.com/assets/5657918/22364670/c2bb6592-e47b-11e6-91f7-117cdaef8ef9.png)
