### PR TITLE
Added a minute.second interpretation of TimeInAir to currentstate 

### DIFF
--- a/CurrentState.cs
+++ b/CurrentState.cs
@@ -613,6 +613,16 @@ namespace MissionPlanner
         [DisplayText("Time in Air (sec)")]
         public float timeInAir { get; set; }
 
+        //Time in Air converted to min.sec format for easier reading
+        [DisplayText("Time in Air (min.sec)")]
+        public float timeInAirMinSec
+        {
+            get
+            {
+                return ((float)((int)(timeInAir / 60))) + ((timeInAir % 60) / 100);
+            }
+        }
+        
         // calced turn rate
         [DisplayText("Turn Rate (speed)")]
         public float turnrate


### PR DESCRIPTION
Added a minutes.seconds interpretation of TimeInAir to currentstate. 

I think It is easier to read the time in air if it displayed in minutes.seconds format. Added a new variable to the  currentstate seemed the easiest way to do it.



Ps. Also this is my first pull request for the Mission Planner, others will follow.