### PR TITLE
Fix missing flight strip bug when doing segmentation in GridUI

### DIFF
--- a/Grid/GridUI.cs
+++ b/Grid/GridUI.cs
@@ -1593,12 +1593,12 @@ namespace MissionPlanner
 
                     while (wpstart != 0 && wpstart < grid.Count && grid[wpstart].Tag != "E")
                     {
-                        wpstart++;
+                        wpstart--;
                     }
 
-                    while (wpend < grid.Count && grid[wpend].Tag != "S")
+                    while (wpend > 0 && wpend < grid.Count && grid[wpend].Tag != "S")
                     {
-                        wpend++;
+                        wpend--;
                     }
 
                     if (CHK_toandland.Checked)


### PR DESCRIPTION
Hi ,
I'm opening the pull request of fixing missing flight strip when doing segmentation in GridUI.
This is the one that we've talked about during the Ardupilot Unconference last week. @meee1 

When planning a survey mission with 4 strips and 2 segments in 1.3.50, the latter segment missed a flight strip.
![before](https://user-images.githubusercontent.com/10142294/32143806-46a42f96-bcea-11e7-9b2d-91923109e53f.JPG)

After the fixing.
![after](https://user-images.githubusercontent.com/10142294/32143805-4663e436-bcea-11e7-8afb-22eb8b55909d.JPG)

I've tested in some other conditions, and as far as I'm concerned, this change will not lead to other bugs.


Shuhang Zhang 

