### PR TITLE
MAVLinkInterface: Do not duplicate DigicamControl messages

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -3243,13 +3243,8 @@ Please check the following
             req.target_component = MAV.compid;
             req.shot = (shot == true) ? (byte) 1 : (byte) 0;
 
-            generatePacket((byte) MAVLINK_MSG_ID.DIGICAM_CONTROL, req);
 
             doCommand(MAV_CMD.DO_DIGICAM_CONTROL, 0, 0, 0, 0, 1, 0, 0);
-
-            //MAVLINK_MSG_ID.CAMERA_FEEDBACK;
-
-            //mavlink_camera_feedback_t
         }
 
         public void setMountConfigure(MAV_MOUNT_MODE mountmode, bool stabroll, bool stabpitch, bool stabyaw)


### PR DESCRIPTION
setDigicamControl method sends 2 equivalent
messages for the purpose of triggering a camera.
For Autopilot modules that support both messages
this will result in 2 trigger requests, which will
likely not be successfull as they are too close together
in time. Regardless of the success of the trigger on
the camera, the 2 triggers will likely be logged
on the autopilot modules leading to difficulties
when geo-referencing pictures.

One example of this functionality leading to problems
is in Ardupilot. See [1].

Also the DIGICAM_CONTROL message seems to be deprecated
in recent Ardupilot versions in favor of the command,
which is the version that we now leave.

[1] https://discuss.ardupilot.org/t/duplicate-coordinate-entry-on-ever-single-trigger-cam-in-dataflash-log/17623/9