### PR TITLE
Reconnect HUD custom items to the main state on connect

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -1688,6 +1688,8 @@ namespace MissionPlanner
                 {
                     FlightPlanner.GeoFencedownloadToolStripMenuItem_Click(null, null);
                 }
+                //Add HUD custom items source 
+                HUD.Custom.src = MainV2.comPort.MAV.cs;
 
                 // set connected icon
                 this.MenuConnect.Image = displayicons.disconnect;


### PR DESCRIPTION
Custom HUD items are loosing data source on disconnect, and connect does not restore it.  Added it to the last stage of connect. Now custom HUD items are refreshed after a disconnect-connect.