### PR TITLE
[Plugin thread]: fix looprate 0

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -2469,7 +2469,7 @@ namespace MissionPlanner
                         if (!nextrun.ContainsKey(plugin))
                             nextrun[plugin] = DateTime.MinValue;
 
-                        if (DateTime.Now > plugin.NextRun)
+                        if ((DateTime.Now > plugin.NextRun) && (plugin.loopratehz > 0))
                         {
                             // get ms till next run
                             int msnext = (int)(1000 / plugin.loopratehz);


### PR DESCRIPTION
Do not call loop() for plugins with zero loop rate.
(Currently loopratehz=0 causing call to loop() at every check.)