### PR TITLE
fix sub-component statustext severity

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4560,7 +4560,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                         // the change of severity and the autopilot version where introduced at the same time, so any version non 0 can be used
                         // copter 3.4+
                         // plane 3.4+
-                        if (MAVlist[sysid, compid].cs.version.Major > 0 || MAVlist[sysid, compid].cs.version.Minor >= 4)
+                        if (MAVlist[sysid, compidcurrent].cs.version.Major > 0 || MAVlist[sysid, compidcurrent].cs.version.Minor >= 4)
                         {
                             if (sev <= (byte)MAV_SEVERITY.WARNING)
                             {


### PR DESCRIPTION
STATUSTEXT severity is a MAV_SEVERITY only if cs.version >= 0.4. This check always fails for sub-components, because they never send an AUTOPILOT_VERSION message. This means high-priority STATUSTEXT messages from sub-components are not sent to the HUD.

Fix this by comparing the "current" component version to 0.4 instead.