### PR TITLE
Suppress repetitive MessageBoxes

### DIFF
--- a/ExtLibs/Utilities/CustomMessageBox.cs
+++ b/ExtLibs/Utilities/CustomMessageBox.cs
@@ -8,7 +8,7 @@ namespace System
     public static class CustomMessageBox
     {
         public delegate DialogResult ShowDelegate(string text, string caption = "",
-            MessageBoxButtons buttons = MessageBoxButtons.OK, MessageBoxIcon icon = MessageBoxIcon.None, string YesText = "Yes", string NoText = "No");
+            MessageBoxButtons buttons = MessageBoxButtons.OK, MessageBoxIcon icon = MessageBoxIcon.None, string YesText = "Yes", string NoText = "No", string DoForAllText = null);
 
         public static event ShowDelegate ShowEvent;
 
@@ -33,12 +33,12 @@ namespace System
             return (int)Show(text, caption, (MessageBoxButtons)(int)MessageBoxButtons, (MessageBoxIcon)(int)MessageBoxIcon);
         }
 
-        public static DialogResult Show(string text, string caption = "", MessageBoxButtons MessageBoxButtons = MessageBoxButtons.OK, MessageBoxIcon MessageBoxIcon = MessageBoxIcon.None, string YesText = "Yes", string NoText = "No")
+        public static DialogResult Show(string text, string caption = "", MessageBoxButtons MessageBoxButtons = MessageBoxButtons.OK, MessageBoxIcon MessageBoxIcon = MessageBoxIcon.None, string YesText = "Yes", string NoText = "No", string DoThisForAllText =null)
         {
             Console.WriteLine("CustomMessageBox.Show");
 
             if (ShowEvent != null)
-                return ShowEvent.Invoke(text, caption, MessageBoxButtons, MessageBoxIcon, YesText, NoText);
+                return ShowEvent.Invoke(text, caption, MessageBoxButtons, MessageBoxIcon, YesText, NoText, DoThisForAllText);
 
             throw new Exception("ShowEvent Not Set");
         }

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -34,6 +34,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         // ?
         internal bool startup = true;
 
+        private static DialogResult _lastOutOfRangeResult = DialogResult.None;
+        private static bool _suppressOutOfRangeWarning = false;
+        private static bool _suppressReadOnlyWarning = false;
+
         public ConfigRawParams()
         {
             InitializeComponent();
@@ -44,6 +48,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             startup = true;
 
             _changes.Clear();
+
+            _suppressOutOfRangeWarning = false;
+            _suppressReadOnlyWarning = false;
 
             BUT_writePIDS.Enabled = MainV2.comPort.BaseStream.IsOpen;
             BUT_rerequestparams.Enabled = MainV2.comPort.BaseStream.IsOpen;
@@ -97,6 +104,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private void BUT_load_Click(object sender, EventArgs e)
         {
+
+            CustomMessageBox.Show("Are you sure?", "caption", CustomMessageBox.MessageBoxButtons.YesNo, CustomMessageBox.MessageBoxIcon.Exclamation, "Ya", "Nope", "Do for all?");
+
             using (var ofd = new OpenFileDialog
             {
                 AddExtension = true,
@@ -389,10 +399,15 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     var readonly2 = bool.Parse(readonly1);
                     if (readonly2)
                     {
-                        CustomMessageBox.Show(
-                            Params[Command.Index, e.RowIndex].Value +
-                            " is marked as ReadOnly, and will not be changed", "ReadOnly",
-                            MessageBoxButtons.OK);
+                        if (!_suppressReadOnlyWarning)
+                        {
+                            CustomMessageBox.Show(
+                                    Params[Command.Index, e.RowIndex].Value +
+                                    " is marked as ReadOnly, and will not be changed", "ReadOnly",
+                                    CustomMessageBox.MessageBoxButtons.OK, DoThisForAllText: "Ok to all");
+
+                            _suppressReadOnlyWarning = MissionPlanner.MsgBox.CustomMessageBox.DoThisForAll;
+                        }
                         Params.CellValueChanged -= Params_CellValueChanged;
                         Params[e.ColumnIndex, e.RowIndex].Value = cellEditValue;
                         Params.CellValueChanged += Params_CellValueChanged;
@@ -405,11 +420,17 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 {
                     if (newvalue > max || newvalue < min)
                     {
-                        if (
-                            CustomMessageBox.Show(
+                        if (!_suppressOutOfRangeWarning)
+                        {
+                            _lastOutOfRangeResult = (DialogResult)CustomMessageBox.Show(
                                 Params[Command.Index, e.RowIndex].Value +
                                 " value is out of range. Do you want to continue?", "Out of range",
-                                MessageBoxButtons.YesNo) == (int)DialogResult.No)
+                                CustomMessageBox.MessageBoxButtons.YesNo, DoThisForAllText: "Do this for all items?");
+
+                            _suppressOutOfRangeWarning = MissionPlanner.MsgBox.CustomMessageBox.DoThisForAll;
+                        }
+                        
+                        if (_lastOutOfRangeResult == DialogResult.No)
                         {
                             Params.CellValueChanged -= Params_CellValueChanged;
                             Params[e.ColumnIndex, e.RowIndex].Value = cellEditValue;

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -104,9 +104,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private void BUT_load_Click(object sender, EventArgs e)
         {
-
-            CustomMessageBox.Show("Are you sure?", "caption", CustomMessageBox.MessageBoxButtons.YesNo, CustomMessageBox.MessageBoxIcon.Exclamation, "Ya", "Nope", "Do for all?");
-
             using (var ofd = new OpenFileDialog
             {
                 AddExtension = true,

--- a/GCSViews/SITL.Designer.cs
+++ b/GCSViews/SITL.Designer.cs
@@ -47,6 +47,7 @@ namespace MissionPlanner.GCSViews
             this.label1 = new System.Windows.Forms.Label();
             this.NUM_heading = new System.Windows.Forms.NumericUpDown();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.chk_skipdownload = new System.Windows.Forms.CheckBox();
             this.but_swarmseq = new MissionPlanner.Controls.MyButton();
             this.but_swarmlink = new MissionPlanner.Controls.MyButton();
             this.chk_wipe = new System.Windows.Forms.CheckBox();
@@ -210,6 +211,7 @@ namespace MissionPlanner.GCSViews
             // groupBox4
             // 
             resources.ApplyResources(this.groupBox4, "groupBox4");
+            this.groupBox4.Controls.Add(this.chk_skipdownload);
             this.groupBox4.Controls.Add(this.but_swarmseq);
             this.groupBox4.Controls.Add(this.but_swarmlink);
             this.groupBox4.Controls.Add(this.chk_wipe);
@@ -221,6 +223,12 @@ namespace MissionPlanner.GCSViews
             this.groupBox4.Controls.Add(this.num_simspeed);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.TabStop = false;
+            // 
+            // chk_skipdownload
+            // 
+            resources.ApplyResources(this.chk_skipdownload, "chk_skipdownload");
+            this.chk_skipdownload.Name = "chk_skipdownload";
+            this.chk_skipdownload.UseVisualStyleBackColor = true;
             // 
             // but_swarmseq
             // 
@@ -370,5 +378,6 @@ namespace MissionPlanner.GCSViews
         private System.Windows.Forms.CheckBox chk_wipe;
         private MyButton but_swarmseq;
         private MyButton but_swarmlink;
+        private System.Windows.Forms.CheckBox chk_skipdownload;
     }
 }

--- a/GCSViews/SITL.cs
+++ b/GCSViews/SITL.cs
@@ -245,33 +245,36 @@ namespace MissionPlanner.GCSViews
                 return BundledPath + System.IO.Path.DirectorySeparatorChar + file;
             }
 
-            Uri fullurl = new Uri(sitlurl, filename);
+            if (!chk_skipdownload.Checked)
+            {
+                Uri fullurl = new Uri(sitlurl, filename);
 
-            var load = Common.LoadingBox("Downloading", "Downloading sitl software");
+                var load = Common.LoadingBox("Downloading", "Downloading sitl software");
 
-            var t1 = Download.getFilefromNetAsync(fullurl.ToString(),
-                sitldirectory + Path.GetFileNameWithoutExtension(filename) + ".exe");
+                var t1 = Download.getFilefromNetAsync(fullurl.ToString(),
+                    sitldirectory + Path.GetFileNameWithoutExtension(filename) + ".exe");
 
-            load.Refresh();
+                load.Refresh();
 
-            // dependancys
-            var depurl = new Uri(sitlurl, "cyggcc_s-1.dll");
-            var t2 = Download.getFilefromNetAsync(depurl.ToString(), sitldirectory + depurl.Segments[depurl.Segments.Length - 1]);
+                // dependancys
+                var depurl = new Uri(sitlurl, "cyggcc_s-1.dll");
+                var t2 = Download.getFilefromNetAsync(depurl.ToString(), sitldirectory + depurl.Segments[depurl.Segments.Length - 1]);
 
-            load.Refresh();
-            depurl = new Uri(sitlurl, "cygstdc++-6.dll");
-            var t3 = Download.getFilefromNetAsync(depurl.ToString(), sitldirectory + depurl.Segments[depurl.Segments.Length - 1]);
+                load.Refresh();
+                depurl = new Uri(sitlurl, "cygstdc++-6.dll");
+                var t3 = Download.getFilefromNetAsync(depurl.ToString(), sitldirectory + depurl.Segments[depurl.Segments.Length - 1]);
 
-            load.Refresh();
-            depurl = new Uri(sitlurl, "cygwin1.dll");
-            var t4 = Download.getFilefromNetAsync(depurl.ToString(), sitldirectory + depurl.Segments[depurl.Segments.Length - 1]);
+                load.Refresh();
+                depurl = new Uri(sitlurl, "cygwin1.dll");
+                var t4 = Download.getFilefromNetAsync(depurl.ToString(), sitldirectory + depurl.Segments[depurl.Segments.Length - 1]);
 
-            await t1.ConfigureAwait(true);
-            await t2.ConfigureAwait(true);
-            await t3.ConfigureAwait(true);
-            await t4.ConfigureAwait(true);
+                await t1.ConfigureAwait(true);
+                await t2.ConfigureAwait(true);
+                await t3.ConfigureAwait(true);
+                await t4.ConfigureAwait(true);
 
-            load.Close();
+                load.Close();
+            }
 
             return sitldirectory + Path.GetFileNameWithoutExtension(filename) + ".exe";
         }

--- a/GCSViews/SITL.resx
+++ b/GCSViews/SITL.resx
@@ -112,23 +112,24 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.1, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.1, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.1, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="myGMAP1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <assembly alias="netstandard" name="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
-  <data name="myGMAP1.Location" type="System.Drawing.Point, netstandard">
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="myGMAP1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 16</value>
   </data>
-  <data name="myGMAP1.Size" type="System.Drawing.Size, netstandard">
+  <data name="myGMAP1.Size" type="System.Drawing.Size, System.Drawing">
     <value>848, 262</value>
   </data>
-  <data name="myGMAP1.TabIndex" type="System.Int32, netstandard">
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="myGMAP1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="&gt;&gt;myGMAP1.Name" xml:space="preserve">
@@ -146,19 +147,19 @@
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="label6.AutoSize" type="System.Boolean, netstandard">
+  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label6.Location" type="System.Drawing.Point, netstandard">
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
     <value>48, 120</value>
   </data>
-  <data name="label6.Size" type="System.Drawing.Size, netstandard">
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 13</value>
   </data>
-  <data name="label6.TabIndex" type="System.Int32, netstandard">
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
@@ -176,19 +177,19 @@
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="label5.AutoSize" type="System.Boolean, netstandard">
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label5.Location" type="System.Drawing.Point, netstandard">
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
     <value>217, 120</value>
   </data>
-  <data name="label5.Size" type="System.Drawing.Size, netstandard">
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
     <value>36, 13</value>
   </data>
-  <data name="label5.TabIndex" type="System.Int32, netstandard">
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
@@ -206,19 +207,19 @@
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="label4.AutoSize" type="System.Boolean, netstandard">
+  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label4.Location" type="System.Drawing.Point, netstandard">
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
     <value>370, 120</value>
   </data>
-  <data name="label4.Size" type="System.Drawing.Size, netstandard">
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 13</value>
   </data>
-  <data name="label4.TabIndex" type="System.Int32, netstandard">
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
   <data name="label4.Text" xml:space="preserve">
@@ -236,19 +237,19 @@
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="label3.AutoSize" type="System.Boolean, netstandard">
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label3.Location" type="System.Drawing.Point, netstandard">
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
     <value>569, 120</value>
   </data>
-  <data name="label3.Size" type="System.Drawing.Size, netstandard">
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>55, 13</value>
   </data>
-  <data name="label3.TabIndex" type="System.Int32, netstandard">
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
@@ -266,7 +267,6 @@
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pictureBoxheli.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAOAAAACECAYAAACJSCetAAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
@@ -688,13 +688,13 @@
   <data name="pictureBoxheli.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="pictureBoxheli.Location" type="System.Drawing.Point, netstandard">
+  <data name="pictureBoxheli.Location" type="System.Drawing.Point, System.Drawing">
     <value>477, 3</value>
   </data>
-  <data name="pictureBoxheli.Size" type="System.Drawing.Size, netstandard">
+  <data name="pictureBoxheli.Size" type="System.Drawing.Size, System.Drawing">
     <value>235, 112</value>
   </data>
-  <data name="pictureBoxheli.TabIndex" type="System.Int32, netstandard">
+  <data name="pictureBoxheli.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
   <data name="&gt;&gt;pictureBoxheli.Name" xml:space="preserve">
@@ -1210,13 +1210,13 @@
   <data name="pictureBoxquad.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="pictureBoxquad.Location" type="System.Drawing.Point, netstandard">
+  <data name="pictureBoxquad.Location" type="System.Drawing.Point, System.Drawing">
     <value>331, 3</value>
   </data>
-  <data name="pictureBoxquad.Size" type="System.Drawing.Size, netstandard">
+  <data name="pictureBoxquad.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 112</value>
   </data>
-  <data name="pictureBoxquad.TabIndex" type="System.Int32, netstandard">
+  <data name="pictureBoxquad.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
   <data name="&gt;&gt;pictureBoxquad.Name" xml:space="preserve">
@@ -1618,13 +1618,13 @@
   <data name="pictureBoxrover.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="pictureBoxrover.Location" type="System.Drawing.Point, netstandard">
+  <data name="pictureBoxrover.Location" type="System.Drawing.Point, System.Drawing">
     <value>159, 3</value>
   </data>
-  <data name="pictureBoxrover.Size" type="System.Drawing.Size, netstandard">
+  <data name="pictureBoxrover.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 112</value>
   </data>
-  <data name="pictureBoxrover.TabIndex" type="System.Int32, netstandard">
+  <data name="pictureBoxrover.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
   <data name="&gt;&gt;pictureBoxrover.Name" xml:space="preserve">
@@ -1932,13 +1932,13 @@
   <data name="pictureBoxplane.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="pictureBoxplane.Location" type="System.Drawing.Point, netstandard">
+  <data name="pictureBoxplane.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>
-  <data name="pictureBoxplane.Size" type="System.Drawing.Size, netstandard">
+  <data name="pictureBoxplane.Size" type="System.Drawing.Size, System.Drawing">
     <value>131, 112</value>
   </data>
-  <data name="pictureBoxplane.TabIndex" type="System.Int32, netstandard">
+  <data name="pictureBoxplane.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
   <data name="&gt;&gt;pictureBoxplane.Name" xml:space="preserve">
@@ -1953,13 +1953,13 @@
   <data name="&gt;&gt;pictureBoxplane.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="panel1.Location" type="System.Drawing.Point, netstandard">
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>69, 12</value>
   </data>
-  <data name="panel1.Size" type="System.Drawing.Size, netstandard">
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>716, 137</value>
   </data>
-  <data name="panel1.TabIndex" type="System.Int32, netstandard">
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
@@ -1977,13 +1977,13 @@
   <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, netstandard">
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 3</value>
   </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, netstandard">
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
     <value>854, 281</value>
   </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, netstandard">
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
@@ -2004,13 +2004,13 @@
   <data name="groupBox2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
   </data>
-  <data name="groupBox2.Location" type="System.Drawing.Point, netstandard">
+  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 368</value>
   </data>
-  <data name="groupBox2.Size" type="System.Drawing.Size, netstandard">
+  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
     <value>854, 152</value>
   </data>
-  <data name="groupBox2.TabIndex" type="System.Int32, netstandard">
+  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
@@ -2031,16 +2031,16 @@
   <data name="groupBox3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
   </data>
-  <data name="label1.AutoSize" type="System.Boolean, netstandard">
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label1.Location" type="System.Drawing.Point, netstandard">
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 20</value>
   </data>
-  <data name="label1.Size" type="System.Drawing.Size, netstandard">
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 13</value>
   </data>
-  <data name="label1.TabIndex" type="System.Int32, netstandard">
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
@@ -2058,13 +2058,13 @@
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="NUM_heading.Location" type="System.Drawing.Point, netstandard">
+  <data name="NUM_heading.Location" type="System.Drawing.Point, System.Drawing">
     <value>60, 18</value>
   </data>
-  <data name="NUM_heading.Size" type="System.Drawing.Size, netstandard">
+  <data name="NUM_heading.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 20</value>
   </data>
-  <data name="NUM_heading.TabIndex" type="System.Int32, netstandard">
+  <data name="NUM_heading.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="&gt;&gt;NUM_heading.Name" xml:space="preserve">
@@ -2079,13 +2079,13 @@
   <data name="&gt;&gt;NUM_heading.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="groupBox3.Location" type="System.Drawing.Point, netstandard">
+  <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 290</value>
   </data>
-  <data name="groupBox3.Size" type="System.Drawing.Size, netstandard">
+  <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
     <value>140, 72</value>
   </data>
-  <data name="groupBox3.TabIndex" type="System.Int32, netstandard">
+  <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="groupBox3.Text" xml:space="preserve">
@@ -2106,17 +2106,41 @@
   <data name="groupBox4.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
   </data>
+  <data name="chk_skipdownload.Location" type="System.Drawing.Point, System.Drawing">
+    <value>299, 42</value>
+  </data>
+  <data name="chk_skipdownload.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 24</value>
+  </data>
+  <data name="chk_skipdownload.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="chk_skipdownload.Text" xml:space="preserve">
+    <value>Skip Download</value>
+  </data>
+  <data name="&gt;&gt;chk_skipdownload.Name" xml:space="preserve">
+    <value>chk_skipdownload</value>
+  </data>
+  <data name="&gt;&gt;chk_skipdownload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_skipdownload.Parent" xml:space="preserve">
+    <value>groupBox4</value>
+  </data>
+  <data name="&gt;&gt;chk_skipdownload.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="but_swarmseq.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="but_swarmseq.Location" type="System.Drawing.Point, netstandard">
+  <data name="but_swarmseq.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 44</value>
   </data>
-  <data name="but_swarmseq.Size" type="System.Drawing.Size, netstandard">
+  <data name="but_swarmseq.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 23</value>
   </data>
-  <data name="but_swarmseq.TabIndex" type="System.Int32, netstandard">
-    <value>14</value>
+  <data name="but_swarmseq.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
   </data>
   <data name="but_swarmseq.Text" xml:space="preserve">
     <value>Copter Swarm - Single link</value>
@@ -2131,16 +2155,16 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;but_swarmseq.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
-  <data name="but_swarmlink.Location" type="System.Drawing.Point, netstandard">
+  <data name="but_swarmlink.Location" type="System.Drawing.Point, System.Drawing">
     <value>104, 44</value>
   </data>
-  <data name="but_swarmlink.Size" type="System.Drawing.Size, netstandard">
+  <data name="but_swarmlink.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 23</value>
   </data>
-  <data name="but_swarmlink.TabIndex" type="System.Int32, netstandard">
-    <value>13</value>
+  <data name="but_swarmlink.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
   <data name="but_swarmlink.Text" xml:space="preserve">
     <value>Copter Swarm - Multilink</value>
@@ -2155,19 +2179,19 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;but_swarmlink.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
-  <data name="chk_wipe.AutoSize" type="System.Boolean, netstandard">
+  <data name="chk_wipe.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="chk_wipe.Location" type="System.Drawing.Point, netstandard">
+  <data name="chk_wipe.Location" type="System.Drawing.Point, System.Drawing">
     <value>638, 17</value>
   </data>
-  <data name="chk_wipe.Size" type="System.Drawing.Size, netstandard">
+  <data name="chk_wipe.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 17</value>
   </data>
-  <data name="chk_wipe.TabIndex" type="System.Int32, netstandard">
-    <value>12</value>
+  <data name="chk_wipe.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
   </data>
   <data name="chk_wipe.Text" xml:space="preserve">
     <value>Wipe</value>
@@ -2182,18 +2206,18 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;chk_wipe.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
-  <data name="label8.AutoSize" type="System.Boolean, netstandard">
+  <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label8.Location" type="System.Drawing.Point, netstandard">
+  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
     <value>296, 20</value>
   </data>
-  <data name="label8.Size" type="System.Drawing.Size, netstandard">
+  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
     <value>99, 13</value>
   </data>
-  <data name="label8.TabIndex" type="System.Int32, netstandard">
+  <data name="label8.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
   <data name="label8.Text" xml:space="preserve">
@@ -2209,16 +2233,16 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
-  <data name="txt_cmdline.Location" type="System.Drawing.Point, netstandard">
+  <data name="txt_cmdline.Location" type="System.Drawing.Point, System.Drawing">
     <value>401, 17</value>
   </data>
-  <data name="txt_cmdline.Size" type="System.Drawing.Size, netstandard">
+  <data name="txt_cmdline.Size" type="System.Drawing.Size, System.Drawing">
     <value>230, 20</value>
   </data>
-  <data name="txt_cmdline.TabIndex" type="System.Int32, netstandard">
-    <value>10</value>
+  <data name="txt_cmdline.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
   <data name="&gt;&gt;txt_cmdline.Name" xml:space="preserve">
     <value>txt_cmdline</value>
@@ -2230,18 +2254,18 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;txt_cmdline.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
-  <data name="label7.AutoSize" type="System.Boolean, netstandard">
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label7.Location" type="System.Drawing.Point, netstandard">
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
     <value>127, 20</value>
   </data>
-  <data name="label7.Size" type="System.Drawing.Size, netstandard">
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
     <value>36, 13</value>
   </data>
-  <data name="label7.TabIndex" type="System.Int32, netstandard">
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
@@ -2257,7 +2281,7 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="cmb_model.Items" xml:space="preserve">
     <value />
@@ -2358,14 +2382,14 @@
   <data name="cmb_model.Items32" xml:space="preserve">
     <value>rover-skid</value>
   </data>
-  <data name="cmb_model.Location" type="System.Drawing.Point, netstandard">
+  <data name="cmb_model.Location" type="System.Drawing.Point, System.Drawing">
     <value>169, 17</value>
   </data>
-  <data name="cmb_model.Size" type="System.Drawing.Size, netstandard">
+  <data name="cmb_model.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 21</value>
   </data>
-  <data name="cmb_model.TabIndex" type="System.Int32, netstandard">
-    <value>8</value>
+  <data name="cmb_model.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
   </data>
   <data name="&gt;&gt;cmb_model.Name" xml:space="preserve">
     <value>cmb_model</value>
@@ -2377,18 +2401,18 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;cmb_model.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
-  <data name="label2.AutoSize" type="System.Boolean, netstandard">
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label2.Location" type="System.Drawing.Point, netstandard">
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 20</value>
   </data>
-  <data name="label2.Size" type="System.Drawing.Size, netstandard">
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 13</value>
   </data>
-  <data name="label2.TabIndex" type="System.Int32, netstandard">
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
@@ -2404,15 +2428,15 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
-  <data name="num_simspeed.Location" type="System.Drawing.Point, netstandard">
+  <data name="num_simspeed.Location" type="System.Drawing.Point, System.Drawing">
     <value>70, 18</value>
   </data>
-  <data name="num_simspeed.Size" type="System.Drawing.Size, netstandard">
+  <data name="num_simspeed.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 20</value>
   </data>
-  <data name="num_simspeed.TabIndex" type="System.Int32, netstandard">
+  <data name="num_simspeed.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="&gt;&gt;num_simspeed.Name" xml:space="preserve">
@@ -2425,15 +2449,15 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;num_simspeed.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
-  <data name="groupBox4.Location" type="System.Drawing.Point, netstandard">
+  <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
     <value>152, 290</value>
   </data>
-  <data name="groupBox4.Size" type="System.Drawing.Size, netstandard">
+  <data name="groupBox4.Size" type="System.Drawing.Size, System.Drawing">
     <value>715, 72</value>
   </data>
-  <data name="groupBox4.TabIndex" type="System.Int32, netstandard">
+  <data name="groupBox4.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
   <data name="groupBox4.Text" xml:space="preserve">
@@ -2451,10 +2475,10 @@
   <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="$this.Localizable" type="System.Boolean, netstandard">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, netstandard">
+  </metadata>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>879, 532</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/Program.cs
+++ b/Program.cs
@@ -236,10 +236,10 @@ namespace MissionPlanner
             Console.WriteLine("Application.DoEvents");
             Application.DoEvents();
 
-            CustomMessageBox.ShowEvent += (text, caption, buttons, icon, yestext, notext) =>
+            CustomMessageBox.ShowEvent += (text, caption, buttons, icon, yestext, notext, doforalltext) =>
                 {
                     return (CustomMessageBox.DialogResult)(int)MsgBox.CustomMessageBox.Show(text, caption,
-                        (MessageBoxButtons)(int)buttons, (MessageBoxIcon)(int)icon, yestext, notext);
+                        (MessageBoxButtons)(int)buttons, (MessageBoxIcon)(int)icon, yestext, notext, doforalltext );
                 };
 
             // setup theme provider


### PR DESCRIPTION
This addresses @tridge 's request to show "do this for all"
#2519
![image](https://user-images.githubusercontent.com/21204270/109434710-8ffa9300-79e4-11eb-86c1-02ba830b6a71.png)

The following approach is used:
There are 2 static classes named CustomMessageBox; one in the  MissionPlanner.MsgBox namespace and one in System. Both need adjusting, as one calls the other.

-The System class has a bunch of overrides. I added an optional parameter DoThisForAllText which, when set, will display a checkbox for example "Do this for all current items"
-The MissionPlanner.MsgBox class, which actually renders the messagebox will add the checkbox to the bottom of the form.

If the checkbox is selected, it will store the selection in a static bool property called DoThisForAll
(I understand this may not be the best approach, but it works. I'm open to ideas how to better pass back the checkbox selection)

in ConfigRawParams.cs I added some bools to track whether the dialog should be suppressed or not. If so, the last choice (Yes/No) is saved and used instead of showing the dialog.
