### PR TITLE
Frame shape Icon can be selected.

### DIFF
--- a/ExtLibs/Maps/GMapMarkerBoat.cs
+++ b/ExtLibs/Maps/GMapMarkerBoat.cs
@@ -8,11 +8,8 @@ using SvgNet.SvgGdi;
 namespace MissionPlanner.Maps
 {
     [Serializable]
-    public class GMapMarkerBoat : GMapMarker
+    public class GMapMarkerBoat : GMapMarker_IconSelectable
     {
-        static readonly System.Drawing.Size SizeSt =
-            new System.Drawing.Size(global::MissionPlanner.Maps.Resources.boat.Width,
-                global::MissionPlanner.Maps.Resources.boat.Height);
 
         float heading = 0;
         float cog = -1;
@@ -26,7 +23,7 @@ namespace MissionPlanner.Maps
             this.cog = cog;
             this.target = target;
             this.nav_bearing = nav_bearing;
-            Size = SizeSt;
+            Size = FrameIcon().Size;
         }
 
         public override void OnRender(IGraphics g)
@@ -61,11 +58,20 @@ namespace MissionPlanner.Maps
             catch
             {
             }
-            g.DrawImageUnscaled(global::MissionPlanner.Maps.Resources.boat,
-                global::MissionPlanner.Maps.Resources.boat.Width / -2,
-                global::MissionPlanner.Maps.Resources.boat.Height / -2);
+            Bitmap icon = FrameIcon();
+            g.DrawImage(icon, icon.Width / -2, icon.Height / -2, icon.Width, icon.Height);
 
             g.Transform = temp;
+        }
+
+        /// <summary>
+        /// Defile default icon of Boat.
+        /// </summary>
+        /// <param name="icon_index">Not used in Boat.</param>
+        /// <returns>default icon of Boat.</returns>
+        protected override Bitmap DefaultIcon(int icon_index)
+        {
+            return global::MissionPlanner.Maps.Resources.boat;
         }
     }
 }

--- a/ExtLibs/Maps/GMapMarkerHeli.cs
+++ b/ExtLibs/Maps/GMapMarkerHeli.cs
@@ -8,9 +8,9 @@ using SvgNet.SvgGdi;
 namespace MissionPlanner.Maps
 {
     [Serializable]
-    public class GMapMarkerHeli : GMapMarker
+    public class GMapMarkerHeli : GMapMarker_IconSelectable
     {
-        private readonly Bitmap icon = global::MissionPlanner.Maps.Resources.heli;
+        private Bitmap icon;
 
         float heading = 0;
         float cog = -1;
@@ -22,6 +22,7 @@ namespace MissionPlanner.Maps
             this.heading = heading;
             this.cog = cog;
             this.target = target;
+            icon = FrameIcon();// global::MissionPlanner.Maps.Resources.heli;
             Size = icon.Size;
         }
 
@@ -53,9 +54,19 @@ namespace MissionPlanner.Maps
             catch
             {
             }
-            g.DrawImageUnscaled(icon, icon.Width/-2 + 2, icon.Height/-2);
+            g.DrawImage(icon, icon.Width/-2 + 2, icon.Height/-2, icon.Width, icon.Height );
 
             g.Transform = temp;
+        }
+
+        /// <summary>
+        /// Defile default icon of Heli.
+        /// </summary>
+        /// <param name="icon_index">Not used in Heli.</param>
+        /// <returns>default icon of Heli.</returns>
+        protected override Bitmap DefaultIcon(int icon_index)
+        {
+            return global::MissionPlanner.Maps.Resources.heli;
         }
     }
 }

--- a/ExtLibs/Maps/GMapMarkerPlane.cs
+++ b/ExtLibs/Maps/GMapMarkerPlane.cs
@@ -8,17 +8,8 @@ using SvgNet.SvgGdi;
 namespace MissionPlanner.Maps
 {
     [Serializable]
-    public class GMapMarkerPlane : GMapMarker
+    public class GMapMarkerPlane : GMapMarker_IconSelectable
     {
-        private readonly Bitmap icon = global::MissionPlanner.Maps.Resources.planeicon;
-
-        private readonly Bitmap icon1 = global::MissionPlanner.Maps.Resources.planeicon1;
-        private readonly Bitmap icon2 = global::MissionPlanner.Maps.Resources.planeicon2;
-        private readonly Bitmap icon3 = global::MissionPlanner.Maps.Resources.planeicon3;
-        private readonly Bitmap icon4 = global::MissionPlanner.Maps.Resources.planeicon4;
-        private readonly Bitmap icon5 = global::MissionPlanner.Maps.Resources.planeicon5;
-        private readonly Bitmap icon6 = global::MissionPlanner.Maps.Resources.planeicon6;
-
         float heading = 0;
         float cog = -1;
         float target = -1;
@@ -35,7 +26,7 @@ namespace MissionPlanner.Maps
             this.nav_bearing = nav_bearing;
             this.radius = radius;
             this.which = which;
-            Size = icon.Size;
+            Size = FrameIcon().Size;
         }
 
         public override void OnRender(IGraphics g)
@@ -108,25 +99,41 @@ namespace MissionPlanner.Maps
             catch
             {
             }
-            // 'which' variable simply selects different coloured plane icon/s from the resource library
-            if (which == 0)
-                g.DrawImageUnscaled(icon, icon.Width / -2, icon.Height / -2);
-            if (which == 1)
-                g.DrawImageUnscaled(icon1, icon1.Width / -2, icon1.Height / -2);
-            if (which == 2)
-                g.DrawImageUnscaled(icon2, icon2.Width / -2, icon2.Height / -2);
-            if (which == 3)
-                g.DrawImageUnscaled(icon3, icon3.Width / -2, icon3.Height / -2);
-            if (which == 4)
-                g.DrawImageUnscaled(icon4, icon4.Width / -2, icon4.Height / -2);
-            if (which == 5)
-                g.DrawImageUnscaled(icon5, icon5.Width / -2, icon5.Height / -2);
-            if (which == 6)
-                g.DrawImageUnscaled(icon6, icon6.Width / -2, icon6.Height / -2);
 
-            
+            Bitmap icon = FrameIcon(which);
+            g.DrawImage(icon, icon.Width / -2, icon.Height / -2, icon.Width, icon.Height );
 
             g.Transform = temp;
+        }
+
+
+        /// <summary>
+        /// Defile default icon of Plane.
+        /// </summary>
+        /// <param name="icon_index">Not used in Plane.</param>
+        /// <returns>default icon of Plane.</returns>
+        protected override Bitmap DefaultIcon(int icon_index)
+        {
+            switch (icon_index)
+            {
+                case 0:
+                    return global::MissionPlanner.Maps.Resources.planeicon;
+                case 1:
+                    return global::MissionPlanner.Maps.Resources.planeicon1;
+                case 2:
+                    return global::MissionPlanner.Maps.Resources.planeicon2;
+                case 3:
+                    return global::MissionPlanner.Maps.Resources.planeicon3;
+                case 4:
+                    return global::MissionPlanner.Maps.Resources.planeicon4;
+                case 5:
+                    return global::MissionPlanner.Maps.Resources.planeicon5;
+                case 6:
+                    return global::MissionPlanner.Maps.Resources.planeicon6;
+                default:
+                    return global::MissionPlanner.Maps.Resources.planeicon;
+            }
+
         }
     }
 }

--- a/ExtLibs/Maps/GMapMarkerQuad.cs
+++ b/ExtLibs/Maps/GMapMarkerQuad.cs
@@ -8,9 +8,10 @@ using SvgNet.SvgGdi;
 namespace MissionPlanner.Maps
 {
     [Serializable]
-    public class GMapMarkerQuad : GMapMarker
+    public class GMapMarkerQuad : GMapMarker_IconSelectable
     {
-        private readonly Bitmap icon = global::MissionPlanner.Maps.Resources.quadicon;
+        //private readonly Bitmap icon = global::MissionPlanner.Maps.Resources.quadicon;
+        private Bitmap icon = null;
 
         float heading = 0;
         float cog = -1;
@@ -27,8 +28,11 @@ namespace MissionPlanner.Maps
             this.cog = cog;
             this.target = target;
             this.sysid = sysid;
+
+            icon = FrameIcon();
             Size = icon.Size;
         }
+
 
         public override void OnRender(IGraphics g)
         {
@@ -59,10 +63,10 @@ namespace MissionPlanner.Maps
             {
             }
 
-            g.DrawImageUnscaled(icon, icon.Width/-2 + 2, icon.Height/-2);
+          //g.DrawImageUnscaled(icon, icon.Width / -2 + 2, icon.Height / -2);
+            g.DrawImage(icon, icon.Width / -2, icon.Height / -2, icon.Width, icon.Height );
 
-            g.DrawString(sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), Brushes.Red, -8,
-                -8);
+            g.DrawString(sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), Brushes.Red, -8, -8);
 
             g.Transform = temp;
 
@@ -91,6 +95,16 @@ namespace MissionPlanner.Maps
                             (int)Math.Abs(loc.X - LocalPosition.X), (int)Math.Abs(loc.X - LocalPosition.X)), 0, 360);   
 
             }
+        }
+
+        /// <summary>
+        /// Defile default icon of QuadCopter.
+        /// </summary>
+        /// <param name="icon_index">Not used in Quad Copter.</param>
+        /// <returns>default icon of QuadCopter.</returns>
+        protected override Bitmap DefaultIcon(int icon_index)
+        {
+            return global::MissionPlanner.Maps.Resources.quadicon;
         }
     }
 }

--- a/ExtLibs/Maps/GMapMarkerRover.cs
+++ b/ExtLibs/Maps/GMapMarkerRover.cs
@@ -8,11 +8,8 @@ using SvgNet.SvgGdi;
 namespace MissionPlanner.Maps
 {
     [Serializable]
-    public class GMapMarkerRover : GMapMarker
+    public class GMapMarkerRover : GMapMarker_IconSelectable
     {
-        static readonly System.Drawing.Size SizeSt =
-            new System.Drawing.Size(global::MissionPlanner.Maps.Resources.rover.Width,
-                global::MissionPlanner.Maps.Resources.rover.Height);
 
         float heading = 0;
         float cog = -1;
@@ -26,7 +23,17 @@ namespace MissionPlanner.Maps
             this.cog = cog;
             this.target = target;
             this.nav_bearing = nav_bearing;
-            Size = SizeSt;
+            Size = FrameIcon().Size;
+        }
+
+        /// <summary>
+        /// Defile default icon of Rover.
+        /// </summary>
+        /// <param name="icon_index">Not used in Rover.</param>
+        /// <returns>default icon of Rover.</returns>
+        protected override Bitmap DefaultIcon(int icon_index)
+        {
+            return global::MissionPlanner.Maps.Resources.rover;
         }
 
         public override void OnRender(IGraphics g)
@@ -61,9 +68,8 @@ namespace MissionPlanner.Maps
             catch
             {
             }
-            g.DrawImageUnscaled(global::MissionPlanner.Maps.Resources.rover,
-                global::MissionPlanner.Maps.Resources.rover.Width/-2,
-                global::MissionPlanner.Maps.Resources.rover.Height/-2);
+            Bitmap icon = FrameIcon();
+            g.DrawImage(icon, icon.Width / -2, icon.Height / -2, icon.Width, icon.Height);
 
             g.Transform = temp;
         }

--- a/ExtLibs/Maps/GMapMarkerSingle.cs
+++ b/ExtLibs/Maps/GMapMarkerSingle.cs
@@ -8,9 +8,9 @@ using SvgNet.SvgGdi;
 namespace MissionPlanner.Maps
 {
     [Serializable]
-    public class GMapMarkerSingle : GMapMarker
+    public class GMapMarkerSingle : GMapMarker_IconSelectable
     {
-        private readonly Bitmap icon = global::MissionPlanner.Maps.Resources.redsinglecopter2;
+        private readonly Bitmap icon;
 
         float heading = 0;
         float cog = -1;
@@ -24,6 +24,7 @@ namespace MissionPlanner.Maps
             this.cog = cog;
             this.target = target;
             this.sysid = sysid;
+            icon = FrameIcon();
             Size = icon.Size;
         }
 
@@ -62,6 +63,17 @@ namespace MissionPlanner.Maps
                 -8);
 
             g.Transform = temp;
+        }
+
+
+        /// <summary>
+        /// Defile default icon of Single(Coaxial).
+        /// </summary>
+        /// <param name="icon_index">Not used in Single(Coaxial).</param>
+        /// <returns>default icon of Single(Coaxial).</returns>
+        protected override Bitmap DefaultIcon(int icon_index)
+        {
+            return global::MissionPlanner.Maps.Resources.redsinglecopter2;
         }
     }
 }

--- a/ExtLibs/Maps/GMapMarker_IconSelectable.cs
+++ b/ExtLibs/Maps/GMapMarker_IconSelectable.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Drawing;
+using GMap.NET;
+using GMap.NET.WindowsForms;
+using MissionPlanner.Utilities;
+using SvgNet.SvgGdi;
+
+namespace MissionPlanner.Maps
+{
+    [Serializable]
+    public abstract class GMapMarker_IconSelectable : GMapMarker
+    {
+
+        private static System.Collections.Generic.List<Bitmap> _frame_icon_list = new System.Collections.Generic.List<Bitmap>();
+        private static String _frame_icon_list_str = "";
+
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public GMapMarker_IconSelectable(PointLatLng p)
+            : base(p)
+        {
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="icon_index">index of icon. usage will define by child class.</param>
+        /// <returns>Icon bitmap</returns>
+        public System.Drawing.Bitmap FrameIcon(int icon_index = 0 )
+        {
+            Bitmap icon = null;
+
+            // Check whether the setting has been changed.
+            if (_frame_icon_list_str != Settings.Instance.FrameShapeFiles)
+            {
+                Load_Icon_List(Settings.Instance.FrameShapeFiles);
+                _frame_icon_list_str = Settings.Instance.FrameShapeFiles;
+
+            }
+
+            if (0 <= icon_index && icon_index < _frame_icon_list.Count)
+                icon = _frame_icon_list[icon_index];
+
+            return icon ?? DefaultIcon(icon_index);
+        }
+
+
+        /// <summary>
+        /// return default icon when use didn't set icon file.
+        /// please override this method in child class for set to default frame icon.
+        /// </summary>
+        /// <param name="icon_index">index of icon. usage will define by child class.</param>
+        /// <returns>Icon bitmap</returns>
+        protected abstract Bitmap DefaultIcon(int icon_index);
+
+
+        /// <summary>
+        /// Load icon list from file.
+        /// </summary>
+        /// <param name="icon_list_str">selected filename list( separated by ';')</param>
+        private static void Load_Icon_List(string icon_list_str)
+        {
+            // clear old icon list
+            if (_frame_icon_list != null)
+            {
+                foreach (Bitmap bmp in _frame_icon_list)
+                {
+                    if (bmp != null) bmp.Dispose();
+                }
+                _frame_icon_list.Clear();
+            }
+
+            //
+            // Load new bitmaps
+            String[] strs = icon_list_str.Split(';');
+            _frame_icon_list.Capacity = strs.Length;
+            foreach (String fn in strs)
+            {
+                System.Drawing.Bitmap bmp = null;
+                try
+                {
+                    bmp = (System.Drawing.Bitmap)System.Drawing.Image.FromFile(fn);
+                }
+                catch
+                {
+                    bmp = null;
+                }
+                _frame_icon_list.Add(bmp);
+            }
+        }
+
+
+    }
+}

--- a/ExtLibs/ProjNet/CoordinateSystems/Ellipsoid.cs
+++ b/ExtLibs/ProjNet/CoordinateSystems/Ellipsoid.cs
@@ -1,4 +1,4 @@
-// Copyright 2005 - 2009 - Morten Nielsen (www.sharpgis.net)
+ï»¿// Copyright 2005 - 2009 - Morten Nielsen (www.sharpgis.net)
 //
 // This file is part of ProjNet.
 // ProjNet is free software; you can redistribute it and/or modify
@@ -142,7 +142,7 @@ namespace ProjNet.CoordinateSystems
 			get
 			{
 				return new Ellipsoid(20926202, 0, 297, true, LinearUnit.ClarkesFoot, "Clarke 1880", "EPSG", 7034, "Clarke 1880", String.Empty,
-					"Clarke gave a and b and also 1/f=293.465 (to 3 decimal places).  1/f derived from a and b = 293.4663077…");
+					"Clarke gave a and b and also 1/f=293.465 (to 3 decimal places).  1/f derived from a and b = 293.4663077.");
 			}
 		}
 

--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -110,6 +110,26 @@ namespace MissionPlanner.Utilities
             }
         }
 
+
+       public string FrameShapeFiles
+       {
+            get
+            {
+                string fname = this["frameshapefile"];
+                if (string.IsNullOrEmpty(fname))
+                {
+                    fname = "";
+                }
+                return fname;
+            }
+            set
+            {
+                this["frameshapefile"] = value;
+            }
+       }
+
+
+
         public int Count { get { return config.Count; } }
 
         public static string GetDefaultLogDir()

--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConfigPlanner));
             this.label33 = new System.Windows.Forms.Label();
             this.CMB_ratesensors = new System.Windows.Forms.ComboBox();
@@ -102,6 +103,10 @@
             this.chk_shownofly = new System.Windows.Forms.CheckBox();
             this.label6 = new System.Windows.Forms.Label();
             this.CMB_altunits = new System.Windows.Forms.ComboBox();
+            this.imageList1 = new System.Windows.Forms.ImageList(this.components);
+            this.LabelFrameShape = new System.Windows.Forms.Label();
+            this.txt_frame_shape_file = new System.Windows.Forms.TextBox();
+            this.BUT_frameshapebrowse = new MissionPlanner.Controls.MyButton();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).BeginInit();
             this.SuspendLayout();
             // 
@@ -679,6 +684,29 @@
             this.CMB_altunits.Name = "CMB_altunits";
             this.CMB_altunits.SelectedIndexChanged += new System.EventHandler(this.CMB_altunits_SelectedIndexChanged);
             // 
+            // imageList1
+            // 
+            this.imageList1.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
+            resources.ApplyResources(this.imageList1, "imageList1");
+            this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
+            // 
+            // LabelFrameShape
+            // 
+            resources.ApplyResources(this.LabelFrameShape, "LabelFrameShape");
+            this.LabelFrameShape.Name = "LabelFrameShape";
+            // 
+            // txt_frame_shape_file
+            // 
+            resources.ApplyResources(this.txt_frame_shape_file, "txt_frame_shape_file");
+            this.txt_frame_shape_file.Name = "txt_frame_shape_file";
+            // 
+            // BUT_frameshapebrowse
+            // 
+            resources.ApplyResources(this.BUT_frameshapebrowse, "BUT_frameshapebrowse");
+            this.BUT_frameshapebrowse.Name = "BUT_frameshapebrowse";
+            this.BUT_frameshapebrowse.UseVisualStyleBackColor = true;
+            this.BUT_frameshapebrowse.Click += new System.EventHandler(this.BUT_frameshapebrowse_Click);
+            // 
             // ConfigPlanner
             // 
             this.Controls.Add(this.label6);
@@ -702,7 +730,10 @@
             this.Controls.Add(this.BUT_themecustom);
             this.Controls.Add(this.CMB_theme);
             this.Controls.Add(this.label4);
+            this.Controls.Add(this.BUT_frameshapebrowse);
             this.Controls.Add(this.BUT_logdirbrowse);
+            this.Controls.Add(this.txt_frame_shape_file);
+            this.Controls.Add(this.LabelFrameShape);
             this.Controls.Add(this.txt_log_dir);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label2);
@@ -838,5 +869,9 @@
         private System.Windows.Forms.CheckBox chk_shownofly;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.ComboBox CMB_altunits;
+        private System.Windows.Forms.ImageList imageList1;
+        private System.Windows.Forms.Label LabelFrameShape;
+        private System.Windows.Forms.TextBox txt_frame_shape_file;
+        private Controls.MyButton BUT_frameshapebrowse;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -28,6 +28,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             txt_log_dir.TextChanged += OnLogDirTextChanged;
 
+            txt_frame_shape_file.TextChanged += OnFrameShapeFileTextChanged;
+
         }
 
 
@@ -185,6 +187,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
 
             txt_log_dir.Text = Settings.Instance.LogDir;
+            txt_frame_shape_file.Text = Settings.Instance.FrameShapeFiles;
 
             startup = false;
         }
@@ -940,6 +943,40 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 return;
             Settings.Instance["altunits"] = CMB_altunits.Text;
             MainV2.instance.ChangeUnits();
+        }
+
+
+        private void BUT_frameshapebrowse_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog fd = new OpenFileDialog())
+            {
+                fd.AddExtension = true;
+                fd.Filter = "Image Files (PNG,BMP,JPEG)|*.png;*.bmp;*.jpg";
+                try
+                {
+                    fd.InitialDirectory = System.IO.Path.GetDirectoryName(Settings.Instance.FrameShapeFiles.Split(';')[0]);
+                }
+                catch { }
+                fd.DefaultExt = ".png";
+                fd.Multiselect = true;
+                if (fd.ShowDialog() == DialogResult.OK)
+                {
+                    String tmp = "";
+                    for ( int i = 0; i < fd.FileNames.Length; i++ )
+                    {
+                        if (i > 0) tmp += ";";
+                        tmp += fd.FileNames[i];
+                    }
+
+                    txt_frame_shape_file.Text = tmp;
+                }
+            }
+        }
+
+
+        private void OnFrameShapeFileTextChanged(object sender, EventArgs e)
+        {
+            Settings.Instance.FrameShapeFiles = txt_frame_shape_file.Text;
         }
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>31</value>
   </data>
   <data name="CMB_ratesensors.Items" xml:space="preserve">
     <value>-1</value>
@@ -190,7 +190,7 @@
     <value>545, 224</value>
   </data>
   <data name="CMB_ratesensors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
+    <value>40, 20</value>
   </data>
   <data name="CMB_ratesensors.TabIndex" type="System.Int32, mscorlib">
     <value>88</value>
@@ -205,7 +205,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_ratesensors.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>32</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -217,7 +217,7 @@
     <value>9, 38</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
+    <value>74, 12</value>
   </data>
   <data name="label26.TabIndex" type="System.Int32, mscorlib">
     <value>86</value>
@@ -235,13 +235,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>30</value>
+    <value>33</value>
   </data>
   <data name="CMB_videoresolutions.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 35</value>
   </data>
   <data name="CMB_videoresolutions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>408, 21</value>
+    <value>408, 20</value>
   </data>
   <data name="CMB_videoresolutions.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -256,7 +256,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_videoresolutions.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>34</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -268,7 +268,7 @@
     <value>9, 323</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
+    <value>29, 12</value>
   </data>
   <data name="label12.TabIndex" type="System.Int32, mscorlib">
     <value>84</value>
@@ -286,7 +286,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>35</value>
   </data>
   <data name="CHK_GDIPlus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -313,7 +313,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_GDIPlus.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>36</value>
   </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -325,7 +325,7 @@
     <value>9, 300</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
+    <value>57, 12</value>
   </data>
   <data name="label24.TabIndex" type="System.Int32, mscorlib">
     <value>82</value>
@@ -343,7 +343,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>37</value>
   </data>
   <data name="CHK_loadwponconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -370,7 +370,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_loadwponconnect.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>38</value>
   </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -382,7 +382,7 @@
     <value>9, 274</value>
   </data>
   <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
+    <value>72, 12</value>
   </data>
   <data name="label23.TabIndex" type="System.Int32, mscorlib">
     <value>81</value>
@@ -400,13 +400,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>36</value>
+    <value>39</value>
   </data>
   <data name="NUM_tracklength.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 273</value>
   </data>
   <data name="NUM_tracklength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 20</value>
+    <value>67, 19</value>
   </data>
   <data name="NUM_tracklength.TabIndex" type="System.Int32, mscorlib">
     <value>80</value>
@@ -421,7 +421,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;NUM_tracklength.ZOrder" xml:space="preserve">
-    <value>37</value>
+    <value>40</value>
   </data>
   <data name="CHK_speechaltwarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -433,7 +433,7 @@
     <value>515, 89</value>
   </data>
   <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
+    <value>83, 16</value>
   </data>
   <data name="CHK_speechaltwarning.TabIndex" type="System.Int32, mscorlib">
     <value>79</value>
@@ -454,7 +454,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechaltwarning.ZOrder" xml:space="preserve">
-    <value>38</value>
+    <value>41</value>
   </data>
   <data name="label108.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -466,7 +466,7 @@
     <value>9, 251</value>
   </data>
   <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 13</value>
+    <value>81, 12</value>
   </data>
   <data name="label108.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -484,7 +484,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label108.ZOrder" xml:space="preserve">
-    <value>39</value>
+    <value>42</value>
   </data>
   <data name="CHK_resetapmonconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -511,7 +511,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_resetapmonconnect.ZOrder" xml:space="preserve">
-    <value>40</value>
+    <value>43</value>
   </data>
   <data name="CHK_mavdebug.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -520,7 +520,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 509</value>
+    <value>107, 523</value>
   </data>
   <data name="CHK_mavdebug.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 17</value>
@@ -541,7 +541,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_mavdebug.ZOrder" xml:space="preserve">
-    <value>41</value>
+    <value>44</value>
   </data>
   <data name="label107.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -568,7 +568,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label107.ZOrder" xml:space="preserve">
-    <value>42</value>
+    <value>45</value>
   </data>
   <data name="CMB_raterc.Items" xml:space="preserve">
     <value>-1</value>
@@ -610,7 +610,7 @@
     <value>450, 224</value>
   </data>
   <data name="CMB_raterc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
+    <value>40, 20</value>
   </data>
   <data name="CMB_raterc.TabIndex" type="System.Int32, mscorlib">
     <value>49</value>
@@ -625,7 +625,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_raterc.ZOrder" xml:space="preserve">
-    <value>43</value>
+    <value>46</value>
   </data>
   <data name="label104.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -652,7 +652,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label104.ZOrder" xml:space="preserve">
-    <value>44</value>
+    <value>47</value>
   </data>
   <data name="label103.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -679,7 +679,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label103.ZOrder" xml:space="preserve">
-    <value>45</value>
+    <value>48</value>
   </data>
   <data name="label102.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -706,7 +706,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label102.ZOrder" xml:space="preserve">
-    <value>46</value>
+    <value>49</value>
   </data>
   <data name="label101.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -718,7 +718,7 @@
     <value>9, 227</value>
   </data>
   <data name="label101.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 13</value>
+    <value>90, 12</value>
   </data>
   <data name="label101.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -736,7 +736,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label101.ZOrder" xml:space="preserve">
-    <value>47</value>
+    <value>50</value>
   </data>
   <data name="CMB_ratestatus.Items" xml:space="preserve">
     <value>-1</value>
@@ -778,7 +778,7 @@
     <value>376, 224</value>
   </data>
   <data name="CMB_ratestatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
+    <value>40, 20</value>
   </data>
   <data name="CMB_ratestatus.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
@@ -793,7 +793,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_ratestatus.ZOrder" xml:space="preserve">
-    <value>48</value>
+    <value>51</value>
   </data>
   <data name="CMB_rateposition.Items" xml:space="preserve">
     <value>-1</value>
@@ -835,7 +835,7 @@
     <value>255, 224</value>
   </data>
   <data name="CMB_rateposition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
+    <value>40, 20</value>
   </data>
   <data name="CMB_rateposition.TabIndex" type="System.Int32, mscorlib">
     <value>55</value>
@@ -850,7 +850,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_rateposition.ZOrder" xml:space="preserve">
-    <value>49</value>
+    <value>52</value>
   </data>
   <data name="CMB_rateattitude.Items" xml:space="preserve">
     <value>-1</value>
@@ -892,7 +892,7 @@
     <value>153, 224</value>
   </data>
   <data name="CMB_rateattitude.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
+    <value>40, 20</value>
   </data>
   <data name="CMB_rateattitude.TabIndex" type="System.Int32, mscorlib">
     <value>56</value>
@@ -907,7 +907,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_rateattitude.ZOrder" xml:space="preserve">
-    <value>50</value>
+    <value>53</value>
   </data>
   <data name="label99.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -935,7 +935,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label99.ZOrder" xml:space="preserve">
-    <value>51</value>
+    <value>54</value>
   </data>
   <data name="label98.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -947,7 +947,7 @@
     <value>9, 198</value>
   </data>
   <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
+    <value>67, 12</value>
   </data>
   <data name="label98.TabIndex" type="System.Int32, mscorlib">
     <value>58</value>
@@ -965,7 +965,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label98.ZOrder" xml:space="preserve">
-    <value>52</value>
+    <value>55</value>
   </data>
   <data name="label97.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -977,7 +977,7 @@
     <value>9, 171</value>
   </data>
   <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>57, 12</value>
   </data>
   <data name="label97.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
@@ -995,13 +995,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label97.ZOrder" xml:space="preserve">
-    <value>53</value>
+    <value>56</value>
   </data>
   <data name="CMB_speedunits.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 195</value>
   </data>
   <data name="CMB_speedunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_speedunits.TabIndex" type="System.Int32, mscorlib">
     <value>60</value>
@@ -1016,13 +1016,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_speedunits.ZOrder" xml:space="preserve">
-    <value>54</value>
+    <value>57</value>
   </data>
   <data name="CMB_distunits.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 168</value>
   </data>
   <data name="CMB_distunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_distunits.TabIndex" type="System.Int32, mscorlib">
     <value>61</value>
@@ -1037,7 +1037,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_distunits.ZOrder" xml:space="preserve">
-    <value>55</value>
+    <value>58</value>
   </data>
   <data name="label96.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1049,7 +1049,7 @@
     <value>9, 144</value>
   </data>
   <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>49, 12</value>
   </data>
   <data name="label96.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -1067,7 +1067,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label96.ZOrder" xml:space="preserve">
-    <value>56</value>
+    <value>59</value>
   </data>
   <data name="label95.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1079,7 +1079,7 @@
     <value>9, 90</value>
   </data>
   <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>42, 12</value>
   </data>
   <data name="label95.TabIndex" type="System.Int32, mscorlib">
     <value>63</value>
@@ -1097,7 +1097,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label95.ZOrder" xml:space="preserve">
-    <value>57</value>
+    <value>60</value>
   </data>
   <data name="CHK_speechbattery.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1109,7 +1109,7 @@
     <value>412, 89</value>
   </data>
   <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 17</value>
+    <value>106, 16</value>
   </data>
   <data name="CHK_speechbattery.TabIndex" type="System.Int32, mscorlib">
     <value>64</value>
@@ -1130,7 +1130,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechbattery.ZOrder" xml:space="preserve">
-    <value>58</value>
+    <value>61</value>
   </data>
   <data name="CHK_speechcustom.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1142,7 +1142,7 @@
     <value>332, 89</value>
   </data>
   <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
+    <value>84, 16</value>
   </data>
   <data name="CHK_speechcustom.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -1163,7 +1163,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechcustom.ZOrder" xml:space="preserve">
-    <value>59</value>
+    <value>62</value>
   </data>
   <data name="CHK_speechmode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1175,7 +1175,7 @@
     <value>280, 89</value>
   </data>
   <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>55, 16</value>
   </data>
   <data name="CHK_speechmode.TabIndex" type="System.Int32, mscorlib">
     <value>66</value>
@@ -1196,7 +1196,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechmode.ZOrder" xml:space="preserve">
-    <value>60</value>
+    <value>63</value>
   </data>
   <data name="CHK_speechwaypoint.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1208,7 +1208,7 @@
     <value>207, 89</value>
   </data>
   <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 17</value>
+    <value>70, 16</value>
   </data>
   <data name="CHK_speechwaypoint.TabIndex" type="System.Int32, mscorlib">
     <value>67</value>
@@ -1229,7 +1229,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechwaypoint.ZOrder" xml:space="preserve">
-    <value>61</value>
+    <value>64</value>
   </data>
   <data name="label94.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1241,7 +1241,7 @@
     <value>9, 65</value>
   </data>
   <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="label94.TabIndex" type="System.Int32, mscorlib">
     <value>68</value>
@@ -1259,13 +1259,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label94.ZOrder" xml:space="preserve">
-    <value>62</value>
+    <value>65</value>
   </data>
   <data name="CMB_osdcolor.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 62</value>
   </data>
   <data name="CMB_osdcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_osdcolor.TabIndex" type="System.Int32, mscorlib">
     <value>69</value>
@@ -1280,13 +1280,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_osdcolor.ZOrder" xml:space="preserve">
-    <value>63</value>
+    <value>66</value>
   </data>
   <data name="CMB_language.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 112</value>
   </data>
   <data name="CMB_language.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_language.TabIndex" type="System.Int32, mscorlib">
     <value>70</value>
@@ -1301,7 +1301,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_language.ZOrder" xml:space="preserve">
-    <value>64</value>
+    <value>67</value>
   </data>
   <data name="label93.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1313,7 +1313,7 @@
     <value>9, 115</value>
   </data>
   <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
+    <value>68, 12</value>
   </data>
   <data name="label93.TabIndex" type="System.Int32, mscorlib">
     <value>71</value>
@@ -1331,7 +1331,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label93.ZOrder" xml:space="preserve">
-    <value>65</value>
+    <value>68</value>
   </data>
   <data name="CHK_enablespeech.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1343,7 +1343,7 @@
     <value>107, 89</value>
   </data>
   <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
+    <value>99, 16</value>
   </data>
   <data name="CHK_enablespeech.TabIndex" type="System.Int32, mscorlib">
     <value>72</value>
@@ -1361,7 +1361,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_enablespeech.ZOrder" xml:space="preserve">
-    <value>66</value>
+    <value>69</value>
   </data>
   <data name="CHK_hudshow.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1388,7 +1388,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_hudshow.ZOrder" xml:space="preserve">
-    <value>67</value>
+    <value>70</value>
   </data>
   <data name="label92.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1400,7 +1400,7 @@
     <value>9, 11</value>
   </data>
   <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
+    <value>73, 12</value>
   </data>
   <data name="label92.TabIndex" type="System.Int32, mscorlib">
     <value>74</value>
@@ -1418,13 +1418,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label92.ZOrder" xml:space="preserve">
-    <value>68</value>
+    <value>71</value>
   </data>
   <data name="CMB_videosources.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 8</value>
   </data>
   <data name="CMB_videosources.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 21</value>
+    <value>245, 20</value>
   </data>
   <data name="CMB_videosources.TabIndex" type="System.Int32, mscorlib">
     <value>75</value>
@@ -1439,7 +1439,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_videosources.ZOrder" xml:space="preserve">
-    <value>69</value>
+    <value>72</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1451,7 +1451,7 @@
     <value>9, 346</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
+    <value>63, 12</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>89</value>
@@ -1469,7 +1469,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>29</value>
   </data>
   <data name="CHK_maprotation.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1496,7 +1496,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_maprotation.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>30</value>
   </data>
   <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1523,7 +1523,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>27</value>
   </data>
   <data name="CHK_disttohomeflightdata.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1550,7 +1550,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_disttohomeflightdata.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>28</value>
   </data>
   <data name="BUT_Joystick.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1577,7 +1577,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_Joystick.ZOrder" xml:space="preserve">
-    <value>70</value>
+    <value>73</value>
   </data>
   <data name="BUT_videostop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1604,7 +1604,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_videostop.ZOrder" xml:space="preserve">
-    <value>71</value>
+    <value>74</value>
   </data>
   <data name="BUT_videostart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1631,7 +1631,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_videostart.ZOrder" xml:space="preserve">
-    <value>72</value>
+    <value>75</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1643,7 +1643,7 @@
     <value>9, 371</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
+    <value>50, 12</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>93</value>
@@ -1661,13 +1661,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>26</value>
   </data>
   <data name="txt_log_dir.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 368</value>
   </data>
   <data name="txt_log_dir.Size" type="System.Drawing.Size, System.Drawing">
-    <value>386, 20</value>
+    <value>386, 19</value>
   </data>
   <data name="txt_log_dir.TabIndex" type="System.Int32, mscorlib">
     <value>94</value>
@@ -1682,7 +1682,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txt_log_dir.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>25</value>
   </data>
   <data name="BUT_logdirbrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1709,7 +1709,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_logdirbrowse.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>22</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1721,7 +1721,7 @@
     <value>9, 397</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
+    <value>39, 12</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>96</value>
@@ -1745,7 +1745,7 @@
     <value>107, 394</value>
   </data>
   <data name="CMB_theme.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_theme.TabIndex" type="System.Int32, mscorlib">
     <value>97</value>
@@ -1799,7 +1799,7 @@
     <value>594, 89</value>
   </data>
   <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
+    <value>87, 16</value>
   </data>
   <data name="CHK_speecharmdisarm.TabIndex" type="System.Int32, mscorlib">
     <value>99</value>
@@ -1859,7 +1859,7 @@
     <value>107, 474</value>
   </data>
   <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 17</value>
+    <value>121, 16</value>
   </data>
   <data name="chk_analytics.TabIndex" type="System.Int32, mscorlib">
     <value>102</value>
@@ -1889,7 +1889,7 @@
     <value>228, 474</value>
   </data>
   <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
+    <value>94, 16</value>
   </data>
   <data name="CHK_beta.TabIndex" type="System.Int32, mscorlib">
     <value>103</value>
@@ -1919,7 +1919,7 @@
     <value>340, 451</value>
   </data>
   <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
+    <value>151, 16</value>
   </data>
   <data name="CHK_Password.TabIndex" type="System.Int32, mscorlib">
     <value>104</value>
@@ -1949,7 +1949,7 @@
     <value>671, 89</value>
   </data>
   <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
+    <value>79, 16</value>
   </data>
   <data name="CHK_speechlowspeed.TabIndex" type="System.Int32, mscorlib">
     <value>105</value>
@@ -1982,7 +1982,7 @@
     <value>496, 451</value>
   </data>
   <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
+    <value>96, 16</value>
   </data>
   <data name="CHK_showairports.TabIndex" type="System.Int32, mscorlib">
     <value>107</value>
@@ -2012,7 +2012,7 @@
     <value>598, 451</value>
   </data>
   <data name="chk_ADSB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
+    <value>55, 16</value>
   </data>
   <data name="chk_ADSB.TabIndex" type="System.Int32, mscorlib">
     <value>108</value>
@@ -2042,7 +2042,7 @@
     <value>496, 474</value>
   </data>
   <data name="chk_tfr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 17</value>
+    <value>54, 16</value>
   </data>
   <data name="chk_tfr.TabIndex" type="System.Int32, mscorlib">
     <value>109</value>
@@ -2069,7 +2069,7 @@
     <value>NoControl</value>
   </data>
   <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>341, 509</value>
+    <value>341, 523</value>
   </data>
   <data name="chk_temp.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 17</value>
@@ -2102,7 +2102,7 @@
     <value>340, 474</value>
   </data>
   <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
+    <value>107, 16</value>
   </data>
   <data name="chk_norcreceiver.TabIndex" type="System.Int32, mscorlib">
     <value>111</value>
@@ -2153,7 +2153,7 @@
     <value>107, 421</value>
   </data>
   <data name="CMB_Layout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_Layout.TabIndex" type="System.Int32, mscorlib">
     <value>113</value>
@@ -2180,7 +2180,7 @@
     <value>9, 424</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>39, 12</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>115</value>
@@ -2207,7 +2207,7 @@
     <value>598, 475</value>
   </data>
   <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 17</value>
+    <value>133, 16</value>
   </data>
   <data name="CHK_AutoParamCommit.TabIndex" type="System.Int32, mscorlib">
     <value>116</value>
@@ -2237,7 +2237,7 @@
     <value>671, 451</value>
   </data>
   <data name="chk_shownofly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>58, 16</value>
   </data>
   <data name="chk_shownofly.TabIndex" type="System.Int32, mscorlib">
     <value>117</value>
@@ -2267,7 +2267,7 @@
     <value>249, 171</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
+    <value>51, 12</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>118</value>
@@ -2291,7 +2291,7 @@
     <value>320, 168</value>
   </data>
   <data name="CMB_altunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
+    <value>138, 20</value>
   </data>
   <data name="CMB_altunits.TabIndex" type="System.Int32, mscorlib">
     <value>119</value>
@@ -2308,16 +2308,106 @@
   <data name="&gt;&gt;CMB_altunits.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="imageList1.ImageSize" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="LabelFrameShape.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LabelFrameShape.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LabelFrameShape.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 501</value>
+  </data>
+  <data name="LabelFrameShape.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 12</value>
+  </data>
+  <data name="LabelFrameShape.TabIndex" type="System.Int32, mscorlib">
+    <value>93</value>
+  </data>
+  <data name="LabelFrameShape.Text" xml:space="preserve">
+    <value>Frame Shape</value>
+  </data>
+  <data name="&gt;&gt;LabelFrameShape.Name" xml:space="preserve">
+    <value>LabelFrameShape</value>
+  </data>
+  <data name="&gt;&gt;LabelFrameShape.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LabelFrameShape.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;LabelFrameShape.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="txt_frame_shape_file.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 498</value>
+  </data>
+  <data name="txt_frame_shape_file.Size" type="System.Drawing.Size, System.Drawing">
+    <value>386, 19</value>
+  </data>
+  <data name="txt_frame_shape_file.TabIndex" type="System.Int32, mscorlib">
+    <value>94</value>
+  </data>
+  <data name="&gt;&gt;txt_frame_shape_file.Name" xml:space="preserve">
+    <value>txt_frame_shape_file</value>
+  </data>
+  <data name="&gt;&gt;txt_frame_shape_file.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txt_frame_shape_file.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;txt_frame_shape_file.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="BUT_frameshapebrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_frameshapebrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>496, 496</value>
+  </data>
+  <data name="BUT_frameshapebrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="BUT_frameshapebrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>95</value>
+  </data>
+  <data name="BUT_frameshapebrowse.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="&gt;&gt;BUT_frameshapebrowse.Name" xml:space="preserve">
+    <value>BUT_frameshapebrowse</value>
+  </data>
+  <data name="&gt;&gt;BUT_frameshapebrowse.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_frameshapebrowse.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_frameshapebrowse.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>750, 535</value>
+    <value>750, 549</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ConfigPlanner</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.MyUserControl, MissionPlanner.Controls, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
Purpose: User can select frame shape icon in Data Flight Mode.
How to Use：
  1) make frame icon file ( *.png ). Nose is above. 　Background color is transparent. 
Appropriate dimensions( around 50x50 to 100x100pixels. Will displayed same size )
  2) Open [CONFIG/TUNING] screen in MissionPlanner. and find [Frame Shape].
  3) Browse Select user made png file. user can select multi files.
  4) selected png will displayed in Data Flight Screen.

Excuse : Only below frames. : Multicopter / Rover / Boat / Heri  /Plane and Caxial(single).

Description of code:
  I edited GCSViews\ConfigurationVIew\ConfigPlanner.cs and related some files.
  And ExtLig\Utilities\Settings.cs. for new settings.

 I added new class [GMapMarker_IconSelectable].  Inherit [GMapMarker] . and base class of each frame classes.( ex. GMapMakerQuad. GmapMakerRover. ... )
Of course, I edited frame class files.( GmapMakerQuad.cs, and more....)
 
In Plane mode ( GMapMakerPlane.cs), user should select six png files. for different images are displayed for each MAV.sysid.
