### PR TITLE
Sikradio: support load/save settings for multipoint firmware

### DIFF
--- a/Radio/Sikradio.Designer.cs
+++ b/Radio/Sikradio.Designer.cs
@@ -132,6 +132,14 @@
             this.label10 = new System.Windows.Forms.Label();
             this.BUT_resettodefault = new MissionPlanner.Controls.MyButton();
             this.BUT_loadcustom = new MissionPlanner.Controls.MyButton();
+            this.label43 = new System.Windows.Forms.Label();
+            this.label44 = new System.Windows.Forms.Label();
+            this.label45 = new System.Windows.Forms.Label();
+            this.label46 = new System.Windows.Forms.Label();
+            this.NODEID = new System.Windows.Forms.TextBox();
+            this.NODEDESTINATION = new System.Windows.Forms.TextBox();
+            this.NODECOUNT = new System.Windows.Forms.TextBox();
+            this.SYNCANY = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.SPLIT_local)).BeginInit();
             this.SPLIT_local.Panel1.SuspendLayout();
             this.SPLIT_local.Panel2.SuspendLayout();
@@ -151,6 +159,12 @@
             // 
             // SPLIT_local.Panel1
             // 
+            this.SPLIT_local.Panel1.Controls.Add(this.NODECOUNT);
+            this.SPLIT_local.Panel1.Controls.Add(this.NODEDESTINATION);
+            this.SPLIT_local.Panel1.Controls.Add(this.NODEID);
+            this.SPLIT_local.Panel1.Controls.Add(this.label45);
+            this.SPLIT_local.Panel1.Controls.Add(this.label44);
+            this.SPLIT_local.Panel1.Controls.Add(this.label43);
             this.SPLIT_local.Panel1.Controls.Add(this.label40);
             this.SPLIT_local.Panel1.Controls.Add(this.GPO1_1R_COUT);
             this.SPLIT_local.Panel1.Controls.Add(this.label39);
@@ -174,6 +188,8 @@
             // 
             // SPLIT_local.Panel2
             // 
+            this.SPLIT_local.Panel2.Controls.Add(this.SYNCANY);
+            this.SPLIT_local.Panel2.Controls.Add(this.label46);
             this.SPLIT_local.Panel2.Controls.Add(this.ENCRYPTION_LEVEL);
             this.SPLIT_local.Panel2.Controls.Add(this.label36);
             this.SPLIT_local.Panel2.Controls.Add(this.label35);
@@ -1151,6 +1167,46 @@
             this.BUT_loadcustom.UseVisualStyleBackColor = true;
             this.BUT_loadcustom.Click += new System.EventHandler(this.BUT_loadcustom_Click);
             // 
+            // label43
+            // 
+            resources.ApplyResources(this.label43, "label43");
+            this.label43.Name = "label43";
+            // 
+            // label44
+            // 
+            resources.ApplyResources(this.label44, "label44");
+            this.label44.Name = "label44";
+            // 
+            // label45
+            // 
+            resources.ApplyResources(this.label45, "label45");
+            this.label45.Name = "label45";
+            // 
+            // label46
+            // 
+            resources.ApplyResources(this.label46, "label46");
+            this.label46.Name = "label46";
+            // 
+            // NODEID
+            // 
+            resources.ApplyResources(this.NODEID, "NODEID");
+            this.NODEID.Name = "NODEID";
+            // 
+            // NODEDESTINATION
+            // 
+            resources.ApplyResources(this.NODEDESTINATION, "NODEDESTINATION");
+            this.NODEDESTINATION.Name = "NODEDESTINATION";
+            // 
+            // NODECOUNT
+            // 
+            resources.ApplyResources(this.NODECOUNT, "NODECOUNT");
+            this.NODECOUNT.Name = "NODECOUNT";
+            // 
+            // SYNCANY
+            // 
+            resources.ApplyResources(this.SYNCANY, "SYNCANY");
+            this.SYNCANY.Name = "SYNCANY";
+            // 
             // Sikradio
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
@@ -1166,9 +1222,8 @@
             this.Controls.Add(this.lbl_status);
             this.Controls.Add(this.Progressbar);
             this.Controls.Add(this.BUT_upload);
-            this.MinimumSize = new System.Drawing.Size(781, 433);
-            this.Name = "Sikradio";
             resources.ApplyResources(this, "$this");
+            this.Name = "Sikradio";
             this.SPLIT_local.Panel1.ResumeLayout(false);
             this.SPLIT_local.Panel1.PerformLayout();
             this.SPLIT_local.Panel2.ResumeLayout(false);
@@ -1294,5 +1349,13 @@
         private System.Windows.Forms.CheckBox RGPO1_1R_COUT;
         private System.Windows.Forms.Label label42;
         private System.Windows.Forms.CheckBox RGPI1_1R_CIN;
+        private System.Windows.Forms.Label label43;
+        private System.Windows.Forms.Label label45;
+        private System.Windows.Forms.Label label44;
+        private System.Windows.Forms.Label label46;
+        private System.Windows.Forms.TextBox NODEID;
+        private System.Windows.Forms.TextBox NODECOUNT;
+        private System.Windows.Forms.TextBox NODEDESTINATION;
+        private System.Windows.Forms.TextBox SYNCANY;
     }
 }

--- a/Radio/Sikradio.cs
+++ b/Radio/Sikradio.cs
@@ -621,7 +621,11 @@ S15: MAX_WINDOW=131
                     {
                         //if (item.StartsWith("S"))
                         {
-                            var values = item.Split(':', '=');
+							int multipoint_fix = -1;
+							if (item.StartsWith("[")) multipoint_fix = item.IndexOf(']') + 1;
+							var mod_item = item;
+							if (multipoint_fix > 0 && item.Length > multipoint_fix) mod_item = item.Substring(multipoint_fix).Trim();
+                            var values = mod_item.Split(':', '=');
 
                             if (values.Length == 3)
                             {
@@ -651,6 +655,19 @@ S15: MAX_WINDOW=131
                                     }
                                     else if (controls[0] is TextBox)
                                     {
+                                        if (controls[0].Text != values[2].Trim())
+                                        {
+                                            var cmdanswer = doCommand(comPort,
+                                                "ATS" + values[0].Trim().TrimStart('S') + "=" + controls[0].Text + "\r");
+
+                                            if (cmdanswer.Contains("OK"))
+                                            {
+                                            }
+                                            else
+                                            {
+                                                CustomMessageBox.Show("Set Command error");
+                                            }
+                                        }
                                     }
                                     else if (controls[0].Name.Contains("MAVLINK")) //
                                     {
@@ -818,11 +835,15 @@ S15: MAX_WINDOW=131
 
                     lbl_status.Text = "Doing Command ATI & RTI";
 
-                    ATI.Text = doCommand(comPort, "ATI");
+					int multipoint_fix = -1;
+                    var ati_str = doCommand(comPort, "ATI").Trim();
+					if (ati_str.StartsWith("[")) multipoint_fix = ati_str.IndexOf(']') + 1;
+					ATI.Text = ati_str;
 
                     NumberStyles style = NumberStyles.Any;
 
                     var freqstring = doCommand(comPort, "ATI3").Trim();
+					if (multipoint_fix > 0) freqstring = freqstring.Substring(multipoint_fix).Trim();
 
                     if(freqstring.ToLower().Contains('x'))
                         style = NumberStyles.AllowHexSpecifier;
@@ -837,6 +858,7 @@ S15: MAX_WINDOW=131
                     style = NumberStyles.Any;
 
                     var boardstring = doCommand(comPort, "ATI2").Trim();
+					if (multipoint_fix > 0) boardstring = boardstring.Substring(multipoint_fix).Trim();
 
                     if (boardstring.ToLower().Contains('x'))
                         style = NumberStyles.AllowHexSpecifier;
@@ -897,8 +919,10 @@ S15: MAX_WINDOW=131
                     foreach (var item in items)
                     {
                         //if (item.StartsWith("S"))
-                        {
-                            var values = item.Split(new char[] { ':', '='}, StringSplitOptions.RemoveEmptyEntries);
+                        {                            
+                            var mod_item = item;
+                            if (multipoint_fix > 0 && item.Length > multipoint_fix) mod_item = item.Substring(multipoint_fix).Trim();
+                            var values = mod_item.Split(new char[] { ':', '='}, StringSplitOptions.RemoveEmptyEntries);
 
                             if (values.Length == 3)
                             {

--- a/Radio/Sikradio.resx
+++ b/Radio/Sikradio.resx
@@ -125,10 +125,163 @@
   <data name="SPLIT_local.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 81</value>
   </data>
-  <data name="label40.AutoSize" type="System.Boolean, mscorlib">
+  <data name="NODECOUNT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 323</value>
+  </data>
+  <data name="NODECOUNT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 22</value>
+  </data>
+  <data name="NODECOUNT.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="&gt;&gt;NODECOUNT.Name" xml:space="preserve">
+    <value>NODECOUNT</value>
+  </data>
+  <data name="&gt;&gt;NODECOUNT.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NODECOUNT.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel1</value>
+  </data>
+  <data name="&gt;&gt;NODECOUNT.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="NODEDESTINATION.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 298</value>
+  </data>
+  <data name="NODEDESTINATION.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 22</value>
+  </data>
+  <data name="NODEDESTINATION.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="&gt;&gt;NODEDESTINATION.Name" xml:space="preserve">
+    <value>NODEDESTINATION</value>
+  </data>
+  <data name="&gt;&gt;NODEDESTINATION.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NODEDESTINATION.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel1</value>
+  </data>
+  <data name="&gt;&gt;NODEDESTINATION.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="NODEID.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 271</value>
+  </data>
+  <data name="NODEID.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 22</value>
+  </data>
+  <data name="NODEID.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="&gt;&gt;NODEID.Name" xml:space="preserve">
+    <value>NODEID</value>
+  </data>
+  <data name="&gt;&gt;NODEID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NODEID.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel1</value>
+  </data>
+  <data name="&gt;&gt;NODEID.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label45.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label45.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label45.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 326</value>
+  </data>
+  <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 12</value>
+  </data>
+  <data name="label45.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="label45.Text" xml:space="preserve">
+    <value>Node Count</value>
+  </data>
+  <data name="&gt;&gt;label45.Name" xml:space="preserve">
+    <value>label45</value>
+  </data>
+  <data name="&gt;&gt;label45.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label45.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel1</value>
+  </data>
+  <data name="&gt;&gt;label45.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label44.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label44.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label44.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 301</value>
+  </data>
+  <data name="label44.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 12</value>
+  </data>
+  <data name="label44.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
+  </data>
+  <data name="label44.Text" xml:space="preserve">
+    <value>Node Dst</value>
+  </data>
+  <data name="&gt;&gt;label44.Name" xml:space="preserve">
+    <value>label44</value>
+  </data>
+  <data name="&gt;&gt;label44.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label44.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel1</value>
+  </data>
+  <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label43.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label43.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label43.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 274</value>
+  </data>
+  <data name="label43.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 12</value>
+  </data>
+  <data name="label43.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="label43.Text" xml:space="preserve">
+    <value>Node ID</value>
+  </data>
+  <data name="&gt;&gt;label43.Name" xml:space="preserve">
+    <value>label43</value>
+  </data>
+  <data name="&gt;&gt;label43.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label43.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel1</value>
+  </data>
+  <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="label40.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="label40.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -136,7 +289,7 @@
     <value>3, 246</value>
   </data>
   <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 13</value>
+    <value>83, 12</value>
   </data>
   <data name="label40.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -154,11 +307,8 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>6</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="GPO1_1R_COUT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -174,6 +324,9 @@
   <data name="GPO1_1R_COUT.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
   </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="GPO1_1R_COUT.ToolTip" xml:space="preserve">
     <value>OPPRESEND enables/disables "opportunistic resend". When enabled the radio will send a packet twice if the serial input buffer has less than 256 bytes in it. The 2nd send is marked as a resend and discarded by the receiving radio if it got the first packet OK. This makes a big difference to the link quality, especially for uplink commands. 
 </value>
@@ -188,7 +341,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;GPO1_1R_COUT.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>7</value>
   </data>
   <data name="label39.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -200,7 +353,7 @@
     <value>3, 220</value>
   </data>
   <data name="label39.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 13</value>
+    <value>72, 12</value>
   </data>
   <data name="label39.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -218,7 +371,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label39.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>8</value>
   </data>
   <data name="GPI1_1R_CIN.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -249,7 +402,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;GPI1_1R_CIN.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>9</value>
   </data>
   <data name="MAVLINK.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -258,7 +411,7 @@
     <value>81, 164</value>
   </data>
   <data name="MAVLINK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="MAVLINK.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -276,7 +429,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;MAVLINK.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>10</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -285,7 +438,7 @@
     <value>3, 7</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>38, 12</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -303,7 +456,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>11</value>
   </data>
   <data name="SERIAL_SPEED.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -339,7 +492,7 @@
     <value>81, 29</value>
   </data>
   <data name="SERIAL_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="SERIAL_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -358,7 +511,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;SERIAL_SPEED.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>12</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -367,7 +520,7 @@
     <value>3, 33</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>30, 12</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -385,13 +538,13 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>13</value>
   </data>
   <data name="FORMAT.Location" type="System.Drawing.Point, System.Drawing">
     <value>81, 3</value>
   </data>
   <data name="FORMAT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="FORMAT.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -406,7 +559,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;FORMAT.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>14</value>
   </data>
   <data name="AIR_SPEED.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -454,7 +607,7 @@
     <value>81, 56</value>
   </data>
   <data name="AIR_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="AIR_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -472,7 +625,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;AIR_SPEED.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>15</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -481,7 +634,7 @@
     <value>3, 59</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>51, 12</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -499,7 +652,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>16</value>
   </data>
   <data name="NETID.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -598,7 +751,7 @@
     <value>81, 83</value>
   </data>
   <data name="NETID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="NETID.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -616,7 +769,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;NETID.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>17</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -625,7 +778,7 @@
     <value>3, 86</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>36, 12</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -643,7 +796,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>18</value>
   </data>
   <data name="TXPOWER.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -676,7 +829,7 @@
     <value>81, 111</value>
   </data>
   <data name="TXPOWER.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="TXPOWER.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -695,7 +848,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;TXPOWER.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>19</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -704,7 +857,7 @@
     <value>3, 113</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -722,7 +875,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>20</value>
   </data>
   <data name="ECC.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -750,7 +903,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;ECC.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>21</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -759,7 +912,7 @@
     <value>3, 138</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 13</value>
+    <value>28, 12</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -777,7 +930,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>22</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -786,7 +939,7 @@
     <value>3, 194</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
+    <value>56, 12</value>
   </data>
   <data name="label8.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -804,7 +957,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>23</value>
   </data>
   <data name="OPPRESEND.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -832,7 +985,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;OPPRESEND.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>24</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -841,7 +994,7 @@
     <value>3, 167</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>44, 12</value>
   </data>
   <data name="label7.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -859,7 +1012,7 @@
     <value>SPLIT_local.Panel1</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>25</value>
   </data>
   <data name="&gt;&gt;SPLIT_local.Panel1.Name" xml:space="preserve">
     <value>SPLIT_local.Panel1</value>
@@ -872,6 +1025,57 @@
   </data>
   <data name="&gt;&gt;SPLIT_local.Panel1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="SYNCANY.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 298</value>
+  </data>
+  <data name="SYNCANY.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 22</value>
+  </data>
+  <data name="SYNCANY.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="&gt;&gt;SYNCANY.Name" xml:space="preserve">
+    <value>SYNCANY</value>
+  </data>
+  <data name="&gt;&gt;SYNCANY.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;SYNCANY.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel2</value>
+  </data>
+  <data name="&gt;&gt;SYNCANY.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label46.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label46.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label46.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 301</value>
+  </data>
+  <data name="label46.Size" type="System.Drawing.Size, System.Drawing">
+    <value>51, 12</value>
+  </data>
+  <data name="label46.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="label46.Text" xml:space="preserve">
+    <value>Sync Any</value>
+  </data>
+  <data name="&gt;&gt;label46.Name" xml:space="preserve">
+    <value>label46</value>
+  </data>
+  <data name="&gt;&gt;label46.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label46.Parent" xml:space="preserve">
+    <value>SPLIT_local.Panel2</value>
+  </data>
+  <data name="&gt;&gt;label46.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="ENCRYPTION_LEVEL.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -898,7 +1102,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;ENCRYPTION_LEVEL.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="label36.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -910,7 +1114,7 @@
     <value>3, 192</value>
   </data>
   <data name="label36.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>81, 12</value>
   </data>
   <data name="label36.TabIndex" type="System.Int32, mscorlib">
     <value>60</value>
@@ -928,7 +1132,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label36.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="label35.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -940,7 +1144,7 @@
     <value>4, 220</value>
   </data>
   <data name="label35.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 13</value>
+    <value>48, 12</value>
   </data>
   <data name="label35.TabIndex" type="System.Int32, mscorlib">
     <value>58</value>
@@ -958,7 +1162,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label35.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="txt_aeskey.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 236</value>
@@ -967,7 +1171,7 @@
     <value>32</value>
   </data>
   <data name="txt_aeskey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 20</value>
+    <value>196, 22</value>
   </data>
   <data name="txt_aeskey.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -982,7 +1186,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;txt_aeskey.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="RTSCTS.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1012,7 +1216,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;RTSCTS.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1024,7 +1228,7 @@
     <value>3, 138</value>
   </data>
   <data name="label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label19.TabIndex" type="System.Int32, mscorlib">
     <value>57</value>
@@ -1042,7 +1246,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="linkLabel_mavlink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1054,7 +1258,7 @@
     <value>4, 254</value>
   </data>
   <data name="linkLabel_mavlink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 13</value>
+    <value>144, 12</value>
   </data>
   <data name="linkLabel_mavlink.TabIndex" type="System.Int32, mscorlib">
     <value>55</value>
@@ -1072,7 +1276,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;linkLabel_mavlink.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="linkLabel_lowlatency.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1081,7 +1285,7 @@
     <value>4, 267</value>
   </data>
   <data name="linkLabel_lowlatency.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 13</value>
+    <value>122, 12</value>
   </data>
   <data name="linkLabel_lowlatency.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
@@ -1099,7 +1303,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;linkLabel_lowlatency.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1111,7 +1315,7 @@
     <value>4, 167</value>
   </data>
   <data name="label18.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 13</value>
+    <value>93, 12</value>
   </data>
   <data name="label18.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -1129,7 +1333,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="MAX_WINDOW.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1231,7 +1435,7 @@
     <value>96, 164</value>
   </data>
   <data name="MAX_WINDOW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="MAX_WINDOW.TabIndex" type="System.Int32, mscorlib">
     <value>52</value>
@@ -1249,7 +1453,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;MAX_WINDOW.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="label13.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1261,7 +1465,7 @@
     <value>4, 7</value>
   </data>
   <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>48, 12</value>
   </data>
   <data name="label13.TabIndex" type="System.Int32, mscorlib">
     <value>47</value>
@@ -1279,7 +1483,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="MAX_FREQ.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1315,7 +1519,7 @@
     <value>96, 28</value>
   </data>
   <data name="MAX_FREQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="MAX_FREQ.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -1333,7 +1537,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;MAX_FREQ.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="NUM_CHANNELS.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1399,7 +1603,7 @@
     <value>96, 55</value>
   </data>
   <data name="NUM_CHANNELS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="NUM_CHANNELS.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1417,7 +1621,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;NUM_CHANNELS.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="DUTY_CYCLE.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1456,7 +1660,7 @@
     <value>96, 82</value>
   </data>
   <data name="DUTY_CYCLE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="DUTY_CYCLE.TabIndex" type="System.Int32, mscorlib">
     <value>43</value>
@@ -1474,7 +1678,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;DUTY_CYCLE.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1486,7 +1690,7 @@
     <value>4, 112</value>
   </data>
   <data name="label17.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
+    <value>49, 12</value>
   </data>
   <data name="label17.TabIndex" type="System.Int32, mscorlib">
     <value>51</value>
@@ -1504,7 +1708,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>16</value>
   </data>
   <data name="LBT_RSSI.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1534,7 +1738,7 @@
     <value>96, 109</value>
   </data>
   <data name="LBT_RSSI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="LBT_RSSI.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -1552,7 +1756,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;LBT_RSSI.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>17</value>
   </data>
   <data name="label16.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1564,7 +1768,7 @@
     <value>4, 85</value>
   </data>
   <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>58, 12</value>
   </data>
   <data name="label16.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -1582,7 +1786,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>18</value>
   </data>
   <data name="MIN_FREQ.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1627,7 +1831,7 @@
     <value>96, 3</value>
   </data>
   <data name="MIN_FREQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="MIN_FREQ.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -1645,7 +1849,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;MIN_FREQ.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>19</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1657,7 +1861,7 @@
     <value>4, 59</value>
   </data>
   <data name="label15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>70, 12</value>
   </data>
   <data name="label15.TabIndex" type="System.Int32, mscorlib">
     <value>49</value>
@@ -1675,7 +1879,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>20</value>
   </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1687,7 +1891,7 @@
     <value>4, 31</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label14.TabIndex" type="System.Int32, mscorlib">
     <value>48</value>
@@ -1705,7 +1909,7 @@
     <value>SPLIT_local.Panel2</value>
   </data>
   <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>21</value>
   </data>
   <data name="&gt;&gt;SPLIT_local.Panel2.Name" xml:space="preserve">
     <value>SPLIT_local.Panel2</value>
@@ -1720,7 +1924,7 @@
     <value>1</value>
   </data>
   <data name="SPLIT_local.Size" type="System.Drawing.Size, System.Drawing">
-    <value>374, 280</value>
+    <value>374, 354</value>
   </data>
   <data name="SPLIT_local.SplitterDistance" type="System.Int32, mscorlib">
     <value>172</value>
@@ -1759,7 +1963,7 @@
     <value>5, 246</value>
   </data>
   <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 13</value>
+    <value>83, 12</value>
   </data>
   <data name="label41.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -1786,7 +1990,7 @@
     <value>83, 163</value>
   </data>
   <data name="RMAVLINK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RMAVLINK.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -1841,7 +2045,7 @@
     <value>83, 3</value>
   </data>
   <data name="RFORMAT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="RFORMAT.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -1868,7 +2072,7 @@
     <value>5, 220</value>
   </data>
   <data name="label42.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 13</value>
+    <value>72, 12</value>
   </data>
   <data name="label42.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -1953,7 +2157,7 @@
     <value>83, 29</value>
   </data>
   <data name="RSERIAL_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RSERIAL_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -2020,7 +2224,7 @@
     <value>83, 56</value>
   </data>
   <data name="RAIR_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RAIR_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -2137,7 +2341,7 @@
     <value>83, 83</value>
   </data>
   <data name="RNETID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RNETID.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -2167,7 +2371,7 @@
     <value>6, 194</value>
   </data>
   <data name="label25.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
+    <value>56, 12</value>
   </data>
   <data name="label25.TabIndex" type="System.Int32, mscorlib">
     <value>72</value>
@@ -2218,7 +2422,7 @@
     <value>83, 111</value>
   </data>
   <data name="RTXPOWER.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RTXPOWER.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -2249,7 +2453,7 @@
     <value>6, 167</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>44, 12</value>
   </data>
   <data name="label26.TabIndex" type="System.Int32, mscorlib">
     <value>71</value>
@@ -2307,7 +2511,7 @@
     <value>6, 140</value>
   </data>
   <data name="label27.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 13</value>
+    <value>28, 12</value>
   </data>
   <data name="label27.TabIndex" type="System.Int32, mscorlib">
     <value>70</value>
@@ -2337,7 +2541,7 @@
     <value>6, 113</value>
   </data>
   <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label28.TabIndex" type="System.Int32, mscorlib">
     <value>69</value>
@@ -2395,7 +2599,7 @@
     <value>6, 86</value>
   </data>
   <data name="label29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>36, 12</value>
   </data>
   <data name="label29.TabIndex" type="System.Int32, mscorlib">
     <value>68</value>
@@ -2425,7 +2629,7 @@
     <value>6, 33</value>
   </data>
   <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>30, 12</value>
   </data>
   <data name="label32.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -2455,7 +2659,7 @@
     <value>6, 59</value>
   </data>
   <data name="label30.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>51, 12</value>
   </data>
   <data name="label30.TabIndex" type="System.Int32, mscorlib">
     <value>67</value>
@@ -2485,7 +2689,7 @@
     <value>6, 7</value>
   </data>
   <data name="label31.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>38, 12</value>
   </data>
   <data name="label31.TabIndex" type="System.Int32, mscorlib">
     <value>66</value>
@@ -2527,7 +2731,7 @@
     <value>5, 220</value>
   </data>
   <data name="label38.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 13</value>
+    <value>48, 12</value>
   </data>
   <data name="label38.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -2581,7 +2785,7 @@
     <value>32</value>
   </data>
   <data name="txt_Raeskey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 20</value>
+    <value>180, 22</value>
   </data>
   <data name="txt_Raeskey.TabIndex" type="System.Int32, mscorlib">
     <value>61</value>
@@ -2608,7 +2812,7 @@
     <value>4, 192</value>
   </data>
   <data name="label37.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>81, 12</value>
   </data>
   <data name="label37.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -2668,7 +2872,7 @@
     <value>4, 138</value>
   </data>
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label33.TabIndex" type="System.Int32, mscorlib">
     <value>67</value>
@@ -2698,7 +2902,7 @@
     <value>5, 167</value>
   </data>
   <data name="label34.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 13</value>
+    <value>93, 12</value>
   </data>
   <data name="label34.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -2818,7 +3022,7 @@
     <value>97, 164</value>
   </data>
   <data name="RMAX_WINDOW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RMAX_WINDOW.TabIndex" type="System.Int32, mscorlib">
     <value>64</value>
@@ -2848,7 +3052,7 @@
     <value>5, 7</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>48, 12</value>
   </data>
   <data name="label24.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
@@ -2902,7 +3106,7 @@
     <value>97, 28</value>
   </data>
   <data name="RMAX_FREQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RMAX_FREQ.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -2986,7 +3190,7 @@
     <value>97, 55</value>
   </data>
   <data name="RNUM_CHANNELS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RNUM_CHANNELS.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
@@ -3043,7 +3247,7 @@
     <value>97, 82</value>
   </data>
   <data name="RDUTY_CYCLE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RDUTY_CYCLE.TabIndex" type="System.Int32, mscorlib">
     <value>55</value>
@@ -3091,7 +3295,7 @@
     <value>97, 109</value>
   </data>
   <data name="RLBT_RSSI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RLBT_RSSI.TabIndex" type="System.Int32, mscorlib">
     <value>56</value>
@@ -3145,7 +3349,7 @@
     <value>97, 3</value>
   </data>
   <data name="RMIN_FREQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 21</value>
+    <value>80, 20</value>
   </data>
   <data name="RMIN_FREQ.TabIndex" type="System.Int32, mscorlib">
     <value>58</value>
@@ -3175,7 +3379,7 @@
     <value>5, 31</value>
   </data>
   <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label23.TabIndex" type="System.Int32, mscorlib">
     <value>60</value>
@@ -3205,7 +3409,7 @@
     <value>5, 59</value>
   </data>
   <data name="label22.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>70, 12</value>
   </data>
   <data name="label22.TabIndex" type="System.Int32, mscorlib">
     <value>61</value>
@@ -3235,7 +3439,7 @@
     <value>5, 85</value>
   </data>
   <data name="label21.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>58, 12</value>
   </data>
   <data name="label21.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -3265,7 +3469,7 @@
     <value>5, 112</value>
   </data>
   <data name="label20.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
+    <value>49, 12</value>
   </data>
   <data name="label20.TabIndex" type="System.Int32, mscorlib">
     <value>63</value>
@@ -3322,7 +3526,7 @@
     <value>2</value>
   </data>
   <data name="Progressbar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 453</value>
+    <value>12, 530</value>
   </data>
   <data name="Progressbar.Size" type="System.Drawing.Size, System.Drawing">
     <value>755, 36</value>
@@ -3342,9 +3546,6 @@
   <data name="&gt;&gt;Progressbar.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="RSSI.Location" type="System.Drawing.Point, System.Drawing">
     <value>59, 38</value>
   </data>
@@ -3386,7 +3587,7 @@ which result in a valid packet CRC
     <value>689, 11</value>
   </data>
   <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 13</value>
+    <value>57, 12</value>
   </data>
   <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
     <value>83</value>
@@ -3417,7 +3618,7 @@ red LED solid - in firmware update mode</value>
     <value>60, 12</value>
   </data>
   <data name="RTI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 20</value>
+    <value>147, 22</value>
   </data>
   <data name="RTI.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -3438,7 +3639,7 @@ red LED solid - in firmware update mode</value>
     <value>59, 12</value>
   </data>
   <data name="ATI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 20</value>
+    <value>147, 22</value>
   </data>
   <data name="ATI.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -3462,7 +3663,7 @@ red LED solid - in firmware update mode</value>
     <value>14, 15</value>
   </data>
   <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="label11.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
@@ -3489,7 +3690,7 @@ red LED solid - in firmware update mode</value>
     <value>18, 50</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>29, 12</value>
   </data>
   <data name="label12.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -3528,7 +3729,7 @@ red LED solid - in firmware update mode</value>
     <value>BUT_savesettings</value>
   </data>
   <data name="&gt;&gt;BUT_savesettings.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.6178.11226, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BUT_savesettings.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3552,7 +3753,7 @@ red LED solid - in firmware update mode</value>
     <value>BUT_getcurrent</value>
   </data>
   <data name="&gt;&gt;BUT_getcurrent.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.6178.11226, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BUT_getcurrent.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3561,7 +3762,7 @@ red LED solid - in firmware update mode</value>
     <value>8</value>
   </data>
   <data name="lbl_status.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 418</value>
+    <value>12, 495</value>
   </data>
   <data name="lbl_status.Size" type="System.Drawing.Size, System.Drawing">
     <value>328, 28</value>
@@ -3601,7 +3802,7 @@ this ensures you wont lose radio link</value>
     <value>BUT_upload</value>
   </data>
   <data name="&gt;&gt;BUT_upload.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.6178.11226, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BUT_upload.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3616,7 +3817,7 @@ this ensures you wont lose radio link</value>
     <value>NoControl</value>
   </data>
   <data name="BUT_Syncoptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>346, 418</value>
+    <value>346, 495</value>
   </data>
   <data name="BUT_Syncoptions.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 29</value>
@@ -3631,7 +3832,7 @@ this ensures you wont lose radio link</value>
     <value>BUT_Syncoptions</value>
   </data>
   <data name="&gt;&gt;BUT_Syncoptions.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.6178.11226, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BUT_Syncoptions.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3643,7 +3844,7 @@ this ensures you wont lose radio link</value>
     <value>207, 12</value>
   </data>
   <data name="ATI3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 20</value>
+    <value>102, 22</value>
   </data>
   <data name="ATI3.TabIndex" type="System.Int32, mscorlib">
     <value>79</value>
@@ -3659,42 +3860,6 @@ this ensures you wont lose radio link</value>
   </data>
   <data name="&gt;&gt;ATI3.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;ATI2.Name" xml:space="preserve">
-    <value>ATI2</value>
-  </data>
-  <data name="&gt;&gt;ATI2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ATI2.Parent" xml:space="preserve">
-    <value>groupBoxLocal</value>
-  </data>
-  <data name="&gt;&gt;ATI2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="groupBoxLocal.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 48</value>
-  </data>
-  <data name="groupBoxLocal.Size" type="System.Drawing.Size, System.Drawing">
-    <value>382, 367</value>
-  </data>
-  <data name="groupBoxLocal.TabIndex" type="System.Int32, mscorlib">
-    <value>80</value>
-  </data>
-  <data name="groupBoxLocal.Text" xml:space="preserve">
-    <value>Local</value>
-  </data>
-  <data name="&gt;&gt;groupBoxLocal.Name" xml:space="preserve">
-    <value>groupBoxLocal</value>
-  </data>
-  <data name="&gt;&gt;groupBoxLocal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxLocal.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBoxLocal.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="ATI2.Location" type="System.Drawing.Point, System.Drawing">
     <value>315, 12</value>
@@ -3719,6 +3884,30 @@ this ensures you wont lose radio link</value>
   </data>
   <data name="&gt;&gt;ATI2.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="groupBoxLocal.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 48</value>
+  </data>
+  <data name="groupBoxLocal.Size" type="System.Drawing.Size, System.Drawing">
+    <value>382, 441</value>
+  </data>
+  <data name="groupBoxLocal.TabIndex" type="System.Int32, mscorlib">
+    <value>80</value>
+  </data>
+  <data name="groupBoxLocal.Text" xml:space="preserve">
+    <value>Local</value>
+  </data>
+  <data name="&gt;&gt;groupBoxLocal.Name" xml:space="preserve">
+    <value>groupBoxLocal</value>
+  </data>
+  <data name="&gt;&gt;groupBoxLocal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxLocal.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBoxLocal.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="RTI2.Location" type="System.Drawing.Point, System.Drawing">
     <value>300, 12</value>
@@ -3754,7 +3943,7 @@ this ensures you wont lose radio link</value>
     <value>12, 15</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -3808,7 +3997,7 @@ this ensures you wont lose radio link</value>
     <value>9, 11</value>
   </data>
   <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 13</value>
+    <value>0, 12</value>
   </data>
   <data name="label10.TabIndex" type="System.Int32, mscorlib">
     <value>82</value>
@@ -3844,7 +4033,7 @@ this ensures you wont lose radio link</value>
     <value>BUT_resettodefault</value>
   </data>
   <data name="&gt;&gt;BUT_resettodefault.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.6178.11226, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BUT_resettodefault.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3871,7 +4060,7 @@ this ensures you wont lose radio link</value>
     <value>BUT_loadcustom</value>
   </data>
   <data name="&gt;&gt;BUT_loadcustom.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.6178.11226, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;BUT_loadcustom.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3882,8 +4071,11 @@ this ensures you wont lose radio link</value>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>781, 433</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>781, 492</value>
+    <value>781, 579</value>
   </data>
   <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
     <value>toolTip1</value>


### PR DESCRIPTION
solve #652

support load/save setting for Sik multipoint frimware (https://github.com/RFDesign/SiK/tree/SiK_Multipoint)
SikRadio Config display and modify additional 4 multipoint firmware specific parameters: Node ID, Node Destination, Node Count and Sync Any

AT command in multipoint firmware return string start with "[Node ID]". For example, normal firmware answer AT15 in S0:FORMAT=25. Multipoint firmware answer AT15 in [1]S0:FORMAT=25, which [1] is node id. Node ID is exists in multipoint firmware only. It is be used to detect firmware branch

![multipoint_sik](https://user-images.githubusercontent.com/19793511/35268857-4a902c22-0065-11e8-977a-2e7e8479ff98.jpg)
