### PR TITLE
ConfigHWCompass: show both options if autopilot doesn't present onboard capability

### DIFF
--- a/GCSViews/ConfigurationView/ConfigHWCompass.cs
+++ b/GCSViews/ConfigurationView/ConfigHWCompass.cs
@@ -40,8 +40,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if ((MainV2.comPort.MAV.cs.capabilities & MAVLink.MAV_PROTOCOL_CAPABILITY.COMPASS_CALIBRATION) == 0)
             {
-                groupBoxonboardcalib.Visible = false;
-                label4.Visible = false;
+                groupBoxonboardcalib.Visible = true;
+                label4.Visible = true;
                 groupBoxmpcalib.Visible = true;
             }
             else


### PR DESCRIPTION
Issue #1422 was implemented in c409c1a5f3f7c678e3edf03dc4f27a3bcfabee7c by showing the onboard or the live calibration if the compass calibration capability is present or not.

Unfortunately ArduPilot didn't include this capability when it started supporting the onboard calibration, notably Copter before 3.4.4 and the current Plane 3.7.1 release don't have it. This has led to complaints, especially from Plane users, that they can't use the onboard calibration.

This change makes only the onboard calibration available when the capability is present but show both types of calibration when it isn't.