### PR TITLE
Added sysid on each marker when >1 vehicle connected

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1394,6 +1394,11 @@ namespace MissionPlanner.GCSViews
                                 foreach (var MAV in port.MAVlist)
                                 {
                                     var marker = Common.getMAVMarker(MAV);
+                                    
+                                    if (port.MAVlist.Count > 1)
+                                    {
+                                        marker.ToolTipText = "Alt: " + MAV.cs.alt.ToString("0") + " \n ID: " + (int)MAV.sysid;
+                                    }
 
                                     if(marker.Position.Lat == 0 && marker.Position.Lng == 0)
                                         continue;


### PR DESCRIPTION
When only one vehicle is connected there are no visible changes. I've introduced a small check in the "draw all mavs" loop. If there is more than one vehicle connected it displays the sysid below the altitude. At the moment it's very difficult to determine which vehicles are which and this makes it much clearer. 

Screenshot:
![image](https://user-images.githubusercontent.com/9560876/33237967-38561a86-d2ce-11e7-94d1-872bd891e629.png)


Apologies if I've done something wrong as I have very little idea about Mission Planners internal workings. (or C#/.NET for that matter)