### PR TITLE
Quick Numbers should not be colored #2026

### DIFF
--- a/Utilities/ThemeManager.cs
+++ b/Utilities/ThemeManager.cs
@@ -1028,30 +1028,9 @@ mc:Ignorable=""d""
                     Color mix = Color.FromArgb(ThemeManager.BGColor.ToArgb() ^ 0xffffff);
 
                     Controls.QuickView but = (QuickView)ctl;
-                    if (but.Name == "quickView6")
-                    {
-                        but.numberColor = Color.FromArgb((0 + mix.R) / 2, (255 + mix.G) / 2, (252 + mix.B) / 2);
-                    }
-                    else if (but.Name == "quickView5")
-                    {
-                        but.numberColor = Color.FromArgb((254 + mix.R) / 2, (254 + mix.G) / 2, (86 + mix.B) / 2);
-                    }
-                    else if (but.Name == "quickView4")
-                    {
-                        but.numberColor = Color.FromArgb((0 + mix.R) / 2, (255 + mix.G) / 2, (83 + mix.B) / 2);
-                    }
-                    else if (but.Name == "quickView3")
-                    {
-                        but.numberColor = Color.FromArgb((255 + mix.R) / 2, (96 + mix.G) / 2, (91 + mix.B) / 2);
-                    }
-                    else if (but.Name == "quickView2")
-                    {
-                        but.numberColor = Color.FromArgb((254 + mix.R) / 2, (132 + mix.G) / 2, (46 + mix.B) / 2);
-                    }
-                    else if (but.Name == "quickView1")
-                    {
-                        but.numberColor = Color.FromArgb((209 + mix.R) / 2, (151 + mix.G) / 2, (248 + mix.B) / 2);
-                    }
+                    
+                        but.numberColor = Color.FromArgb(mix.R, mix.G, mix.B);
+                    
                     //return;  //return removed to process all quickView controls
                 }
                 else if (ctl.GetType() == typeof(TreeView))


### PR DESCRIPTION
Sorry I didn't wait for you to give me the go ahead to contribute - I thought it would take me much longer to do this.
I changed ThemeManager.cs (around line 1032):
1) Each QuickView numberColor property is set to the inverse of BGColor.
2) Removes the code that sets each QuickView color individually.