### PR TITLE
Couple of ui tweaks

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -141,7 +141,12 @@ namespace MissionPlanner.GCSViews
             try
             {
                 if (hud1 != null)
-                    Settings.Instance["FlightSplitter"] = hud1.Width.ToString();
+                    Settings.Instance["FlightSplitter"] = MainH.SplitterDistance.ToString();
+
+                if (!this.SubMainLeft.Panel1.Controls.Contains(hud1))
+                    Settings.Instance["HudSwap"] = "true";
+                else
+                    Settings.Instance["HudSwap"] = "false";
             }
             catch
             {
@@ -666,6 +671,9 @@ namespace MissionPlanner.GCSViews
 
             if (Settings.Instance["CHK_autopan"] != null)
                 CHK_autopan.Checked = Settings.Instance.GetBoolean("CHK_autopan");
+
+            if (Settings.Instance.ContainsKey("HudSwap") && Settings.Instance["HudSwap"] == "true")
+                SwapHud1AndMap();
 
             if (Settings.Instance.ContainsKey("FlightSplitter"))
             {

--- a/GCSViews/FlightPlanner.Designer.cs
+++ b/GCSViews/FlightPlanner.Designer.cs
@@ -274,6 +274,7 @@ namespace MissionPlanner.GCSViews
             this.Commands.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.Commands_EditingControlShowing);
             this.Commands.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.Commands_RowEnter);
             this.Commands.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.Commands_RowsAdded);
+            this.Commands.RowsRemoved += new System.Windows.Forms.DataGridViewRowsRemovedEventHandler(this.Commands_RowsRemoved);
             this.Commands.RowValidating += new System.Windows.Forms.DataGridViewCellCancelEventHandler(this.Commands_RowValidating);
             // 
             // Command

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -7100,5 +7100,10 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
             grid.Host = new PluginHost();
             grid.but_Click(sender, e);
         }
+        
+        private void Commands_RowsRemoved(object sender, DataGridViewRowsRemovedEventArgs e)
+        {
+            writeKML();
+        }
     }
 }


### PR DESCRIPTION
When row is deleted from grid in flight planner redraw waypoints. Allow saving of map / hud swap on flightdata view. Fixed bug in saving hud width... changed to save splitter width.