### PR TITLE
Add -config command line option for defining alternative config file

### DIFF
--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -43,7 +43,7 @@ namespace MissionPlanner.Utilities
         /// </summary>
         public static Dictionary<string, string> config = new Dictionary<string, string>();
 
-        const string FileName = "config.xml";
+        public static string FileName { get; set; } = "config.xml";
 
         public string this[string key]
         {

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -34,8 +34,7 @@ using System.Windows.Forms;
 using MissionPlanner.ArduPilot.Mavlink;
 using MissionPlanner.Utilities.HW;
 using Transitions;
-
-
+using System.Linq;
 
 namespace MissionPlanner
 {
@@ -663,6 +662,18 @@ namespace MissionPlanner
 
             // create one here - but override on load
             Settings.Instance["guid"] = Guid.NewGuid().ToString();
+            
+            //Check for -config argument, and if it is an xml extension filename then use that for config
+            if (Program.args.Length > 0 && Program.args.Contains("-config"))
+            {
+                var cmds = ProcessCommandLine(Program.args);  //This will be called later as well, but we need it here and now
+                if (cmds.ContainsKey("config") &&
+                     (cmds["config"] != null) &&
+                     (String.Compare(Path.GetExtension(cmds["config"]), ".xml", true) == 0))
+                {
+                    Settings.FileName = cmds["config"];
+                }
+            }
 
             // load config
             LoadConfig();


### PR DESCRIPTION
With this one can create different shortcuts for different vehicles with the same Mission Planner installation.
format is -config filename.xml where the extension must be .xml. The specified config file will be created from actual config.xml in the same directory.
Default config file is still config.xml