### PR TITLE
removed KeyError: 'POWR'

### DIFF
--- a/LogAnalyzer/py2exe/tests/TestVCC.py
+++ b/LogAnalyzer/py2exe/tests/TestVCC.py
@@ -25,10 +25,14 @@ class TestVCC(Test):
             vccMin  = logdata.channels["CURR"]["Vcc"].min()
             vccMax  = logdata.channels["CURR"]["Vcc"].max()
         except KeyError as e:
-            vccMin  = logdata.channels["POWR"]["Vcc"].min()
-            vccMax  = logdata.channels["POWR"]["Vcc"].max()
-            vccMin *= 1000
-            vccMax *= 1000
+            try:
+                vccMin  = logdata.channels["CURR"]["Volt"].min()
+                vccMax  = logdata.channels["CURR"]["Volt"].max()
+            except KeyError as e:
+                vccMin  = logdata.channels["POWR"]["Vcc"].min()
+                vccMax  = logdata.channels["POWR"]["Vcc"].max()
+                vccMin *= 1000
+                vccMax *= 1000
 
         vccDiff = vccMax - vccMin;
         vccMinThreshold = 4.6 * 1000;


### PR DESCRIPTION
The Navio2 uses `Volt`: instead of `Vcc`