### PR TITLE
LogBrowse: filter options only show seen messages

### DIFF
--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -2275,14 +2275,16 @@ namespace MissionPlanner.Log
 
             int b = 0;
 
-            foreach (var item2 in logdata.dflog.logformat)
+            foreach (string item2 in seenmessagetypes.Keys)
             {
-                string celldata = item2.Key.Trim();
+                string celldata = item2.Trim();
                 if (!options.Contains(celldata))
                 {
                     options.Add(celldata);
                 }
             }
+
+            options.Sort();
 
             Controls.OptionForm opt = new Controls.OptionForm();
 


### PR DESCRIPTION
Showing all the possible messages in the filter select box isn't useful because many times logs only contain a small subset of messages.

This also sorts the options to be easier to find them.