### PR TITLE
DashWare: add trailing commas to csv file

### DIFF
--- a/ExtLibs/Utilities/DashWare.cs
+++ b/ExtLibs/Utilities/DashWare.cs
@@ -35,8 +35,10 @@ namespace MissionPlanner.Utilities
                 using (StreamWriter sr = new StreamWriter(fileout))
                 {
                     // header
+                    var nCols = 0;
                     foreach (var item in colList)
                     {
+                        nCols++;
                         sr.Write(item + ",");
                     }
                     sr.WriteLine();
@@ -65,6 +67,12 @@ namespace MissionPlanner.Utilities
                         foreach (var item in dfitem.items.Skip(1))
                         {
                             sb.Append(item?.Trim());
+                            idx++;
+                            sb.Append(',');
+                        }
+
+                        while (idx < nCols)
+                        {
                             idx++;
                             sb.Append(',');
                         }

--- a/temp.cs
+++ b/temp.cs
@@ -973,7 +973,7 @@ namespace MissionPlanner
 
             if (ofd.CheckFileExists)
             {
-                string options = "GPS;ATT;NTUN;CTUN;MODE;CURR";
+                string options = "GPS;ATT;NTUN;CTUN;MODE;BAT";
                 InputBox.Show("", "Enter Messages you want eg PARM;NTUN;CTUN", ref options);
 
                 var split = options.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
short packets dont get trailing commas out to the max column number...so those columns get interpreted by Dashware as ZEROS instead of nulls

@Hwurzburg Could you test this fix?