### PR TITLE
Do not display waypoints with lat and lon 0

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -158,6 +158,10 @@ namespace MissionPlanner.ArduPilot
                         addpolygonmarker((a + 1).ToString(), item.lng, item.lat,
                             item.alt, Color.Green, wpradius);
                     }
+                    else if (command == (ushort)MAVLink.MAV_CMD.WAYPOINT && item.lat == 0 && item.lng == 0)
+                    {
+                        fullpointlist.Add(pointlist[pointlist.Count - 1]);
+                    }
                     else
                     {
                         pointlist.Add(new PointLatLngAlt(item.lat, item.lng,


### PR DESCRIPTION
I often set the lat=0 and lon=0 of waypoint to hold the current location.
but I am not happy that the location of (0, 0) is displayed on the map.

Before
![image](https://user-images.githubusercontent.com/16643069/73925789-e8f71500-4911-11ea-90bf-c8cc4febcb32.png)

After
![image](https://user-images.githubusercontent.com/16643069/73925872-117f0f00-4912-11ea-9610-21dfbc877c83.png)