### PR TITLE
Fix plane basic tuning throttle slewrate field DE

### DIFF
--- a/GCSViews/ConfigurationView/ConfigArduplane.de-DE.resx
+++ b/GCSViews/ConfigurationView/ConfigArduplane.de-DE.resx
@@ -148,7 +148,7 @@
     <value>Servo Pitch PID</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
-    <value>FS Werte</value>
+    <value>Anstiegsrate %/s</value>
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
     <value>Navigationswinkel</value>


### PR DESCRIPTION
this is erroneously translated as "FS Werte" (=failsafe value), while it does set throttle slewrate (=Anstiegsrate)