### PR TITLE
Updating required Visual Studio version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ How to compile
 
 3. Build
 
-- Open MissionPlanner.sln with Visual Studio express 2013 for windows desktop.
+- Open MissionPlanner.sln with Visual Studio Community 2017 for windows desktop.
 - Compile.
 
 


### PR DESCRIPTION
Changing from VS Express 2013 to VS Community 2017. I tried opening in VS2015 and it failed reading the slns, so I went through and downloaded VS2013 to see if that would work. An hour later I found out that I wasted my time and could just open in 2017...