### PR TITLE
Added QAUTOTUNE to flight modes

### DIFF
--- a/ExtLibs/ArduPilot/Common.cs
+++ b/ExtLibs/ArduPilot/Common.cs
@@ -155,6 +155,8 @@ union px4_custom_mode {
                     firmware.ToString());
                 flightModes.Add(new KeyValuePair<int, string>(16, "INITIALISING"));
 
+                flightModes.Add(new KeyValuePair<int, string>(22, "QAUTOTUNE"));
+
                 return flightModes;
             }
             else if (firmware == Firmwares.Ateryx)


### PR DESCRIPTION
this mode being missing is really confusing users. I think we need this until
it is in a stable release.

I know this should be automatic when users load firmware, but that isn't working. I suspect it may be because users are using load custom firmware.
