### PR TITLE
MAVLinkInspector: fix the unit of bytes per second

### DIFF
--- a/Controls/MAVLinkInspector.cs
+++ b/Controls/MAVLinkInspector.cs
@@ -108,7 +108,7 @@ namespace MissionPlanner.Controls
                 var msgidheader = mavLinkMessage.msgtypename + " (" +
                                   (mavi.SeenRate(mavLinkMessage.sysid, mavLinkMessage.compid, mavLinkMessage.msgid))
                                   .ToString("0.0 Hz") + ", #" + mavLinkMessage.msgid + ") " +
-                                  mavi.SeenBps(mavLinkMessage.sysid, mavLinkMessage.compid, mavLinkMessage.msgid).ToString("0bps");
+                                  mavi.SeenBps(mavLinkMessage.sysid, mavLinkMessage.compid, mavLinkMessage.msgid).ToString("0Bps");
 
                 if (msgidnode.Text != msgidheader)
                     msgidnode.Text = msgidheader;


### PR DESCRIPTION
I changed the unit from "bit per second" to "bytes per second".
![image](https://user-images.githubusercontent.com/16643069/103077049-643ce480-4612-11eb-9838-267c20f39094.png)