### PR TITLE
MoterTest: add SURFACE_BOAT to if statement

### DIFF
--- a/GCSViews/ConfigurationView/ConfigMotorTest.cs
+++ b/GCSViews/ConfigurationView/ConfigMotorTest.cs
@@ -86,7 +86,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             var motormax = 8;
 
-            if (MainV2.comPort.MAV.aptype == MAVLink.MAV_TYPE.GROUND_ROVER)
+            if (MainV2.comPort.MAV.aptype == MAVLink.MAV_TYPE.GROUND_ROVER || MainV2.comPort.MAV.aptype == MAVLink.MAV_TYPE.SURFACE_BOAT)
             {
                 return 4;
             }


### PR DESCRIPTION
When FRAME_CLASS = 2 is set, the MotorTest screen is disabled. The screen is displayed. But you can not operate it. I think that the motor test should be valid even when FRAME_CLASS = 2 (boat).