### PR TITLE
Add Altitude Angel flight reporting to Mission Planner

### DIFF
--- a/ExtLibs/AltitudeAngelWings/AltitudeAngelPlugin.cs
+++ b/ExtLibs/AltitudeAngelWings/AltitudeAngelPlugin.cs
@@ -1,0 +1,38 @@
+using System;
+using AltitudeAngelWings.ApiClient.Client;
+using AltitudeAngelWings.Extra;
+using AltitudeAngelWings.Service;
+using AltitudeAngelWings.Service.FlightData;
+using AltitudeAngelWings.Service.FlightData.Providers;
+using AltitudeAngelWings.Service.Messaging;
+
+namespace AltitudeAngelWings
+{
+    public static class AltitudeAngelPlugin
+    {
+        public static void Configure()
+        {
+            ServiceLocator.Register<ISettings>(l => new Settings(
+                l.Resolve<IMissionPlanner>()));
+            ServiceLocator.Register<IMessagesService>(l => new MessagesService());
+            ServiceLocator.Register<IFlightDataProvider>(l => new MissionPlannerFlightDataProvider(
+                l.Resolve<IMissionPlannerState>()));
+            ServiceLocator.Register<IFlightDataService>(l => new FlightDataService(
+                TimeSpan.FromMilliseconds(500),
+                l.Resolve<IFlightDataProvider>()));
+            ServiceLocator.Register<IAltitudeAngelClient>(l => new AltitudeAngelClient(
+                l.Resolve<ISettings>().AuthenticationUrl,
+                l.Resolve<ISettings>().ApiUrl,
+                l.Resolve<ISettings>().AuthToken,
+                (a, s) => new AltitudeAngelHttpHandlerFactory(a, s,
+                    l.Resolve<ISettings>().ClientId,
+                    l.Resolve<ISettings>().ClientSecret)));
+            ServiceLocator.Register<IAltitudeAngelService>(l => new AltitudeAngelService(
+                l.Resolve<IMessagesService>(),
+                l.Resolve<IMissionPlanner>(),
+                l.Resolve<ISettings>(),
+                l.Resolve<IFlightDataService>(),
+                l.Resolve<IAltitudeAngelClient>()));
+        }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/AltitudeAngelWings.csproj
+++ b/ExtLibs/AltitudeAngelWings/AltitudeAngelWings.csproj
@@ -28,6 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,6 +39,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -55,8 +57,8 @@
     <Reference Include="Flurl, Version=2.7.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Flurl.2.7.1\lib\net40\Flurl.dll</HintPath>
     </Reference>
-    <Reference Include="Flurl.Http, Version=2.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.2.3.1\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=2.3.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.2.3.2\lib\net46\Flurl.Http.dll</HintPath>
     </Reference>
     <Reference Include="GeoJSON.Net, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\GeoJSON.Net.1.1.64\lib\net45\GeoJSON.Net.dll</HintPath>
@@ -69,46 +71,24 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Reactive, Version=4.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.4.0.0\lib\net46\System.Reactive.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.Core.4.0.0\lib\net46\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reactive.Interfaces.4.0.0\lib\net46\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reactive.Linq.4.0.0\lib\net46\System.Reactive.Linq.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reactive.PlatformServices.4.0.0\lib\net46\System.Reactive.PlatformServices.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reactive.Windows.Threading.4.0.0\lib\net46\System.Reactive.Windows.Threading.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
+    <Reference Include="TimeZoneConverter, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\TimeZoneConverter.2.4.1\lib\net45\TimeZoneConverter.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
@@ -117,6 +97,7 @@
     <Compile Include="ApiClient\Client\ClientHandlerInfo.cs" />
     <Compile Include="ApiClient\Client\AltitudeAngelHttpHandlerFactory.cs" />
     <Compile Include="ApiClient\Client\Extensions.cs" />
+    <Compile Include="ApiClient\Client\IAltitudeAngelClient.cs" />
     <Compile Include="ApiClient\Client\IAuthorizeCodeProvider.cs" />
     <Compile Include="ApiClient\CodeProvider\WpfAuthorizeDisplay.cs" />
     <Compile Include="ApiClient\Models\AAFeatureCollection.cs" />
@@ -137,20 +118,29 @@
     <Compile Include="Extra\IMissionPlanner.cs" />
     <Compile Include="Extra\IMissionPlannerState.cs" />
     <Compile Include="Extra\IOverlay.cs" />
+    <Compile Include="IServiceLocator.cs" />
     <Compile Include="Models\FlightData.cs" />
     <Compile Include="Models\FlightDataPosition.cs" />
+    <Compile Include="Models\FlightPlan.cs" />
+    <Compile Include="Models\FlightPlanWaypoint.cs" />
     <Compile Include="Models\Message.cs" />
     <Compile Include="ObservableProperty.cs" />
+    <Compile Include="AltitudeAngelPlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactiveExtensions.cs" />
+    <Compile Include="ServiceLocator.cs" />
     <Compile Include="Service\AltitudeAngelService.cs" />
     <Compile Include="Service\FlightData\FlightDataService.cs" />
+    <Compile Include="Service\FlightData\IFlightDataService.cs" />
     <Compile Include="Service\FlightData\Providers\IFlightDataProvider.cs" />
     <Compile Include="Service\FlightData\Providers\MissionPlannerFlightDataProvider.cs" />
+    <Compile Include="Service\IAltitudeAngelService.cs" />
+    <Compile Include="Service\ISettings.cs" />
     <Compile Include="Service\Logging\ILogger.cs" />
     <Compile Include="Service\Logging\Logger.cs" />
     <Compile Include="Service\Messaging\IMessagesService.cs" />
     <Compile Include="Service\Messaging\MessagesService.cs" />
+    <Compile Include="Service\Settings.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Client/AltitudeAngelClient.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Client/AltitudeAngelClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using AltitudeAngelWings.ApiClient.Models;
 using DotNetOpenAuth.OAuth2;
@@ -7,12 +6,18 @@ using Flurl;
 using Flurl.Http;
 using GMap.NET;
 using Newtonsoft.Json.Linq;
+using TimeZoneConverter;
 
 namespace AltitudeAngelWings.ApiClient.Client
 {
-    public class AltitudeAngelClient
+    public class AltitudeAngelClient : IAltitudeAngelClient
     {
-        public delegate AltitudeAngelClient Create(string authUrl, string apiUrl, AuthorizationState existingState);
+        private const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffff";
+
+        private readonly string _apiUrl;
+        private readonly string _authUrl;
+        private readonly FlurlClient _client;
+        private readonly AltitudeAngelHttpHandlerFactory _handlerFactory;
 
         public IAuthorizationState AuthorizationState => _handlerFactory.AuthorizationState;
 
@@ -26,9 +31,8 @@ namespace AltitudeAngelWings.ApiClient.Client
         public AltitudeAngelClient(
             string authUrl,
             string apiUrl,
-            AuthorizationState existingState,
-            AltitudeAngelHttpHandlerFactory.Create handlerFactory
-            )
+            IAuthorizationState existingState,
+            Func<string, IAuthorizationState, AltitudeAngelHttpHandlerFactory> handlerFactory)
         {
             _authUrl = authUrl;
             _apiUrl = apiUrl;
@@ -40,8 +44,6 @@ namespace AltitudeAngelWings.ApiClient.Client
                     HttpClientFactory = _handlerFactory
                 }
             };
-
-            _disposer.Add(_client);
         }
 
         /// <summary>
@@ -68,7 +70,9 @@ namespace AltitudeAngelWings.ApiClient.Client
                     n = latLongBounds.Top,
                     e = latLongBounds.Right,
                     s = latLongBounds.Bottom,
-                    w = latLongBounds.Left
+                    w = latLongBounds.Left,
+                    isCompact = false,
+                    include = "flight_report"
                 })
                 .WithClient(_client)
                 .GetJsonAsync<AAFeatureCollection>();
@@ -117,10 +121,49 @@ namespace AltitudeAngelWings.ApiClient.Client
                 .GetJsonAsync<UserProfileInfo>();
         }
 
-        private readonly string _apiUrl;
-        private readonly string _authUrl;
-        private readonly FlurlClient _client;
-        private readonly AltitudeAngelHttpHandlerFactory _handlerFactory;
-        private readonly CompositeDisposable _disposer = new CompositeDisposable();
+        public async Task<string> CreateFlightReport(string flightReportName, bool isCommerial, DateTime localStartTime, DateTime localEndTime, PointLatLng location, int radius)
+        {
+            var response = await _apiUrl
+                .AppendPathSegments("flightReport")
+                .WithClient(_client)
+                .PutJsonAsync(new
+                {
+                    name = flightReportName,
+                    flight_type = isCommerial ? "com" : "rec",
+                    timezone = TZConvert.WindowsToIana(TimeZoneInfo.Local.Id),
+                    start = localStartTime.ToString(DateTimeFormat),
+                    end = localEndTime.ToString(DateTimeFormat),
+                    radius_meters = radius,
+                    loc = new
+                    {
+                        lat = location.Lat,
+                        lng = location.Lng
+                    }
+                })
+                .ReceiveJson<JObject>();
+            return response.SelectToken("flightId").ToString();
+        }
+
+        public Task CompleteFlightReport(string flightId)
+        {
+            return _apiUrl
+                .AppendPathSegments("flightReport", flightId)
+                .WithClient(_client)
+                .DeleteAsync();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _client?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Client/ApiOAuthClientHandler.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Client/ApiOAuthClientHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -24,7 +25,7 @@ namespace AltitudeAngelWings.ApiClient.Client
         string clientId,
             string clientSecret,
             IEnumerable<string> scopes,
-            AuthorizationState existingState = null
+            IAuthorizationState existingState = null
             )
         {
             return Create(authBaseUri, clientId, clientSecret, scopes, existingState, false, null, null);
@@ -50,14 +51,14 @@ namespace AltitudeAngelWings.ApiClient.Client
             string clientId,
             string clientSecret,
             IEnumerable<string> scopes,
-            AuthorizationState existingState,
+            IAuthorizationState existingState,
             bool requireUserToken,
             string redirectUri,
             IAuthorizeCodeProvider codeProvider)
         {
-            AuthorizationServerDescription serverDescription = GetServerDescription(authBaseUri);
+            var serverDescription = GetServerDescription(authBaseUri);
             ClientBase client;
-            IAuthorizationState state = existingState;
+            var state = existingState;
 
             if (requireUserToken)
             {
@@ -72,8 +73,8 @@ namespace AltitudeAngelWings.ApiClient.Client
                 {
                     // Open browser here
                     var returnTo = new Uri(redirectUri);
-                    Uri uri = userClient.RequestUserAuthorization(scopes, returnTo: returnTo);
-                    Uri result = codeProvider.GetCodeUri(uri, returnTo).Result;
+                    var uri = userClient.RequestUserAuthorization(scopes, returnTo: returnTo);
+                    var result = codeProvider.GetCodeUri(uri, returnTo).Result;
 
                     state = new AuthorizationState {Callback = returnTo};
                     state.Scope.AddRange(scopes);
@@ -88,51 +89,12 @@ namespace AltitudeAngelWings.ApiClient.Client
                 state = state ?? client.GetClientAccessToken(scopes);
             }
 
-            return new ClientHandlerInfo(new BearerTokenHttpMessageHandler(client, state, new HttpClientHandler()), state);
-        }
-
-        internal class BearerTokenHttpMessageHandler : DelegatingHandler
-        {
-            internal string BearerToken
-            {
-                get;
-                private set;
-            }
-            internal IAuthorizationState Authorization
-            {
-                get;
-                private set;
-            }
-            internal ClientBase Client
-            {
-                get;
-                private set;
-            }
-            public BearerTokenHttpMessageHandler(string bearerToken, HttpMessageHandler innerHandler) : base(innerHandler)
-            {
-                this.BearerToken = bearerToken;
-            }
-            public BearerTokenHttpMessageHandler(ClientBase client, IAuthorizationState authorization, HttpMessageHandler innerHandler) : base(innerHandler)
-            {
-                this.Client = client;
-                this.Authorization = authorization;
-            }
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                string text = this.BearerToken;
-                if (text == null)
-                {
-                    //ErrorUtilities.VerifyProtocol(!this.Authorization.AccessTokenExpirationUtc.HasValue || this.Authorization.AccessTokenExpirationUtc >= DateTime.UtcNow || this.Authorization.RefreshToken != null, ClientStrings.AuthorizationExpired, new object[0]);
-                    if (this.Authorization.AccessTokenExpirationUtc.HasValue && this.Authorization.AccessTokenExpirationUtc.Value < DateTime.UtcNow)
-                    {
-                        //ErrorUtilities.VerifyProtocol(this.Authorization.RefreshToken != null, ClientStrings.AccessTokenRefreshFailed, new object[0]);
-                        this.Client.RefreshAuthorization(this.Authorization, null);
-                    }
-                    text = this.Authorization.AccessToken;
-                }
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", text);
-                return base.SendAsync(request, cancellationToken);
-            }
+            return new ClientHandlerInfo(
+                new BearerTokenHttpMessageHandler(
+                    client,
+                    state,
+                    new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate }),
+                state);
         }
 
         private static AuthorizationServerDescription GetServerDescription(string authBaseUri)
@@ -144,6 +106,50 @@ namespace AltitudeAngelWings.ApiClient.Client
                 AuthorizationEndpoint = new Uri($"{authBaseUri}/oauth/v2/authorize"),
                 TokenEndpoint = new Uri($"{authBaseUri}/oauth/v2/token")
             };
+        }
+
+        internal class BearerTokenHttpMessageHandler : DelegatingHandler
+        {
+            internal string BearerToken
+            {
+                get;
+            }
+
+            internal IAuthorizationState Authorization
+            {
+                get;
+            }
+
+            internal ClientBase Client
+            {
+                get;
+            }
+
+            public BearerTokenHttpMessageHandler(string bearerToken, HttpMessageHandler innerHandler) : base(innerHandler)
+            {
+                BearerToken = bearerToken;
+            }
+
+            public BearerTokenHttpMessageHandler(ClientBase client, IAuthorizationState authorization, HttpMessageHandler innerHandler) : base(innerHandler)
+            {
+                Client = client;
+                Authorization = authorization;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var text = BearerToken;
+                if (text == null)
+                {
+                    if (Authorization.AccessTokenExpirationUtc.HasValue && Authorization.AccessTokenExpirationUtc.Value < DateTime.UtcNow)
+                    {
+                        Client.RefreshAuthorization(Authorization, null);
+                    }
+                    text = Authorization.AccessToken;
+                }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", text);
+                return base.SendAsync(request, cancellationToken);
+            }
         }
     }
 }

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Client/Extensions.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Client/Extensions.cs
@@ -2,10 +2,8 @@
 using GeoJSON.Net.Feature;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace AltitudeAngelWings.ApiClient.Client
 {

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Client/IAltitudeAngelClient.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Client/IAltitudeAngelClient.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+using AltitudeAngelWings.ApiClient.Models;
+using DotNetOpenAuth.OAuth2;
+using GMap.NET;
+
+namespace AltitudeAngelWings.ApiClient.Client
+{
+    public interface IAltitudeAngelClient : IDisposable
+    {
+        IAuthorizationState AuthorizationState { get; }
+        void Disconnect();
+        Task<AAFeatureCollection> GetMapData(RectLatLng latLongBounds);
+        Task<WeatherInfo> GetWeather(PointLatLng latLong);
+        Task<UserProfileInfo> GetUserProfile();
+        Task<string> CreateFlightReport(string flightReportName, bool isCommerial, DateTime localStartTime, DateTime localEndTime, PointLatLng location, int radius);
+        Task CompleteFlightReport(string flightId);
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/ApiClient/CodeProvider/WpfAuthorizeDisplay.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/CodeProvider/WpfAuthorizeDisplay.cs
@@ -10,8 +10,12 @@ namespace AltitudeAngelWings.ApiClient.CodeProvider
     /// <summary>
     ///     Provides auth code URIs from an auth URI.
     /// </summary>
-    public class WpfAuthorizeDisplay : Window, IAuthorizeCodeProvider
+    public class WpfAuthorizeDisplay : Window, IAuthorizeCodeProvider, IDisposable
     {
+        private readonly TaskCompletionSource<Uri> _tcs = new TaskCompletionSource<Uri>();
+        private Uri _redirectUri;
+        private readonly WebBrowser _webBrowser;
+
         /// <summary>
         ///     Constructor. Ensure this is called from the UI thread.
         /// </summary>
@@ -35,23 +39,29 @@ namespace AltitudeAngelWings.ApiClient.CodeProvider
             if (result == true)
             {
             }
-
-
             return _tcs.Task;
         }
 
         private void WebBrowserOnNavigating(object sender, NavigatingCancelEventArgs navigatingCancelEventArgs)
         {
-            if (navigatingCancelEventArgs.Uri.ToString().StartsWith(_redirectUri.ToString(), StringComparison.OrdinalIgnoreCase))
+            if (!navigatingCancelEventArgs.Uri.ToString().StartsWith(_redirectUri.ToString(), StringComparison.OrdinalIgnoreCase)) return;
+            navigatingCancelEventArgs.Cancel = true;
+            _tcs.SetResult(navigatingCancelEventArgs.Uri);
+            Close();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
             {
-                navigatingCancelEventArgs.Cancel = true;
-                _tcs.SetResult(navigatingCancelEventArgs.Uri);
-                Close();
+                _webBrowser?.Dispose();
             }
         }
 
-        private readonly TaskCompletionSource<Uri> _tcs = new TaskCompletionSource<Uri>();
-        private Uri _redirectUri;
-        private readonly WebBrowser _webBrowser;
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/AircraftInfo.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/AircraftInfo.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AltitudeAngelWings.ApiClient.Models
 {
     public class AircraftInfo

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/Altitude.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/Altitude.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/AltitudeDatum.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/AltitudeDatum.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AltitudeAngelWings.ApiClient.Models
 {
     public enum AltitudeDatum

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/BoundingLatLong.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/BoundingLatLong.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 
 namespace AltitudeAngelWings.ApiClient.Models

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/FlightInfo.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/FlightInfo.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 
 namespace AltitudeAngelWings.ApiClient.Models

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/LatLong.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/LatLong.cs
@@ -1,4 +1,3 @@
-using System;
 using GMap.NET;
 using Newtonsoft.Json;
 

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/ReportRequest.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/ReportRequest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using DotNetOpenAuth.Messaging;
 using Newtonsoft.Json;

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/UnitOfMeasure.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/UnitOfMeasure.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AltitudeAngelWings.ApiClient.Models
 {
     public enum UnitOfMeasure

--- a/ExtLibs/AltitudeAngelWings/ApiClient/Models/UserProfileInfo.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Models/UserProfileInfo.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/ExtLibs/AltitudeAngelWings/App.config
+++ b/ExtLibs/AltitudeAngelWings/App.config
@@ -39,6 +39,14 @@
     
         </dependentAssembly>
     
+        <dependentAssembly>
+    
+            <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    
+            <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+    
+        </dependentAssembly>
+    
     </assemblyBinding>
   </runtime>
   <!-- Create the keys.config and add the section below in the comment,

--- a/ExtLibs/AltitudeAngelWings/CollectionExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/CollectionExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace AltitudeAngelWings

--- a/ExtLibs/AltitudeAngelWings/DrawingExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/DrawingExtensions.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using AltitudeAngel.IsolatedPlugin.Common.Maps;
+using AltitudeAngelWings.Extra;
 using GeoJSON.Net.Feature;
 
 namespace AltitudeAngelWings

--- a/ExtLibs/AltitudeAngelWings/Extra/ColorInfo.cs
+++ b/ExtLibs/AltitudeAngelWings/Extra/ColorInfo.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace AltitudeAngel.IsolatedPlugin.Common.Maps
+namespace AltitudeAngelWings.Extra
 {
     [Serializable]
     public class ColorInfo

--- a/ExtLibs/AltitudeAngelWings/Extra/IMap.cs
+++ b/ExtLibs/AltitudeAngelWings/Extra/IMap.cs
@@ -2,7 +2,7 @@ using System;
 using System.Reactive;
 using GMap.NET;
 
-namespace AltitudeAngel.IsolatedPlugin.Common.Maps
+namespace AltitudeAngelWings.Extra
 {
     public interface IMap
     {

--- a/ExtLibs/AltitudeAngelWings/Extra/IMissionPlanner.cs
+++ b/ExtLibs/AltitudeAngelWings/Extra/IMissionPlanner.cs
@@ -1,6 +1,6 @@
-using AltitudeAngel.IsolatedPlugin.Common.Maps;
+using AltitudeAngelWings.Models;
 
-namespace AltitudeAngel.IsolatedPlugin.Common
+namespace AltitudeAngelWings.Extra
 {
     public interface IMissionPlanner
     {
@@ -9,5 +9,6 @@ namespace AltitudeAngel.IsolatedPlugin.Common
         void SaveSetting(string key, string data);
         string LoadSetting(string key);
         void ClearSetting(string key);
+        FlightPlan GetFlightPlan();
     }
 }

--- a/ExtLibs/AltitudeAngelWings/Extra/IMissionPlannerState.cs
+++ b/ExtLibs/AltitudeAngelWings/Extra/IMissionPlannerState.cs
@@ -1,4 +1,4 @@
-namespace AltitudeAngel.IsolatedPlugin.Common
+namespace AltitudeAngelWings.Extra
 {
     public interface IMissionPlannerState
     {

--- a/ExtLibs/AltitudeAngelWings/Extra/IOverlay.cs
+++ b/ExtLibs/AltitudeAngelWings/Extra/IOverlay.cs
@@ -1,16 +1,17 @@
-using System;
 using System.Collections.Generic;
 using GeoJSON.Net.Feature;
 using GMap.NET;
 
-namespace AltitudeAngel.IsolatedPlugin.Common.Maps
+namespace AltitudeAngelWings.Extra
 {
     public interface IOverlay
     {
-        void AddPolygon(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo);
-        void AddLine(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo);
+        void AddOrUpdatePolygon(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo);
+        void AddOrUpdateLine(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo);
         bool LineExists(string name);
         bool PolygonExists(string name);
         bool IsVisible { get; set; }
+        void RemovePolygonsExcept(List<string> names);
+        void RemoveLinesExcept(List<string> names);
     }
 }

--- a/ExtLibs/AltitudeAngelWings/IServiceLocator.cs
+++ b/ExtLibs/AltitudeAngelWings/IServiceLocator.cs
@@ -1,0 +1,7 @@
+namespace AltitudeAngelWings
+{
+    public interface IServiceLocator
+    {
+        T Resolve<T>();
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/Models/FlightDataPosition.cs
+++ b/ExtLibs/AltitudeAngelWings/Models/FlightDataPosition.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AltitudeAngelWings.Models
 {
     public class FlightDataPosition

--- a/ExtLibs/AltitudeAngelWings/Models/FlightPlan.cs
+++ b/ExtLibs/AltitudeAngelWings/Models/FlightPlan.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace AltitudeAngelWings.Models
+{
+    public class FlightPlan
+    {
+        public FlightPlan(IEnumerable<FlightPlanWaypoint> waypoints)
+        {
+            Waypoints = new List<FlightPlanWaypoint>(waypoints);
+        }
+
+        public IList<FlightPlanWaypoint> Waypoints { get; }
+        public double CenterLatitude { get; set; }
+        public double CenterLongitude { get; set; }
+        public int BoundingRadius { get; set; }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/Models/FlightPlanWaypoint.cs
+++ b/ExtLibs/AltitudeAngelWings/Models/FlightPlanWaypoint.cs
@@ -1,0 +1,9 @@
+namespace AltitudeAngelWings.Models
+{
+    public class FlightPlanWaypoint
+    {
+        public double Longitude { get; set; }
+        public double Latitude { get; set; }
+        public int Altitude { get; set; }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/Models/Message.cs
+++ b/ExtLibs/AltitudeAngelWings/Models/Message.cs
@@ -1,5 +1,3 @@
-using System.Windows.Markup;
-
 namespace AltitudeAngelWings.Models
 {
     public class Message

--- a/ExtLibs/AltitudeAngelWings/ReactiveExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/ReactiveExtensions.cs
@@ -17,5 +17,14 @@ namespace AltitudeAngelWings
             return source.ObserveOnDispatcher()
                          .Subscribe(state => VisualStateManager.GoToElementState(stateElement, state.ToString(), true));
         }
+
+        public static IObservable<T> RepeatLastValue<T>(this IObservable<T> source, TimeSpan repeatInterval)
+        {
+            return source.Select(s => Observable
+                    .Interval(repeatInterval)
+                    .Select(_ => s)
+                    .StartWith(s))
+                .Switch();
+        }
     }
 }

--- a/ExtLibs/AltitudeAngelWings/Service/FlightData/IFlightDataService.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/FlightData/IFlightDataService.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AltitudeAngelWings.Service.FlightData
+{
+    public interface IFlightDataService : IDisposable
+    {
+        IObservable<Models.FlightData> FlightArmed { get; }
+        IObservable<Models.FlightData> FlightDisarmed { get; }
+        IObservable<Models.FlightData> ArmedFlightData { get; }
+        IObservable<Models.FlightData> RawFlightData { get; }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/Service/FlightData/Providers/IFlightDataProvider.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/FlightData/Providers/IFlightDataProvider.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace AltitudeAngelWings.Service.FlightData.Providers
 {
     public interface IFlightDataProvider

--- a/ExtLibs/AltitudeAngelWings/Service/FlightData/Providers/MissionPlannerFlightDataProvider.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/FlightData/Providers/MissionPlannerFlightDataProvider.cs
@@ -1,5 +1,4 @@
-using System;
-using AltitudeAngel.IsolatedPlugin.Common;
+using AltitudeAngelWings.Extra;
 using AltitudeAngelWings.Models;
 
 namespace AltitudeAngelWings.Service.FlightData.Providers

--- a/ExtLibs/AltitudeAngelWings/Service/IAltitudeAngelService.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/IAltitudeAngelService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Threading.Tasks;
+using AltitudeAngelWings.ApiClient.Models;
+using AltitudeAngelWings.Extra;
+
+namespace AltitudeAngelWings.Service
+{
+    public interface IAltitudeAngelService : IDisposable
+    {
+        ObservableProperty<bool> IsSignedIn { get; }
+        ObservableProperty<WeatherInfo> WeatherReport { get; }
+        ObservableProperty<Unit> SentTelemetry { get; }
+        UserProfileInfo CurrentUser { get; }
+        IList<string> FilteredOut { get; }
+        Task SignInAsync();
+        Task DisconnectAsync();
+        void ProcessAllFromCache(IMap map);
+        Task SignInIfAuthenticated();
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/Service/ISettings.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/ISettings.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using DotNetOpenAuth.OAuth2;
+
+namespace AltitudeAngelWings.Service
+{
+    public interface ISettings
+    {
+        bool CheckEnableAltitudeAngel { get; set; }
+        string AuthenticationUrl { get; }
+        string ApiUrl { get; }
+        string ClientId { get; }
+        string ClientSecret { get; }
+        IAuthorizationState AuthToken { get; set; }
+        bool GroundDataDisplay { get; set; }
+        bool AirDataDisplay { get; set; }
+        IList<string> MapFilters { get; set; }
+        bool FlightReportEnable { get; set; }
+        string CurrentFlightReportId { get; set; }
+        string FlightReportName { get; set; }
+        bool FlightReportCommercial { get; set; }
+        TimeSpan FlightReportTimeSpan { get; set; }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/Service/Logging/ILogger.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/Logging/ILogger.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 
 namespace AltitudeAngelWings.Service.Logging

--- a/ExtLibs/AltitudeAngelWings/Service/Logging/Logger.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/Logging/Logger.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 
 namespace AltitudeAngelWings.Service.Logging

--- a/ExtLibs/AltitudeAngelWings/Service/Messaging/IMessagesService.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/Messaging/IMessagesService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using AltitudeAngelWings.Models;
 

--- a/ExtLibs/AltitudeAngelWings/Service/Messaging/MessagesService.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/Messaging/MessagesService.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using AltitudeAngelWings.Models;
 
 namespace AltitudeAngelWings.Service.Messaging
 {
-    public class MessagesService : IMessagesService
+    public class MessagesService : IMessagesService, IDisposable
     {
         public MessagesService()
         {
@@ -16,7 +17,24 @@ namespace AltitudeAngelWings.Service.Messaging
         public Task AddMessageAsync(Message message)
         {
             Console.WriteLine(message.Content);
+#if DEBUG
+            Debug.WriteLine(message.Content);
+#endif
             return Task.Factory.StartNew(() => Messages.Value = message);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Messages?.Dispose();
+            }
         }
     }
 }

--- a/ExtLibs/AltitudeAngelWings/Service/Settings.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/Settings.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using AltitudeAngelWings.Extra;
+using DotNetOpenAuth.OAuth2;
+using Newtonsoft.Json;
+
+namespace AltitudeAngelWings.Service
+{
+    public class Settings : ISettings
+    {
+        private readonly IMissionPlanner _missionPlanner;
+
+        public Settings(IMissionPlanner missionPlanner)
+        {
+            _missionPlanner = missionPlanner;
+        }
+
+        public bool CheckEnableAltitudeAngel
+        {
+            get => Get("AACheck2", false, bool.Parse);
+            set => Set("AACheck2", value);
+        }
+
+        public string AuthenticationUrl => ConfigurationManager.AppSettings["AuthURL"];
+
+        public string ApiUrl => ConfigurationManager.AppSettings["APIURL"];
+
+        public string ClientId => ConfigurationManager.AppSettings["ClientId"];
+
+        public string ClientSecret => ConfigurationManager.AppSettings["ClientSecret"];
+
+        public IAuthorizationState AuthToken
+        {
+            get => Get("AAWings.Token", null, JsonConvert.DeserializeObject<AuthorizationState>);
+            set => Set("AAWings.Token", value, JsonConvert.SerializeObject);
+        }
+
+        public bool GroundDataDisplay
+        {
+            get => Get("AA.Ground", true, bool.Parse);
+            set => Set("AA.Ground", value);
+        }
+
+        public bool AirDataDisplay
+        {
+            get => Get("AA.Air", true, bool.Parse);
+            set => Set("AA.Air", value);
+        }
+
+        public IList<string> MapFilters
+        {
+            get => Get("AAWings.Filters", new List<string>(), JsonConvert.DeserializeObject<List<string>>);
+            set => Set("AAWings.Filters", value, JsonConvert.SerializeObject);
+        }
+
+        public bool FlightReportEnable
+        {
+            get => Get("AA.FlightReportEnable", true, bool.Parse);
+            set => Set("AA.FlightReportEnable", value);
+        }
+
+        public string CurrentFlightReportId
+        {
+            get => Get("AA.CurrentFlightReportId", null, s => s);
+            set => Set("AA.CurrentFlightReportId", value);
+        }
+
+        public string FlightReportName
+        {
+            get => Get("AA.FlightReportName", "MissionPlanner Flight", s => s);
+            set => Set("AA.FlightReportName", value);
+        }
+
+        public bool FlightReportCommercial
+        {
+            get => Get("AA.FlightReportCommercial", false, bool.Parse);
+            set => Set("AA.FlightReportCommercial", value);
+        }
+
+        public TimeSpan FlightReportTimeSpan
+        {
+            get => Get("AA.FlightReportTimeSpan", TimeSpan.FromMinutes(60), TimeSpan.Parse);
+            set => Set("AA.FlightReportTimeSpan", value);
+        }
+
+        private T Get<T>(string settingName, T defaultValue, Func<string, T> getSetting)
+        {
+            return string.IsNullOrEmpty(_missionPlanner.LoadSetting(settingName))
+                ? defaultValue
+                : getSetting(_missionPlanner.LoadSetting(settingName));
+        }
+
+        private void Set<T>(string settingName, T value, Func<T, string> setSetting = null)
+        {
+            if (value == null)
+            {
+                _missionPlanner.ClearSetting(settingName);
+                return;
+            }
+            if (setSetting == null)
+            {
+                setSetting = v => v.ToString();
+            }
+            _missionPlanner.SaveSetting(settingName, setSetting(value));
+        }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/ServiceLocator.cs
+++ b/ExtLibs/AltitudeAngelWings/ServiceLocator.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace AltitudeAngelWings
+{
+    public static class ServiceLocator
+    {
+        private class Resolver : IServiceLocator
+        {
+            public T Resolve<T>()
+            {
+                return GetService<T>();
+            }
+        }
+
+        private static readonly object Lock = new object();
+        private static readonly IDictionary<Type, object> ServiceInstances = new Dictionary<Type, object>();
+        private static readonly IDictionary<Type, Func<IServiceLocator, object>> ServiceRegistry = new Dictionary<Type, Func<IServiceLocator, object>>();
+
+        public static T GetService<T>()
+        {
+            if (ServiceInstances.ContainsKey(typeof(T)))
+            {
+                return (T)ServiceInstances[typeof(T)];
+            }
+            lock (Lock)
+            {
+                if (!ServiceRegistry.ContainsKey(typeof(T)))
+                {
+                    throw new InvalidOperationException($"The type {typeof(T)} is not registered.");
+                }
+                var resolve = ServiceRegistry[typeof(T)](new Resolver());
+                ServiceInstances[typeof(T)] = resolve;
+                return (T) resolve;
+            }
+        }
+
+        public static void Register<T>(Func<IServiceLocator, T> constructor)
+        {
+            lock (Lock)
+            {
+                if (ServiceRegistry.ContainsKey(typeof(T)))
+                {
+                    throw new InvalidOperationException($"The type {typeof(T)} is already registered.");
+                }
+                ServiceRegistry.Add(typeof(T), l => constructor(l));
+            }
+        }
+
+        public static void Clear()
+        {
+            lock (Lock)
+            {
+                ServiceRegistry.Clear();
+                foreach (var instance in ServiceInstances.Values)
+                {
+                    if (instance is IDisposable dispose)
+                    {
+                        dispose.Dispose();
+                    }
+                }
+                ServiceInstances.Clear();
+            }
+        }
+    }
+}

--- a/ExtLibs/AltitudeAngelWings/packages.config
+++ b/ExtLibs/AltitudeAngelWings/packages.config
@@ -2,19 +2,11 @@
 <packages>
   <package id="DotNetOpenAuth.Ultimate" version="4.3.4.13329" targetFramework="net461" />
   <package id="Flurl" version="2.7.1" targetFramework="net461" />
-  <package id="Flurl.Http" version="2.3.1" targetFramework="net461" />
+  <package id="Flurl.Http" version="2.3.2" targetFramework="net461" />
   <package id="GeoJSON.Net" version="1.1.64" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.3" targetFramework="net461" />
   <package id="System.Reactive" version="4.0.0" targetFramework="net461" />
   <package id="System.Reactive.Core" version="4.0.0" targetFramework="net461" />
-  <package id="System.Reactive.Interfaces" version="4.0.0" targetFramework="net461" />
-  <package id="System.Reactive.Linq" version="4.0.0" targetFramework="net461" />
-  <package id="System.Reactive.PlatformServices" version="4.0.0" targetFramework="net461" />
-  <package id="System.Reactive.Windows.Threading" version="4.0.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="TimeZoneConverter" version="2.4.1" targetFramework="net461" />
 </packages>

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1774,6 +1774,11 @@ namespace MissionPlanner.GCSViews
             }
         }
 
+        internal IList<Locationwp> GetFlightPlanLocations()
+        {
+            return GetCommandList().AsReadOnly();
+        }
+
         List<Locationwp> GetCommandList()
         {
             List<Locationwp> commands = new List<Locationwp>();

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -21,6 +21,7 @@ using System.Collections.Concurrent;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using MissionPlanner.ArduPilot;
+using MissionPlanner.Utilities.AltitudeAngel;
 
 namespace MissionPlanner
 {
@@ -1850,6 +1851,8 @@ namespace MissionPlanner
             Settings.Instance["MainLocY"] = this.Location.Y.ToString();
 
             log.Info("close logs");
+            AltitudeAngel.Dispose();
+
             // close bases connection
             try
             {
@@ -2990,21 +2993,8 @@ namespace MissionPlanner
             try
             {
                 log.Info("Load AltitudeAngel");
-                new Utilities.AltitudeAngel.AltitudeAngel();
-
-                // setup as a prompt once dialog
-                if (!Settings.Instance.GetBoolean("AACheck2"))
-                {
-                    if (CustomMessageBox.Show(
-                            "Do you wish to enable Altitude Angel airspace management data?\nFor more information visit [link;http://www.altitudeangel.com;www.altitudeangel.com]",
-                            "Altitude Angel - Enable", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
-                    {
-                        Utilities.AltitudeAngel.AltitudeAngel.service.SignInAsync();
-                    }
-
-                    Settings.Instance["AACheck2"] = true.ToString();
-                }
-                
+                AltitudeAngel.Configure();
+                AltitudeAngel.Initialize();
                 log.Info("Load AltitudeAngel... Done");
             }
             catch (TypeInitializationException) // windows xp lacking patch level

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -200,6 +200,7 @@
     <PackageReference Include="DotSpatial.Extensions" version="1.9" targetFramework="net462" />
     <PackageReference Include="DotSpatial.Modeling.Forms" version="1.9" targetFramework="net462" />
     <PackageReference Include="DotSpatial.Mono" version="1.9" targetFramework="net462" />
+    <PackageReference Include="DotSpatial.Positioning" Version="1.9.0" />
     <PackageReference Include="DotSpatial.Projections" version="1.9" targetFramework="net462" />
     <PackageReference Include="DotSpatial.Projections.Forms" version="1.9" targetFramework="net462" />
     <PackageReference Include="DotSpatial.Serialization" version="1.9" targetFramework="net462" />
@@ -257,6 +258,7 @@
     <Compile Include="Swarm\TD\UI.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Utilities\AltitudeAngel\MissionPlannerStateAdapter.cs" />
     <Compile Include="Utilities\SSHTerminal.cs" />
     <Compile Include="Utilities\XTermRBGColors.cs" />
     <Compile Include="GenOTP.cs"> <SubType>Control</SubType> </Compile>

--- a/Utilities/AltitudeAngel/AASettings.Designer.cs
+++ b/Utilities/AltitudeAngel/AASettings.Designer.cs
@@ -2,9 +2,7 @@
 
 namespace MissionPlanner.Utilities.AltitudeAngel
 {
-
-
-    partial class AASettings
+    internal partial class AASettings
     {
         /// <summary>
         /// Required designer variable.
@@ -37,6 +35,13 @@ namespace MissionPlanner.Utilities.AltitudeAngel
             this.chk_airdata = new System.Windows.Forms.CheckBox();
             this.chk_grounddata = new System.Windows.Forms.CheckBox();
             this.chklb_layers = new System.Windows.Forms.CheckedListBox();
+            this.txt_FlightReportName = new System.Windows.Forms.TextBox();
+            this.lbl_FlightReportName = new System.Windows.Forms.Label();
+            this.txt_FlightReportDuration = new System.Windows.Forms.TextBox();
+            this.lbl_FlightReportDuration = new System.Windows.Forms.Label();
+            this.chk_FlightReportCommercial = new System.Windows.Forms.CheckBox();
+            this.chk_FlightReportEnable = new System.Windows.Forms.CheckBox();
+            this.lbl_FlightReportWhat = new System.Windows.Forms.LinkLabel();
             this.SuspendLayout();
             // 
             // but_enable
@@ -62,10 +67,10 @@ namespace MissionPlanner.Utilities.AltitudeAngel
             // chk_airdata
             // 
             this.chk_airdata.AutoSize = true;
-            this.chk_airdata.Location = new System.Drawing.Point(13, 43);
+            this.chk_airdata.Location = new System.Drawing.Point(13, 163);
             this.chk_airdata.Name = "chk_airdata";
-            this.chk_airdata.Size = new System.Drawing.Size(64, 17);
-            this.chk_airdata.TabIndex = 2;
+            this.chk_airdata.Size = new System.Drawing.Size(121, 29);
+            this.chk_airdata.TabIndex = 5;
             this.chk_airdata.Text = "Air Data";
             this.chk_airdata.UseVisualStyleBackColor = true;
             this.chk_airdata.CheckedChanged += new System.EventHandler(this.chk_airdata_CheckedChanged);
@@ -73,10 +78,10 @@ namespace MissionPlanner.Utilities.AltitudeAngel
             // chk_grounddata
             // 
             this.chk_grounddata.AutoSize = true;
-            this.chk_grounddata.Location = new System.Drawing.Point(94, 42);
+            this.chk_grounddata.Location = new System.Drawing.Point(94, 163);
             this.chk_grounddata.Name = "chk_grounddata";
-            this.chk_grounddata.Size = new System.Drawing.Size(87, 17);
-            this.chk_grounddata.TabIndex = 3;
+            this.chk_grounddata.Size = new System.Drawing.Size(166, 29);
+            this.chk_grounddata.TabIndex = 6;
             this.chk_grounddata.Text = "Ground Data";
             this.chk_grounddata.UseVisualStyleBackColor = true;
             this.chk_grounddata.CheckedChanged += new System.EventHandler(this.chk_grounddata_CheckedChanged);
@@ -85,16 +90,90 @@ namespace MissionPlanner.Utilities.AltitudeAngel
             // 
             this.chklb_layers.CheckOnClick = true;
             this.chklb_layers.FormattingEnabled = true;
-            this.chklb_layers.Location = new System.Drawing.Point(12, 65);
+            this.chklb_layers.Location = new System.Drawing.Point(13, 187);
             this.chklb_layers.Name = "chklb_layers";
-            this.chklb_layers.Size = new System.Drawing.Size(159, 199);
-            this.chklb_layers.TabIndex = 4;
+            this.chklb_layers.Size = new System.Drawing.Size(172, 186);
+            this.chklb_layers.TabIndex = 7;
             this.chklb_layers.SelectedIndexChanged += new System.EventHandler(this.chklb_layers_SelectedIndexChanged);
+            // 
+            // txt_FlightReportName
+            // 
+            this.txt_FlightReportName.Location = new System.Drawing.Point(13, 90);
+            this.txt_FlightReportName.Name = "txt_FlightReportName";
+            this.txt_FlightReportName.Size = new System.Drawing.Size(172, 31);
+            this.txt_FlightReportName.TabIndex = 3;
+            this.txt_FlightReportName.TextChanged += new System.EventHandler(this.txt_FlightReportName_TextChanged);
+            // 
+            // lbl_FlightReportName
+            // 
+            this.lbl_FlightReportName.AutoSize = true;
+            this.lbl_FlightReportName.Location = new System.Drawing.Point(8, 74);
+            this.lbl_FlightReportName.Name = "lbl_FlightReportName";
+            this.lbl_FlightReportName.Size = new System.Drawing.Size(197, 25);
+            this.lbl_FlightReportName.TabIndex = 8;
+            this.lbl_FlightReportName.Text = "Flight Report Name";
+            // 
+            // txt_FlightReportDuration
+            // 
+            this.txt_FlightReportDuration.Location = new System.Drawing.Point(13, 141);
+            this.txt_FlightReportDuration.Name = "txt_FlightReportDuration";
+            this.txt_FlightReportDuration.Size = new System.Drawing.Size(172, 31);
+            this.txt_FlightReportDuration.TabIndex = 4;
+            this.txt_FlightReportDuration.TextChanged += new System.EventHandler(this.txt_FlightReportDuration_TextChanged);
+            // 
+            // lbl_FlightReportDuration
+            // 
+            this.lbl_FlightReportDuration.AutoSize = true;
+            this.lbl_FlightReportDuration.Location = new System.Drawing.Point(8, 125);
+            this.lbl_FlightReportDuration.Name = "lbl_FlightReportDuration";
+            this.lbl_FlightReportDuration.Size = new System.Drawing.Size(287, 25);
+            this.lbl_FlightReportDuration.TabIndex = 9;
+            this.lbl_FlightReportDuration.Text = "Flight Report Duration (mins)";
+            // 
+            // chk_FlightReportCommercial
+            // 
+            this.chk_FlightReportCommercial.AutoSize = true;
+            this.chk_FlightReportCommercial.Location = new System.Drawing.Point(12, 107);
+            this.chk_FlightReportCommercial.Name = "chk_FlightReportCommercial";
+            this.chk_FlightReportCommercial.Size = new System.Drawing.Size(216, 29);
+            this.chk_FlightReportCommercial.TabIndex = 3;
+            this.chk_FlightReportCommercial.Text = "Commercial Flight";
+            this.chk_FlightReportCommercial.UseVisualStyleBackColor = true;
+            this.chk_FlightReportCommercial.CheckedChanged += new System.EventHandler(this.chk_FlightReportCommercial_CheckedChanged);
+            // 
+            // chk_FlightReportEnable
+            // 
+            this.chk_FlightReportEnable.AutoSize = true;
+            this.chk_FlightReportEnable.Location = new System.Drawing.Point(12, 39);
+            this.chk_FlightReportEnable.Name = "chk_FlightReportEnable";
+            this.chk_FlightReportEnable.Size = new System.Drawing.Size(269, 29);
+            this.chk_FlightReportEnable.TabIndex = 2;
+            this.chk_FlightReportEnable.Text = "Enable Flight Reporting";
+            this.chk_FlightReportEnable.UseVisualStyleBackColor = true;
+            this.chk_FlightReportEnable.CheckedChanged += new System.EventHandler(this.chk_FlightReportEnable_CheckedChanged);
+            // 
+            // lbl_FlightReportWhat
+            // 
+            this.lbl_FlightReportWhat.AutoSize = true;
+            this.lbl_FlightReportWhat.Location = new System.Drawing.Point(12, 57);
+            this.lbl_FlightReportWhat.Name = "lbl_FlightReportWhat";
+            this.lbl_FlightReportWhat.Size = new System.Drawing.Size(136, 25);
+            this.lbl_FlightReportWhat.TabIndex = 10;
+            this.lbl_FlightReportWhat.TabStop = true;
+            this.lbl_FlightReportWhat.Text = "What is this?";
+            this.lbl_FlightReportWhat.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lbl_FlightReportWhat_LinkClicked);
             // 
             // AASettings
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.ClientSize = new System.Drawing.Size(183, 274);
+            this.ClientSize = new System.Drawing.Size(198, 379);
+            this.Controls.Add(this.lbl_FlightReportWhat);
+            this.Controls.Add(this.chk_FlightReportEnable);
+            this.Controls.Add(this.chk_FlightReportCommercial);
+            this.Controls.Add(this.lbl_FlightReportDuration);
+            this.Controls.Add(this.txt_FlightReportDuration);
+            this.Controls.Add(this.lbl_FlightReportName);
+            this.Controls.Add(this.txt_FlightReportName);
             this.Controls.Add(this.chklb_layers);
             this.Controls.Add(this.chk_grounddata);
             this.Controls.Add(this.chk_airdata);
@@ -115,5 +194,12 @@ namespace MissionPlanner.Utilities.AltitudeAngel
         private MyButton but_enable;
         private MyButton but_disable;
         private System.Windows.Forms.CheckedListBox chklb_layers;
+        private System.Windows.Forms.TextBox txt_FlightReportName;
+        private System.Windows.Forms.Label lbl_FlightReportName;
+        private System.Windows.Forms.TextBox txt_FlightReportDuration;
+        private System.Windows.Forms.Label lbl_FlightReportDuration;
+        private System.Windows.Forms.CheckBox chk_FlightReportCommercial;
+        private System.Windows.Forms.CheckBox chk_FlightReportEnable;
+        private System.Windows.Forms.LinkLabel lbl_FlightReportWhat;
     }
 }

--- a/Utilities/AltitudeAngel/AASettings.cs
+++ b/Utilities/AltitudeAngel/AASettings.cs
@@ -1,50 +1,66 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Web.Configuration;
+using System.Diagnostics;
 using System.Windows.Forms;
+using AltitudeAngelWings;
+using AltitudeAngelWings.Extra;
+using AltitudeAngelWings.Service;
 
 namespace MissionPlanner.Utilities.AltitudeAngel
 {
-    public partial class AASettings : Form
+    internal partial class AASettings : Form
     {
+        private readonly ISettings _settings;
+        private readonly IAltitudeAngelService _altitudeAngelService;
+        private readonly IMissionPlanner _missionPlanner;
+
         public AASettings()
+            : this(ServiceLocator.GetService<ISettings>(), ServiceLocator.GetService<IAltitudeAngelService>(), ServiceLocator.GetService<IMissionPlanner>())
         {
+        }
+
+        public AASettings(ISettings settings, IAltitudeAngelService altitudeAngelService, IMissionPlanner missionPlanner)
+        {
+            _settings = settings;
+            _altitudeAngelService = altitudeAngelService;
+            _missionPlanner = missionPlanner;
             InitializeComponent();
 
             ThemeManager.ApplyThemeTo(this);
 
             // load settings
-            chk_grounddata.Checked = Utilities.AltitudeAngel.AltitudeAngel.service.GroundDataDisplay;
-            chk_airdata.Checked = Utilities.AltitudeAngel.AltitudeAngel.service.AirDataDisplay;
+            chk_grounddata.Checked = _settings.GroundDataDisplay;
+            chk_airdata.Checked = _settings.AirDataDisplay;
+            chk_FlightReportEnable.Checked = _settings.FlightReportEnable;
+            txt_FlightReportName.Text = _settings.FlightReportName;
+            chk_FlightReportCommercial.Checked = _settings.FlightReportCommercial;
+            txt_FlightReportDuration.Text =
+                ((int) _settings.FlightReportTimeSpan.TotalMinutes).ToString();
 
-            but_enable.Enabled = !Utilities.AltitudeAngel.AltitudeAngel.service.IsSignedIn;
-            but_disable.Enabled = Utilities.AltitudeAngel.AltitudeAngel.service.IsSignedIn;
+            but_enable.Enabled = !_altitudeAngelService.IsSignedIn;
+            but_disable.Enabled = _altitudeAngelService.IsSignedIn;
 
             foreach (var item in AltitudeAngelWings.ApiClient.Client.Extensions.FiltersSeen)
             {
-                if (AltitudeAngel.service.FilteredOut.Contains(item))
+                if (_altitudeAngelService.FilteredOut.Contains(item))
                     chklb_layers.Items.Add(item, false);
                 else
                     chklb_layers.Items.Add(item, true);
             }
+
+            RefreshControlStates();
         }
 
         private void but_enable_Click(object sender, EventArgs e)
         {
             try
             {
-                if (Utilities.AltitudeAngel.AltitudeAngel.service.IsSignedIn)
+                if (_altitudeAngelService.IsSignedIn)
                 {
-                    CustomMessageBox.Show("You are already signed in", "AltitudeAngel");
+                    CustomMessageBox.Show("You are already signed in", "Altitude Angel");
                     return;
                 }
 
-                Utilities.AltitudeAngel.AltitudeAngel.service.SignInAsync();
+                _altitudeAngelService.SignInAsync();
             }
             catch (TypeInitializationException)
             {
@@ -54,39 +70,77 @@ namespace MissionPlanner.Utilities.AltitudeAngel
 
         private void but_disable_Click(object sender, EventArgs e)
         {
-            Utilities.AltitudeAngel.AltitudeAngel.service.DisconnectAsync();
+            _altitudeAngelService.DisconnectAsync();
 
-            AltitudeAngel.service.ProcessAllFromCache(AltitudeAngel.MP.FlightDataMap);
+            _altitudeAngelService.ProcessAllFromCache(_missionPlanner.FlightDataMap);
         }
 
         private void chk_airdata_CheckedChanged(object sender, EventArgs e)
         {
-            Utilities.AltitudeAngel.AltitudeAngel.service.AirDataDisplay = chk_airdata.Checked;
+            _settings.AirDataDisplay = chk_airdata.Checked;
 
-            AltitudeAngel.service.ProcessAllFromCache(AltitudeAngel.MP.FlightDataMap);
+            _altitudeAngelService.ProcessAllFromCache(_missionPlanner.FlightDataMap);
         }
 
         private void chk_grounddata_CheckedChanged(object sender, EventArgs e)
         {
-            Utilities.AltitudeAngel.AltitudeAngel.service.GroundDataDisplay = chk_grounddata.Checked;
+            _settings.GroundDataDisplay = chk_grounddata.Checked;
 
-            AltitudeAngel.service.ProcessAllFromCache(AltitudeAngel.MP.FlightDataMap);
+            _altitudeAngelService.ProcessAllFromCache(_missionPlanner.FlightDataMap);
         }
 
         private void chklb_layers_SelectedIndexChanged(object sender, EventArgs e)
         {
-            AltitudeAngel.service.FilteredOut.Clear();
+            _altitudeAngelService.FilteredOut.Clear();
 
             foreach (string item in chklb_layers.Items)
             {
                 if (!chklb_layers.CheckedItems.Contains(item))
                 {
-                    AltitudeAngel.service.FilteredOut.Add(item);
+                    _altitudeAngelService.FilteredOut.Add(item);
                 }
             }
 
             // reset state on change
-            AltitudeAngel.service.ProcessAllFromCache(AltitudeAngel.MP.FlightDataMap);
+            _altitudeAngelService.ProcessAllFromCache(_missionPlanner.FlightDataMap);
+        }
+
+        private void txt_FlightReportName_TextChanged(object sender, EventArgs e)
+        {
+            _settings.FlightReportName = txt_FlightReportName.Text;
+        }
+
+        private void txt_FlightReportDuration_TextChanged(object sender, EventArgs e)
+        {
+            if (int.TryParse(txt_FlightReportDuration.Text, out var minutes))
+            {
+                _settings.FlightReportTimeSpan = TimeSpan.FromMinutes(minutes);
+            }
+        }
+
+        private void chk_FlightReportCommercial_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.FlightReportCommercial = chk_FlightReportCommercial.Checked;
+        }
+
+        private void chk_FlightReportEnable_CheckedChanged(object sender, EventArgs e)
+        {
+            _settings.FlightReportEnable = chk_FlightReportEnable.Checked;
+            RefreshControlStates();
+        }
+
+        private void RefreshControlStates()
+        {
+            lbl_FlightReportName.Enabled = chk_FlightReportEnable.Checked;
+            txt_FlightReportName.Enabled = chk_FlightReportEnable.Checked;
+            lbl_FlightReportDuration.Enabled = chk_FlightReportEnable.Checked;
+            txt_FlightReportDuration.Enabled = chk_FlightReportEnable.Checked;
+            chk_FlightReportCommercial.Enabled = chk_FlightReportEnable.Checked;
+        }
+
+        private void lbl_FlightReportWhat_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            Process.Start("http://bit.ly/aamissionplanner1");
         }
     }
 }

--- a/Utilities/AltitudeAngel/AltitudeAngel.cs
+++ b/Utilities/AltitudeAngel/AltitudeAngel.cs
@@ -1,32 +1,46 @@
 ﻿using System;
-using System.Text;
-using System.Windows.Forms;
+using System.Threading.Tasks;
 using AltitudeAngelWings;
-using AltitudeAngelWings.ApiClient.Client;
+using AltitudeAngelWings.Extra;
 using AltitudeAngelWings.Service;
-using AltitudeAngelWings.Service.FlightData;
-using AltitudeAngelWings.Service.FlightData.Providers;
-using AltitudeAngelWings.Service.Messaging;
-using MissionPlanner.Controls;
+using MissionPlanner.GCSViews;
 
 namespace MissionPlanner.Utilities.AltitudeAngel
 {
-    public class AltitudeAngel : IDisposable
+    internal static class AltitudeAngel
     {
-        public static MissionPlannerAdaptor MP = new MissionPlannerAdaptor();
-        private static MessagesService Message = new MessagesService();
-
-        public static AltitudeAngelService service = null;
-
-        static AltitudeAngel()
+        internal static void Configure()
         {
-            service = new AltitudeAngelService(Message, MP,
-                new FlightDataService(new ObservableProperty<long>(3), new MissionPlannerFlightDataProvider(null)));
+            AltitudeAngelPlugin.Configure();
+            ServiceLocator.Register<IMissionPlanner>(l => new MissionPlannerAdaptor(
+                new MapAdapter(FlightData.instance.gMapControl1),
+                new MapAdapter(FlightPlanner.instance.MainMap),
+                () => FlightPlanner.instance.GetFlightPlanLocations()));
+            ServiceLocator.Register<IMissionPlannerState>(l => new MissionPlannerStateAdapter(
+                () => MainV2.comPort.MAV.cs));
         }
 
-        public void Dispose()
+        internal static async Task Initialize()
         {
-            service.Dispose();
+            var settings = ServiceLocator.GetService<ISettings>();
+            var service = ServiceLocator.GetService<IAltitudeAngelService>();
+            if (settings.CheckEnableAltitudeAngel)
+            {
+                await service.SignInIfAuthenticated();
+                return;
+            }
+            if (CustomMessageBox.Show(
+                    "Do you wish to enable Altitude Angel airspace management data?\nFor more information visit [link;http://www.altitudeangel.com;www.altitudeangel.com]",
+                    "Altitude Angel - Enable", CustomMessageBox.MessageBoxButtons.YesNo) == (int)CustomMessageBox.DialogResult.Yes)
+            {
+                await service.SignInAsync();
+            }
+            settings.CheckEnableAltitudeAngel = true;
+        }
+
+        internal static void Dispose()
+        {
+            ServiceLocator.Clear();
         }
     }
 }

--- a/Utilities/AltitudeAngel/MapAdapter.cs
+++ b/Utilities/AltitudeAngel/MapAdapter.cs
@@ -5,19 +5,16 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Windows.Forms;
-using AltitudeAngel.IsolatedPlugin.Common.Maps;
-using AltitudeAngelWings;
+using AltitudeAngelWings.Extra;
 using GMap.NET;
 using GMap.NET.WindowsForms;
 using MissionPlanner.Maps;
-using SharpKml.Dom;
 using Feature = GeoJSON.Net.Feature.Feature;
-using Timer = System.Windows.Forms.Timer;
 using Unit = System.Reactive.Unit;
 
 namespace MissionPlanner.Utilities.AltitudeAngel
 {
-    class MapAdapter : IMap, IDisposable
+    internal class MapAdapter : IMap, IDisposable
     {
         public MapAdapter(GMapControl mapControl)
         {

--- a/Utilities/AltitudeAngel/MissionPlannerAdaptor.cs
+++ b/Utilities/AltitudeAngel/MissionPlannerAdaptor.cs
@@ -1,21 +1,24 @@
 using System;
-using AltitudeAngel.IsolatedPlugin.Common;
-using AltitudeAngel.IsolatedPlugin.Common.Maps;
+using System.Collections.Generic;
+using System.Linq;
+using AltitudeAngelWings.Extra;
 using AltitudeAngelWings.Models;
-using MissionPlanner.GCSViews;
-using FlightData = MissionPlanner.GCSViews.FlightData;
+using DotSpatial.Positioning;
+using DotSpatial.Topology;
 
 namespace MissionPlanner.Utilities.AltitudeAngel
 {
-    public class MissionPlannerAdaptor : IMissionPlanner
+    internal class MissionPlannerAdaptor : IMissionPlanner
     {
-        public IMap FlightPlanningMap { get; set; }
-        public IMap FlightDataMap { get; set; }
+        private readonly Func<IList<Locationwp>> _getFlightPlan;
+        public IMap FlightPlanningMap { get; }
+        public IMap FlightDataMap { get; }
 
-        public MissionPlannerAdaptor()
+        public MissionPlannerAdaptor(IMap flightDataMap, IMap flightPlanningMap, Func<IList<Locationwp>> getFlightPlan)
         {
-            FlightDataMap = new MapAdapter(FlightData.instance.gMapControl1);
-            FlightPlanningMap = new MapAdapter(FlightPlanner.instance.MainMap);
+            FlightDataMap = flightDataMap;
+            FlightPlanningMap = flightPlanningMap;
+            _getFlightPlan = getFlightPlan;
         }
 
         public void SaveSetting(string key, string data)
@@ -25,15 +28,87 @@ namespace MissionPlanner.Utilities.AltitudeAngel
 
         public string LoadSetting(string key)
         {
-            if (Settings.Instance.ContainsKey(key))
-                return Settings.Instance[key];
-
-            return null;
+            return Settings.Instance.ContainsKey(key) ? Settings.Instance[key] : null;
         }
 
         public void ClearSetting(string key)
         {
             Settings.Instance.Remove(key);
+        }
+
+        public FlightPlan GetFlightPlan()
+        {
+            var waypoints = _getFlightPlan().Where(IsValidWaypoint).ToList();
+            if (waypoints.Count == 0)
+            {
+                return null;
+            }
+            var envelope = GeometryFactory.Default.CreateMultiPoint(waypoints
+                .Select(l => new Coordinate(l.lng, l.lat))).Envelope;
+            var center = envelope.Center();
+            var minPos = new Position(new Latitude(envelope.Minimum.Y), new Longitude(envelope.Minimum.X));
+            var maxPos = new Position(new Latitude(envelope.Maximum.Y), new Longitude(envelope.Maximum.X));
+            var boundingRadius = (int)Math.Ceiling(minPos.DistanceTo(maxPos).ToMeters().Value);
+            return new FlightPlan(waypoints.Select(f => new FlightPlanWaypoint
+            {
+                Latitude = f.lat,
+                Longitude = f.lng,
+                Altitude = (int) f.alt,
+            }))
+            {
+                CenterLongitude = center.X,
+                CenterLatitude = center.Y,
+                BoundingRadius = boundingRadius
+            };
+        }
+
+        private static bool IsValidWaypoint(Locationwp location)
+        {
+            // Command that can contain latitude and longitude
+            var cmd = (MAVLink.MAV_CMD)location.id;
+            if (cmd != MAVLink.MAV_CMD.WAYPOINT &&
+                cmd != MAVLink.MAV_CMD.LOITER_UNLIM &&
+                cmd != MAVLink.MAV_CMD.LOITER_TURNS &&
+                cmd != MAVLink.MAV_CMD.LOITER_TIME &&
+                cmd != MAVLink.MAV_CMD.LAND &&
+                cmd != MAVLink.MAV_CMD.TAKEOFF &&
+                cmd != MAVLink.MAV_CMD.FOLLOW &&
+                cmd != MAVLink.MAV_CMD.LOITER_TO_ALT &&
+                cmd != MAVLink.MAV_CMD.PATHPLANNING &&
+                cmd != MAVLink.MAV_CMD.SPLINE_WAYPOINT &&
+                cmd != MAVLink.MAV_CMD.VTOL_TAKEOFF &&
+                cmd != MAVLink.MAV_CMD.VTOL_LAND &&
+                cmd != MAVLink.MAV_CMD.PAYLOAD_PLACE &&
+                cmd != MAVLink.MAV_CMD.DO_SET_HOME &&
+                cmd != MAVLink.MAV_CMD.DO_LAND_START &&
+                cmd != MAVLink.MAV_CMD.DO_REPOSITION &&
+                cmd != MAVLink.MAV_CMD.DO_SET_ROI_LOCATION &&
+                cmd != MAVLink.MAV_CMD.DO_MOUNT_CONTROL &&
+                cmd != MAVLink.MAV_CMD.OVERRIDE_GOTO &&
+                cmd != MAVLink.MAV_CMD.SET_GUIDED_SUBMODE_CIRCLE &&
+                cmd != MAVLink.MAV_CMD.FENCE_RETURN_POINT &&
+                cmd != MAVLink.MAV_CMD.FENCE_POLYGON_VERTEX_INCLUSION &&
+                cmd != MAVLink.MAV_CMD.FENCE_POLYGON_VERTEX_EXCLUSION &&
+                cmd != MAVLink.MAV_CMD.FENCE_CIRCLE_INCLUSION &&
+                cmd != MAVLink.MAV_CMD.FENCE_CIRCLE_EXCLUSION &&
+                cmd != MAVLink.MAV_CMD.RALLY_POINT &&
+                cmd != MAVLink.MAV_CMD.PAYLOAD_PREPARE_DEPLOY &&
+                cmd != MAVLink.MAV_CMD.WAYPOINT_USER_1 &&
+                cmd != MAVLink.MAV_CMD.WAYPOINT_USER_2 &&
+                cmd != MAVLink.MAV_CMD.WAYPOINT_USER_3 &&
+                cmd != MAVLink.MAV_CMD.WAYPOINT_USER_4 &&
+                cmd != MAVLink.MAV_CMD.WAYPOINT_USER_5 &&
+                cmd != MAVLink.MAV_CMD.SPATIAL_USER_1 &&
+                cmd != MAVLink.MAV_CMD.SPATIAL_USER_2 &&
+                cmd != MAVLink.MAV_CMD.SPATIAL_USER_3 &&
+                cmd != MAVLink.MAV_CMD.SPATIAL_USER_4 &&
+                cmd != MAVLink.MAV_CMD.SPATIAL_USER_5)
+            {
+                return false;
+            }
+
+            // Exclude "empty" latitude and longitude
+            return location.lat != 0 && location.lng != 0;
         }
     }
 }

--- a/Utilities/AltitudeAngel/MissionPlannerStateAdapter.cs
+++ b/Utilities/AltitudeAngel/MissionPlannerStateAdapter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using AltitudeAngelWings.Extra;
+
+namespace MissionPlanner.Utilities.AltitudeAngel
+{
+    internal class MissionPlannerStateAdapter : IMissionPlannerState
+    {
+        private readonly Func<CurrentState> _getCurrentState;
+
+        public MissionPlannerStateAdapter(Func<CurrentState> getCurrentState)
+        {
+            _getCurrentState = getCurrentState;
+        }
+
+        public bool IsArmed => _getCurrentState().armed;
+        public double Longitude => _getCurrentState().lng;
+        public double Latitude => _getCurrentState().lat;
+        public float Altitude => _getCurrentState().alt;
+        public float GroundSpeed => _getCurrentState().groundspeed;
+        public float MagneticDeclination => _getCurrentState().mag_declination;
+        public bool IsConnected => _getCurrentState().connected;
+    }
+}

--- a/Utilities/AltitudeAngel/OverlayAdapter.cs
+++ b/Utilities/AltitudeAngel/OverlayAdapter.cs
@@ -1,18 +1,17 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
-using AltitudeAngel.IsolatedPlugin.Common.Maps;
+using AltitudeAngelWings.Extra;
 using GeoJSON.Net.Feature;
 using GMap.NET;
 using GMap.NET.WindowsForms;
 
 namespace MissionPlanner.Utilities.AltitudeAngel
 {
-    class OverlayAdapter : IOverlay
+    internal class OverlayAdapter : IOverlay
     {
         private readonly GMapOverlay _overlay;
         private readonly SynchronizationContext _context;
@@ -57,20 +56,44 @@ namespace MissionPlanner.Utilities.AltitudeAngel
             }
         }
 
-        public void AddPolygon(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo)
+        public void AddOrUpdatePolygon(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo)
         {
             try
             {
                 _context.Send(_ =>
                 {
-                    _overlay.Polygons.Add(new GMapPolygon(points, name)
+                    var polygon = _overlay.Polygons.FirstOrDefault(p => p.Name == name);
+                    if (polygon == null)
                     {
-                        Fill = new SolidBrush(Color.FromArgb((int) colorInfo.FillColor)),
-                        Stroke = new Pen(Color.FromArgb((int) colorInfo.StrokeColor), colorInfo.StrokeWidth),
-                        IsHitTestVisible = true,
-                        Tag = featureInfo
-                    });
+                        polygon = new GMapPolygon(points, name);
+                        _overlay.Polygons.Add(polygon);
+                    }
+                    polygon.Fill = new SolidBrush(Color.FromArgb((int) colorInfo.FillColor));
+                    polygon.Stroke = new Pen(Color.FromArgb((int) colorInfo.StrokeColor), colorInfo.StrokeWidth);
+                    polygon.IsHitTestVisible = true;
+                    polygon.Tag = featureInfo;
+               }, null);
+            }
+            catch (InvalidAsynchronousStateException)
+            {
 
+            }
+        }
+
+        public void RemovePolygonsExcept(List<string> names)
+        {
+            try
+            {
+                _context.Send(_ =>
+                {
+                    for (var pos = 0; pos < _overlay.Polygons.Count; pos++)
+                    {
+                        var polygon = _overlay.Polygons[pos];
+                        if (!names.Contains(polygon.Name))
+                        {
+                            _overlay.Polygons.Remove(polygon);
+                        }
+                    }
                 }, null);
             }
             catch (InvalidAsynchronousStateException)
@@ -95,18 +118,43 @@ namespace MissionPlanner.Utilities.AltitudeAngel
             return polygonExists;
         }
 
-        public void AddLine(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo)
+        public void AddOrUpdateLine(string name, List<PointLatLng> points, ColorInfo colorInfo, Feature featureInfo)
         {
             try
             {
                 _context.Send(_ =>
                 {
-                    _overlay.Routes.Add(new GMapRoute(points, name)
+                    var route = _overlay.Routes.FirstOrDefault(r => r.Name == name);
+                    if (route == null)
                     {
-                        Stroke = new Pen(Color.FromArgb((int) colorInfo.StrokeColor), colorInfo.StrokeWidth + 2),
-                        IsHitTestVisible = true,
-                        Tag = featureInfo
-                    });
+                        route = new GMapRoute(points, name);
+                        _overlay.Routes.Add(route);
+                    }
+                    route.Stroke = new Pen(Color.FromArgb((int) colorInfo.StrokeColor), colorInfo.StrokeWidth + 2);
+                    route.IsHitTestVisible = true;
+                    route.Tag = featureInfo;
+                }, null);
+            }
+            catch (InvalidAsynchronousStateException)
+            {
+
+            }
+        }
+
+        public void RemoveLinesExcept(List<string> names)
+        {
+            try
+            {
+                _context.Send(_ =>
+                {
+                    for (var pos = 0; pos < _overlay.Routes.Count; pos++)
+                    {
+                        var route = _overlay.Routes[pos];
+                        if (!names.Contains(route.Name))
+                        {
+                            _overlay.Routes.Remove(route);
+                        }
+                    }
                 }, null);
             }
             catch (InvalidAsynchronousStateException)


### PR DESCRIPTION
These changes add Altitude Angel flight reporting to Mission Planner. This includes displaying other flight reports on the map so you are aware of them, and reporting your own flights. To do this we summarise a flight plan to a centroid and radius (or current location if there’s no flight plan), and on arm we submit the flight report, and complete the flight report on disarm. There are also settings that control if this happens or not, and the metadata used for the flight report.