### PR TITLE
Set Mode dropdown fix

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1937,9 +1937,11 @@ namespace MissionPlanner.GCSViews
 
         private void CMB_modes_Click(object sender, EventArgs e)
         {
+            string current_value = CMB_modes.Text;
             CMB_modes.DataSource = ArduPilot.Common.getModesList(MainV2.comPort.MAV.cs.firmware);
             CMB_modes.ValueMember = "Key";
             CMB_modes.DisplayMember = "Value";
+            CMB_modes.Text = current_value;
         }
 
         private void CMB_setwp_Click(object sender, EventArgs e)


### PR DESCRIPTION
Let the Set Mode dropdown in FlightData/Actions retain selected value if not clicked in, instead of go back to stabilize every time.