### PR TITLE
use "POS" data to draw map

### DIFF
--- a/ExtLibs/Utilities/DFLog.cs
+++ b/ExtLibs/Utilities/DFLog.cs
@@ -688,7 +688,7 @@ namespace MissionPlanner.Utilities
         {
             DateTime last = DateTime.MaxValue;
 
-            foreach (var dfItem in logdata.GetEnumeratorType(new string[] { "GPS","GPS2"}))
+            foreach (var dfItem in logdata.GetEnumeratorType(new string[] { "GPS","GPS2","POS"}))
             {
                 // always forwards
                 if (dfItem.time >= p1)


### PR DESCRIPTION
In case of non-gps navigation, there is no GPS log.

The trajectory of POS is disappeared by selecting item
![image](https://user-images.githubusercontent.com/16643069/102857880-990f3700-446c-11eb-94f9-eeba73e5386b.png)

It appeared after my change.
![image](https://user-images.githubusercontent.com/16643069/102857808-72510080-446c-11eb-8f36-ac8a8ff58d3a.png)
