### PR TITLE
MAVState.cs: array size to match extended ID space

### DIFF
--- a/Mavlink/MAVState.cs
+++ b/Mavlink/MAVState.cs
@@ -19,8 +19,8 @@ namespace MissionPlanner
             this.parent = mavLinkInterface;
             this.sysid = sysid;
             this.compid = compid;
-            this.packetspersecond = new double[0x100];
-            this.packetspersecondbuild = new DateTime[0x100];
+            this.packetspersecond = new double[0x10000];
+            this.packetspersecondbuild = new DateTime[0x10000];
             this.lastvalidpacket = DateTime.MinValue;
             sendlinkid = (byte)(new Random().Next(256));
             signing = false;


### PR DESCRIPTION
Size of packetspersecond and packetspersecondbuild arrays was 256 and during receive of Mavlink v2 messages exception was generated in MAVLinkInterfac.cs at refernce to packetspersecond[msgid].