### PR TITLE
keep the delay value of a waypoint when moving

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -978,7 +978,7 @@ namespace MissionPlanner.GCSViews
         /// <param name="lat"></param>
         /// <param name="lng"></param>
         /// <param name="alt"></param>
-        public void setfromMap(double lat, double lng, int alt, double p1 = 0)
+        public void setfromMap(double lat, double lng, int alt, double p1 = -1)
         {
             if (selectedrow > Commands.RowCount)
             {
@@ -1133,7 +1133,7 @@ namespace MissionPlanner.GCSViews
             convertFromGeographic(lat, lng);
 
             // Add more for other params
-            if (Commands.Columns[Param1.Index].HeaderText.Equals("Delay"))
+            if (Commands.Columns[Param1.Index].HeaderText.Equals("Delay") && p1 != -1)
             {
                 cell = Commands.Rows[selectedrow].Cells[Param1.Index] as DataGridViewTextBoxCell;
                 cell.Value = p1;


### PR DESCRIPTION
If I move waypoints using drag & drop in Flight Planner screen, the delay (1st param) is reset.
This PR allow to maintain the delay value.