### PR TITLE
work around for emlid reach Beidou RTCM message parsing

### DIFF
--- a/SerialInjectGPS.cs
+++ b/SerialInjectGPS.cs
@@ -132,7 +132,7 @@ namespace MissionPlanner
             {
                 List<rtcm3.ob> obs = sender as List<rtcm3.ob>;
 
-				if (obs.Count == 0) return;
+                if (obs.Count == 0) return;
 				
                 // get system controls
                 Func<char,List<VerticalProgressBar2>> ctls = delegate (char sys)

--- a/SerialInjectGPS.cs
+++ b/SerialInjectGPS.cs
@@ -132,6 +132,8 @@ namespace MissionPlanner
             {
                 List<rtcm3.ob> obs = sender as List<rtcm3.ob>;
 
+				if (obs.Count == 0) return;
+				
                 // get system controls
                 Func<char,List<VerticalProgressBar2>> ctls = delegate (char sys)
                 {


### PR DESCRIPTION
https://community.emlid.com/t/rtk-inject-with-mission-planner-error/6666

MP seems do not get well with emlid reach Beidou RTCM message (message 1127).  MP will build a type1127 instance with empty obs list. This cause exception when obs[0].sys called.