### PR TITLE
FlightPlanner: Change the error message to item name

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -4103,7 +4103,7 @@ namespace MissionPlanner.GCSViews
                 } catch (Exception ex)
                 {
                     log.Error(ex);
-                    CustomMessageBox.Show("Invalid Lat/Lng, please fix",Strings.ERROR);
+                    CustomMessageBox.Show("Invalid Lat/Long, please fix",Strings.ERROR);
                 }
             }
 


### PR DESCRIPTION
I change the error message "Lng" to the item name "Long".
That is because the error message was incorrect in the input of the item.
I think this error message is for users.

![lng](https://user-images.githubusercontent.com/646194/35357675-a0ac6ee4-0197-11e8-908c-ee87aa02f998.png)
