### PR TITLE
Vector3: changed dot product overload to output a scalar #1712

### DIFF
--- a/ExtLibs/Utilities/Matrix3.cs
+++ b/ExtLibs/Utilities/Matrix3.cs
@@ -240,7 +240,7 @@ namespace MissionPlanner.Utilities
         public void normalize()
         {
             //  '''re-normalise a rotation matrix'''
-            Vector3 error = a*b;
+            double error = a*b;
             Vector3 t0 = a - (b*(0.5*error));
             Vector3 t1 = b - (a*(0.5*error));
             Vector3 t2 = t0%t1;

--- a/ExtLibs/Utilities/Vector3.cs
+++ b/ExtLibs/Utilities/Vector3.cs
@@ -166,10 +166,10 @@ namespace MissionPlanner.Utilities
             return new Vector3<T>(-(dynamic)self.x, -(dynamic)self.y, -(dynamic)self.z);
         }
 
-        public static Vector3<T> operator *(Vector3<T> self, Vector3<T> v)
+        public static double operator *(Vector3<T> self, Vector3<T> v)
         {
             //  '''dot product'''
-            return new Vector3<T>((dynamic)self.x*v.x + (dynamic)self.y*v.y + (dynamic)self.z*v.z);
+            return ((dynamic)self.x*v.x + (dynamic)self.y*v.y + (dynamic)self.z*v.z);
         }
 
         public static Vector3<T> operator *(Vector3<T> self, double v)


### PR DESCRIPTION
Resolves exceptions being thrown when DCM normalisation method is
called and prevents misinterpretation of * operator when multiplying
a vector by the result of a dot product