### PR TITLE
Add possibility to use own GoogleAPI key

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -222,7 +222,8 @@ namespace MissionPlanner
             GMap.NET.MapProviders.GMapProviders.List.Add(Maps.Japan_Sea.Instance);
 
             GoogleMapProvider.APIKey = "AIzaSyA5nFp39fEHruCezXnG3r8rGyZtuAkmCug";
-
+            if (Settings.Instance["GoogleApiKey"] != null) GoogleMapProvider.APIKey = Settings.Instance["GoogleApiKey"];
+            
             Tracking.productName = Application.ProductName;
             Tracking.productVersion = Application.ProductVersion;
             Tracking.currentCultureName = Application.CurrentCulture.Name;


### PR DESCRIPTION
Due a setup problem (which fixed meanwhile) , if somebody want to use GeoCoding in MP (ZoomTo)  they need their own API key. This line adds a GoogleApiKey parameter to config.xml. If key not found then the original key used.