### PR TITLE
SITL fix : vehicleinfo.py changes broke Json parser

### DIFF
--- a/GCSViews/SITL.cs
+++ b/GCSViews/SITL.cs
@@ -362,7 +362,9 @@ namespace MissionPlanner.GCSViews
         void cleanupJson(string filename)
         {
             var content = File.ReadAllText(filename);
-
+            
+            content = content.Replace("True,", "\"True\",");
+            
             var match = BraceMatch(content, '{', '}');
 
             match = Regex.Replace(match, @"#.*", "");


### PR DESCRIPTION
A boolean value added to vehicleinfo.py broke the Jason parsing   ("external_model": True, )
A quick fix, add "  around the True to satisfy Jason parser.