### PR TITLE
Fix log->param extraction files to be CSV instead of TSV

### DIFF
--- a/ExtLibs/Utilities/LogOutput.cs
+++ b/ExtLibs/Utilities/LogOutput.cs
@@ -1112,7 +1112,7 @@ gnssId GNSS Type
             {
                 foreach (var item in paramlist)
                 {
-                    paramoutput.WriteLine("{0}\t{1}", item.Key, item.Value);
+                    paramoutput.WriteLine("{0},{1}", item.Key, item.Value);
                 }
             }
         }


### PR DESCRIPTION
Fix log->param extraction files to be CSV (comma) instead of TSV (tab)