### PR TITLE
Map: Added Japan Maps

### DIFF
--- a/ExtLibs/Maps/Japan.cs
+++ b/ExtLibs/Maps/Japan.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan
+    /// </summary>
+    public class Japan : GMapProvider
+    {
+        public static readonly Japan Instance;
+
+        Japan ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan()
+        {
+            Instance = new Japan();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("99fe9e6b-719c-42d1-99e8-7fa2f55d4295");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            ret = string.Format(CultureInfo.InvariantCulture, CustomURL, zoom, pos.X, pos.Y);
+
+            return ret;
+        }
+
+        public static string CustomURL =
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+    }
+}

--- a/ExtLibs/Maps/Japan_1974.cs
+++ b/ExtLibs/Maps/Japan_1974.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan 1974
+    /// </summary>
+    public class Japan_1974 : GMapProvider
+    {
+        public static readonly Japan_1974 Instance;
+
+        Japan_1974 ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_1974()
+        {
+            Instance = new Japan_1974();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("5c6d4628-d445-4244-92dc-ea3b44252ec9");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_1974";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 10 || zoom > 17)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLgazo, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLgazo = 
+            "https://cyberjapandata.gsi.go.jp/xyz/gazo1/{0}/{1}/{2}.jpg";
+    }
+}

--- a/ExtLibs/Maps/Japan_1979.cs
+++ b/ExtLibs/Maps/Japan_1979.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan 1979
+    /// </summary>
+    public class Japan_1979 : GMapProvider
+    {
+        public static readonly Japan_1979 Instance;
+
+        Japan_1979 ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_1979()
+        {
+            Instance = new Japan_1979();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("9f685396-6873-4ef3-bdf1-afdb27f6b4bc");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_1979";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 10 || zoom > 17)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLgazo, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLgazo = 
+            "https://cyberjapandata.gsi.go.jp/xyz/gazo2/{0}/{1}/{2}.jpg";
+    }
+}

--- a/ExtLibs/Maps/Japan_1984.cs
+++ b/ExtLibs/Maps/Japan_1984.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan 1984
+    /// </summary>
+    public class Japan_1984 : GMapProvider
+    {
+        public static readonly Japan_1984 Instance;
+
+        Japan_1984 ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_1984()
+        {
+            Instance = new Japan_1984();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("9f0c3381-3662-488c-8689-d3bcc2e3cbb4");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_1984";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 10 || zoom > 17)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLgazo, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLgazo = 
+            "https://cyberjapandata.gsi.go.jp/xyz/gazo3/{0}/{1}/{2}.jpg";
+    }
+}

--- a/ExtLibs/Maps/Japan_1988.cs
+++ b/ExtLibs/Maps/Japan_1988.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan 1988
+    /// </summary>
+    public class Japan_1988 : GMapProvider
+    {
+        public static readonly Japan_1988 Instance;
+
+        Japan_1988 ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_1988()
+        {
+            Instance = new Japan_1988();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("dbc20d51-f9a1-4d17-9002-90c2ef0405d2");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_1988";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 10 || zoom > 17)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLgazo, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLgazo = 
+            "https://cyberjapandata.gsi.go.jp/xyz/gazo4/{0}/{1}/{2}.jpg";
+    }
+}

--- a/ExtLibs/Maps/Japan_Lake.cs
+++ b/ExtLibs/Maps/Japan_Lake.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan Lake
+    /// </summary>
+    public class Japan_Lake : GMapProvider
+    {
+        public static readonly Japan_Lake Instance;
+
+        Japan_Lake ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_Lake()
+        {
+            Instance = new Japan_Lake();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("ab71e490-4131-447b-808b-a13aa0490ab0");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_Lake";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 16 || zoom > 17)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLlake, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLlake = 
+            "https://cyberjapandata.gsi.go.jp/xyz/lake1/{0}/{1}/{2}.png";
+    }
+}

--- a/ExtLibs/Maps/Japan_Relief.cs
+++ b/ExtLibs/Maps/Japan_Relief.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan Relief
+    /// </summary>
+    public class Japan_Relief : GMapProvider
+    {
+        public static readonly Japan_Relief Instance;
+
+        Japan_Relief ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_Relief()
+        {
+            Instance = new Japan_Relief();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("298f1ed6-113a-4073-9840-2c65d5ba905f");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_Relief";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 5 || zoom > 15)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLrelief, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLrelief = 
+            "https://cyberjapandata.gsi.go.jp/xyz/relief/{0}/{1}/{2}.png";
+    }
+}

--- a/ExtLibs/Maps/Japan_Sea.cs
+++ b/ExtLibs/Maps/Japan_Sea.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan Sea
+    /// </summary>
+    public class Japan_Sea : GMapProvider
+    {
+        public static readonly Japan_Sea Instance;
+
+        Japan_Sea ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_Sea()
+        {
+            Instance = new Japan_Sea();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("7a3a64d0-98f7-42d3-b7ee-31fac87b4c6c");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_Sea";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 14 || zoom > 16)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLccm, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLccm = 
+            "https://cyberjapandata.gsi.go.jp/xyz/ccm1/{0}/{1}/{2}.png";
+    }
+}

--- a/ExtLibs/Maps/Japan_Slopezone.cs
+++ b/ExtLibs/Maps/Japan_Slopezone.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Maps
+{
+    using System;
+    using GMap.NET.Projections;
+    using System.Globalization;
+    using GMap.NET.MapProviders;
+    using GMap.NET;
+    using System.Reflection;
+
+    /// <summary>
+    /// Japan Slopezone
+    /// </summary>
+    public class Japan_Slopezone : GMapProvider
+    {
+        public static readonly Japan_Slopezone Instance;
+
+        Japan_Slopezone ()
+        {
+            MaxZoom = 22;
+            MinZoom = 2;
+            Copyright = string.Format("©Geospatial Information Authority of Japan.", DateTime.Today.Year);
+        }
+
+        static Japan_Slopezone()
+        {
+            Instance = new Japan_Slopezone();
+
+            Type mytype = typeof (GMapProviders);
+            FieldInfo field = mytype.GetField("DbHash", BindingFlags.Static | BindingFlags.NonPublic);
+            Dictionary<int, GMapProvider> list = (Dictionary<int, GMapProvider>) field.GetValue(Instance);
+
+            list.Add(Instance.DbId, Instance);
+        }
+
+        #region GMapProvider Members
+
+        readonly Guid id = new Guid("c673ef56-1aee-4d69-9792-fa207783bfee");
+
+        public override Guid Id
+        {
+            get { return id; }
+        }
+
+        readonly string name = "Japan_Slopezone";
+
+        public override string Name
+        {
+            get { return name; }
+        }
+
+        GMapProvider[] overlays;
+
+        public override GMapProvider[] Overlays
+        {
+            get
+            {
+                if (overlays == null)
+                {
+                    overlays = new GMapProvider[] {this};
+                }
+                return overlays;
+            }
+        }
+
+        public override PureProjection Projection
+        {
+            get { return MercatorProjection.Instance; }
+        }
+
+        public override PureImage GetTileImage(GPoint pos, int zoom)
+        {
+            string url = MakeTileImageUrl(pos, zoom, LanguageStr);
+
+            return GetTileImageUsingHttp(url);
+        }
+
+        #endregion
+
+        string MakeTileImageUrl(GPoint pos, int zoom, string language)
+        {
+            string ret;
+
+            if (zoom < 3 || zoom > 15)
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLstd, zoom, pos.X, pos.Y);
+            }
+            else
+            {
+                ret = string.Format(CultureInfo.InvariantCulture, CustomURLslopezone, zoom, pos.X, pos.Y);
+            }
+
+            return ret;
+        }
+        public readonly string CustomURLstd = 
+            "https://cyberjapandata.gsi.go.jp/xyz/std/{0}/{1}/{2}.png";
+            
+        public readonly string CustomURLslopezone = 
+            "https://cyberjapandata.gsi.go.jp/xyz/slopezone1map/{0}/{1}/{2}.png";
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -166,6 +166,16 @@ namespace MissionPlanner
             GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Eniro_Topo.Instance);
             GMap.NET.MapProviders.GMapProviders.List.Add(Maps.MapBox.Instance);
             GMap.NET.MapProviders.GMapProviders.List.Add(Maps.MapboxNoFly.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_Lake.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_1974.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_1979.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_1984.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_1988.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_Relief.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_Slopezone.Instance);
+            GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_Sea.Instance);
+
             // optionally add gdal support
             if (Directory.Exists(Application.StartupPath + Path.DirectorySeparatorChar + "gdal"))
                 GMap.NET.MapProviders.GMapProviders.List.Add(GDAL.GDALProvider.Instance);
@@ -208,7 +218,7 @@ namespace MissionPlanner
             Device.DeviceStructure test5 = new Device.DeviceStructure(466441);
             Device.DeviceStructure test6 = new Device.DeviceStructure(131874);
             Device.DeviceStructure test7 = new Device.DeviceStructure(263178);
-            // 
+            //
             Device.DeviceStructure test8 = new Device.DeviceStructure(1442082);
             Device.DeviceStructure test9 = new Device.DeviceStructure(1114914);
             Device.DeviceStructure test10 = new Device.DeviceStructure(1442826);
@@ -334,7 +344,7 @@ namespace MissionPlanner
             }
             catch
             {
-                
+
             }
 
             try
@@ -520,7 +530,7 @@ namespace MissionPlanner
                     {
                     }
 
-                    // Create a request using a URL that can receive a post. 
+                    // Create a request using a URL that can receive a post.
                     WebRequest request = WebRequest.Create("http://vps.oborne.me/mail.php");
                     request.Timeout = 10000; // 10 sec
                     // Set the Method property of the request to POST.


### PR DESCRIPTION
The comment of #1964  was reflected.
Japan uses old roads. The latest satellite image hides in trees. Old images are useful.
· Japan: Contour map of Japan
· Japan_1974: Japan satellite image
· Japan_1979: Japan satellite image
· Japan_ 1984: Japan satellite image
· Japan_ 1988: Japan satellite image
· Japan_Lake: Japan's Lake Map
· Japan_Relief: color altitude map in Japan
· Japan_Sea: Chart of Japan
· Japan_Slopezone: Japan's slope map