### PR TITLE
MainV2: Make titlebar public

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -417,7 +417,7 @@ namespace MissionPlanner
 
         public ConcurrentDictionary<string, adsb.PointLatLngAltHdg> adsbPlanes = new ConcurrentDictionary<string, adsb.PointLatLngAltHdg>();
 
-        string titlebar;
+        public static string titlebar;
 
         /// <summary>
         /// Comport name


### PR DESCRIPTION
To allow Main form title manipulation from a plugin (and keep the changed title on connect) titlebar should be public