### PR TITLE
Exposing sky and ground color values to support upcoming "Night MODE" plugin

### DIFF
--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -747,6 +747,36 @@ namespace MissionPlanner.Controls
             }
         }
 
+        [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Values")]
+        public Color skyColor1
+        {
+            get { return _skyColor1; }
+            set { _skyColor1 = value; }
+        }
+        [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Values")]
+        public Color skyColor2
+        {
+            get { return _skyColor2; }
+            set { _skyColor2 = value; }
+        }
+        [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Values")]
+        public Color groundColor1
+        {
+            get { return _groundColor1; }
+            set { _groundColor1 = value; }
+        }
+        [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Values")]
+        public Color groundColor2
+        {
+            get { return _groundColor2; }
+            set { _groundColor2 = value; }
+        }
+
+        private Color _skyColor1 = Color.Blue;
+        private Color _skyColor2 = Color.LightBlue;
+        private Color _groundColor1 = Color.FromArgb(0x9b, 0xb8, 0x24);
+        private Color _groundColor2 = Color.FromArgb(0x41, 0x4f, 0x07);
+
         private Color _hudcolor = Color.White;
         private Pen _whitePen = new Pen(Color.White, 2);
         private readonly SolidBrush _whiteBrush = new SolidBrush(Color.White);
@@ -1752,7 +1782,7 @@ namespace MissionPlanner.Controls
                     if (bg.Height != 0)
                     {
                         using (LinearGradientBrush linearBrush = new LinearGradientBrush(
-                            bg, Color.Blue, Color.LightBlue, LinearGradientMode.Vertical))
+                            bg, _skyColor1, _skyColor2, LinearGradientMode.Vertical))
                         {
                             graphicsObject.FillRectangle(linearBrush, bg);
                         }
@@ -1765,7 +1795,7 @@ namespace MissionPlanner.Controls
                     {
                         using (
                             LinearGradientBrush linearBrush = new LinearGradientBrush(
-                                bg, Color.FromArgb(0x9b, 0xb8, 0x24), Color.FromArgb(0x41, 0x4f, 0x07),
+                                bg, _groundColor1, _groundColor2,
                                 LinearGradientMode.Vertical))
                         {
                             graphicsObject.FillRectangle(linearBrush, bg);


### PR DESCRIPTION
I'm working on a "night mode" plugin, which enables quick switch between different color schemas for night or day usage. To support this, colors used for hud sky and ground are needed to be exposed as public properties. This change does this, keeping the current values as default setting.
