### PR TITLE
Fix garbled characters in HORIZONTAL ELLIPSIS

### DIFF
--- a/ExtLibs/ProjNet/CoordinateSystems/Ellipsoid.cs
+++ b/ExtLibs/ProjNet/CoordinateSystems/Ellipsoid.cs
@@ -142,7 +142,7 @@ namespace ProjNet.CoordinateSystems
 			get
 			{
 				return new Ellipsoid(20926202, 0, 297, true, LinearUnit.ClarkesFoot, "Clarke 1880", "EPSG", 7034, "Clarke 1880", String.Empty,
-					"Clarke gave a and b and also 1/f=293.465 (to 3 decimal places).  1/f derived from a and b = 293.4663077…");
+					"Clarke gave a and b and also 1/f=293.465 (to 3 decimal places).  1/f derived from a and b = 293.4663077...");
 			}
 		}
 


### PR DESCRIPTION
My Windows is Japanese. The character of HORIZONTAL ELLIPSIS becomes the first byte of SJIS double-byte character and the double quote character is concatenated. This concatenation results in a build error.
I changed "..." to "." In three expressions.