### PR TITLE
Uploader: Fix broken logic in PR 1760

### DIFF
--- a/ExtLibs/px4uploader/Uploader.cs
+++ b/ExtLibs/px4uploader/Uploader.cs
@@ -681,8 +681,13 @@ namespace px4uploader
 
             //Make sure we are doing the right thing
             if (self.board_type != fw.board_id)
-            if ((self.board_type == 33) && (fw.board_id != 9))
-                throw new Exception("Firmware not suitable for this board");
+            {
+                if (!((self.board_type == 33) && (fw.board_id == 9)))
+                {
+                    throw new Exception("Firmware not suitable for this board");
+                }
+            }
+
             if (self.fw_maxsize < fw.image_size)
                 throw new Exception("Firmware image is too large for this board");
 


### PR DESCRIPTION
Uploader: Fix broken logic and added braces to make the nested condition more readable.

Sorry @meee1 the logic in my previous PR was flawed. It is oddly complicated. PR1760 creates a condition where the exception would never be thrown.

This fixes my error and has been thoroughly tested with both good and bad firmware on a PixHawk v1, X2.1 and Pixracer.