### PR TITLE
AltitudeAngel - catch bug crashes with invalid WebBrowser()

### DIFF
--- a/ExtLibs/AltitudeAngelWings/ApiClient/Client/ApiOAuthClientHandler.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/Client/ApiOAuthClientHandler.cs
@@ -139,7 +139,7 @@ namespace AltitudeAngelWings.ApiClient.Client
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 var text = BearerToken;
-                if (text == null)
+                if (text == null && Authorization != null && Authorization.AccessTokenExpirationUtc != null)
                 {
                     if (Authorization.AccessTokenExpirationUtc.HasValue && Authorization.AccessTokenExpirationUtc.Value < DateTime.UtcNow)
                     {

--- a/ExtLibs/AltitudeAngelWings/ApiClient/CodeProvider/WpfAuthorizeDisplay.cs
+++ b/ExtLibs/AltitudeAngelWings/ApiClient/CodeProvider/WpfAuthorizeDisplay.cs
@@ -24,11 +24,15 @@ namespace AltitudeAngelWings.ApiClient.CodeProvider
             Width = 800;
             Height = 600;
 
-            _webBrowser = new WebBrowser();
-            _webBrowser.Navigating += WebBrowserOnNavigating;
-            _webBrowser.Navigated += WebBrowserOnNavigated;
-            _webBrowser.Dock = DockStyle.Fill;
-            Controls.Add(_webBrowser);
+            try
+            {
+                _webBrowser = new WebBrowser();
+                _webBrowser.Navigating += WebBrowserOnNavigating;
+                _webBrowser.Navigated += WebBrowserOnNavigated;
+                _webBrowser.Dock = DockStyle.Fill;
+                Controls.Add(_webBrowser);
+            }
+            catch { }
         }
 
         private void WebBrowserOnNavigated(object sender, WebBrowserNavigatedEventArgs e)
@@ -44,9 +48,11 @@ namespace AltitudeAngelWings.ApiClient.CodeProvider
         {
             _redirectUri = redirectUri;
 
-            _webBrowser.Navigate(authorizeUri);
-
-            ShowDialog();
+            if (_webBrowser != null)
+            {
+                _webBrowser.Navigate(authorizeUri);
+                ShowDialog();
+            }
 
             if(!seturl)
                 _tcs.SetResult(_redirectUri);


### PR DESCRIPTION
I found that my system's WebBrowser() class would return null sometimes when running in debug. I don't know why, but it's at least good to not-crash when it happens. This catches the event and skips the dialog.show which keeps additional problems away