### PR TITLE
Updating sw and build requirements (VS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ How to compile
   https://tortoisegit.org/
 - Visual Studio
   http://www.visualstudio.com/downloads/download-visual-studio-vs
-  Select "Visual Studio Express 2013 for Windows Desktop"
+  Select "Visual Studio Community 2017 for Windows Desktop" version 15.3 or newer (to include .NET standard 2.0).
 - Microsoft .NET 4.0
+- .NET standard 2.0
 
 2. Check out
 
@@ -39,7 +40,7 @@ How to compile
 
 3. Build
 
-- Open MissionPlanner.sln with Visual Studio express 2013 for windows desktop.
+- Open MissionPlanner.sln with Visual Studio 2017 for windows desktop.
 - Compile.
 
 


### PR DESCRIPTION
Changing to VS 2017 and indicating need for .NET standard 2.0 so newcomers to the project have some clues as to why library references are broken.