### PR TITLE
WarningEngine: Add new type warning to color QV item backgroung

### DIFF
--- a/ExtLibs/Controls/QuickView.cs
+++ b/ExtLibs/Controls/QuickView.cs
@@ -58,6 +58,9 @@ namespace MissionPlanner.Controls
         [System.ComponentModel.Browsable(true)]
         public Color numberColor { get { return _numbercolor; } set { if (_numbercolor == value) return; _numbercolor = value; Invalidate(); } }
 
+        //We use this property as a backup store for the numberColor, so it is possible to change numberColor temporary.
+        public Color numberColorBackup { get; set; }
+
         public QuickView()
         {
             InitializeComponent();
@@ -75,7 +78,7 @@ namespace MissionPlanner.Controls
 
                 var mid = extent.Width / 2;
 
-                e.DrawString(desc, this.Font, new SolidBrush(this.ForeColor), this.Width / 2 - mid, 0);
+                e.DrawString(desc, this.Font, new SolidBrush(this.ForeColor), this.Width / 2 - mid, 5);
 
                 y = extent.Height;
             }

--- a/ExtLibs/Utilities/Warnings/CustomWarning.cs
+++ b/ExtLibs/Utilities/Warnings/CustomWarning.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 
 namespace MissionPlanner.Warnings
 {
@@ -20,6 +21,27 @@ namespace MissionPlanner.Warnings
             GT,
             GTEQ,
             NEQ
+        }
+
+        public enum WarningColors
+        {
+            NoColor = 0,
+            Red,
+            OrangeRed,
+            Maroon,
+            Yellow,
+            Gold,
+            Goldenrod,
+            LawnGreen,
+            Green,
+            DarkGreen
+        }
+
+        // Differentiate between speak/text and QV Coloring items
+        public enum WarningType
+        {
+            SpeakAndText = 0,
+            Coloring
         }
 
         public CustomWarning()
@@ -92,6 +114,16 @@ namespace MissionPlanner.Warnings
         /// used to track last time something was said
         /// </summary>
         DateTime lastrepeat;
+
+        /// <summary>
+        /// identify the type of warning  (SpeakAndText or Coloring)
+        /// </summary>
+        public WarningType type { get; set; }
+
+        /// <summary>
+        /// this color is used when warning fired
+        /// </summary>
+        public string color { get; set; }
 
         /// <summary>
         /// in seconds

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -110,7 +110,7 @@ namespace MissionPlanner.GCSViews
         bool playingLog;
         GMapOverlay polygons;
         private Propagation prop;
-        Random random = new Random();
+        
         GMapRoute route;
         GMapOverlay routes;
         GMapOverlay adsbais;
@@ -351,7 +351,7 @@ namespace MissionPlanner.GCSViews
                     if (ctls.Length > 0)
                     {
                         QuickView QV = (QuickView) ctls[0];
-
+                        
                         // set description and unit
                         string desc = Settings.Instance["quickView" + f];
                         if (QV.Tag == null)
@@ -2358,30 +2358,6 @@ namespace MissionPlanner.GCSViews
             }
         }
 
-        Color GetColor()
-        {
-            //The mix color is set to the inverse of background color, so white background will get dark colors
-            Color mix = Color.FromArgb(ThemeManager.BGColor.ToArgb() ^ 0xffffff);
-
-            int red = random.Next(256);
-            int green = random.Next(256);
-            int blue = random.Next(256);
-
-            // mix the color
-            if (mix != null)
-            {
-                red = (red + mix.R) / 2;
-                green = (green + mix.G) / 2;
-                blue = (blue + mix.B) / 2;
-            }
-
-            var col = Color.FromArgb(red, green, blue);
-
-            this.LogInfo("GetColor() " + col);
-
-            return col;
-        }
-
         private void gimbalTrackbar_Scroll(object sender, EventArgs e)
         {
             MainV2.comPort.setMountControl((float) trackBarPitch.Value * 100.0f, (float) trackBarRoll.Value * 100.0f,
@@ -4230,7 +4206,8 @@ namespace MissionPlanner.GCSViews
                 QV.DoubleClick += quickView_DoubleClick;
                 QV.ContextMenuStrip = contextMenuStripQuickView;
                 QV.Dock = DockStyle.Fill;
-                QV.numberColor = GetColor();
+                QV.numberColor = ThemeManager.getQvNumberColor();
+                QV.numberColorBackup = QV.numberColor;
                 QV.number = 0;
 
                 tableLayoutPanelQuick.Controls.Add(QV);

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -551,14 +551,14 @@ namespace MissionPlanner
                 AutoHideMenu(true);
                 Settings.Instance["menu_autohide"] = true.ToString();
                 autoHideToolStripMenuItem.Visible = false;
-            } 
+            }
             else if (Settings.Instance.GetBoolean("menu_autohide"))
             {
                 AutoHideMenu(Settings.Instance.GetBoolean("menu_autohide"));
                 Settings.Instance["menu_autohide"] = Settings.Instance.GetBoolean("menu_autohide").ToString();
             }
 
-            
+
 
             //Flight data page
             if (MainV2.instance.FlightData != null)
@@ -659,7 +659,7 @@ namespace MissionPlanner
 
             if (MainV2.instance.FlightPlanner != null)
             {
-                //hide menu items 
+                //hide menu items
                 MainV2.instance.FlightPlanner.updateDisplayView();
             }
         }
@@ -673,7 +673,7 @@ namespace MissionPlanner
 
             // create one here - but override on load
             Settings.Instance["guid"] = Guid.NewGuid().ToString();
-            
+
             //Check for -config argument, and if it is an xml extension filename then use that for config
             if (Program.args.Length > 0 && Program.args.Contains("-config"))
             {
@@ -724,10 +724,10 @@ namespace MissionPlanner
 
             //Init Theme table and load BurntKermit as a default
             ThemeManager.thmColor = new ThemeColorTable(); //Init colortable
-            ThemeManager.thmColor.InitColors();     //This fills up the table with BurntKermit defaults. 
+            ThemeManager.thmColor.InitColors();     //This fills up the table with BurntKermit defaults.
             ThemeManager.thmColor.SetTheme();              //Set the colors, this need to handle the case when not all colors are defined in the theme file
 
- 
+
 
             if (Settings.Instance["theme"] == null) Settings.Instance["theme"] = "BurntKermit.mpsystheme";
 
@@ -774,6 +774,8 @@ namespace MissionPlanner
             {
                 MainV2.comPort.MAV.cs.messageHigh = s;
             };
+
+            Warnings.WarningEngine.QuickPanelColoring += WarningEngine_QuickPanelColoring;
 
             // proxy loader - dll load now instead of on config form load
             new Transition(new TransitionType_EaseInEaseOut(2000));
@@ -954,7 +956,7 @@ namespace MissionPlanner
                         Settings.Instance.GetInt32("MainLocY"));
 
                     // fix common bug which happens when user removes a monitor, the app shows up
-                    // offscreen and it is very hard to move it onscreen.  Also happens with 
+                    // offscreen and it is very hard to move it onscreen.  Also happens with
                     // remote desktop a lot.  So this only restores position if the position
                     // is visible.
                     foreach (Screen s in Screen.AllScreens)
@@ -1186,7 +1188,7 @@ namespace MissionPlanner
 
         public void switchicons(menuicons icons)
         {
-            //Check if we starting 
+            //Check if we starting
             if (displayicons != null)
             {
                 // dont update if no change
@@ -1282,7 +1284,7 @@ namespace MissionPlanner
         private void ResetConnectionStats()
         {
             log.Info("Reset connection stats");
-            // If the form has been closed, or never shown before, we need do nothing, as 
+            // If the form has been closed, or never shown before, we need do nothing, as
             // connection stats will be reset when shown
             if (this.connectionStatsForm != null && connectionStatsForm.Visible)
             {
@@ -1717,7 +1719,7 @@ namespace MissionPlanner
                     }
                 }
 
-                _connectionControl.UpdateSysIDS();             
+                _connectionControl.UpdateSysIDS();
 
                 // check for newer firmware
                 Task.Run(() =>
@@ -1828,7 +1830,7 @@ namespace MissionPlanner
                     }
                     catch (Exception ex) { log.Warn(ex); }
                 }
-                //Add HUD custom items source 
+                //Add HUD custom items source
                 HUD.Custom.src = MainV2.comPort.MAV.cs;
 
                 // set connected icon
@@ -1996,9 +1998,9 @@ namespace MissionPlanner
 
 
         /// <summary>
-        /// overriding the OnCLosing is a bit cleaner than handling the event, since it 
+        /// overriding the OnCLosing is a bit cleaner than handling the event, since it
         /// is this object.
-        /// 
+        ///
         /// This happens before FormClosed
         /// </summary>
         /// <param name="e"></param>
@@ -2263,7 +2265,7 @@ namespace MissionPlanner
             while (joystickthreadrun)
             {
                 joysendThreadExited = false;
-                //so we know this thread is stil alive.           
+                //so we know this thread is stil alive.
                 try
                 {
                     if (MONO)
@@ -2348,7 +2350,7 @@ namespace MissionPlanner
 
                                         lastratechange = DateTime.Now;
                                     }
-                                 
+
                                 }
                                 */
                                     //                                Console.WriteLine(DateTime.Now.Millisecond + " {0} {1} {2} {3} {4}", rc.chan1_raw, rc.chan2_raw, rc.chan3_raw, rc.chan4_raw,rate);
@@ -2416,7 +2418,7 @@ namespace MissionPlanner
                 {
                 } // cant fall out
             }
-            joysendThreadExited = true; //so we know this thread exited.    
+            joysendThreadExited = true; //so we know this thread exited.
         }
 
         /// <summary>
@@ -2542,7 +2544,7 @@ namespace MissionPlanner
         /// link quality stats
         /// speech voltage - custom - alt warning - data lost
         /// heartbeat packet sending
-        /// 
+        ///
         /// and can't fall out
         /// </summary>
         private async void SerialReader()
@@ -3405,7 +3407,7 @@ namespace MissionPlanner
                                      MainV2._connectionControl.UpdateSysIDS();
                                  });
 
-                             } 
+                             }
                              // add to seen list, so we skip on next refresh
                              seen.Add(zeroconfHost.Id);
                          }
@@ -4576,6 +4578,43 @@ namespace MissionPlanner
                         doConnect(mav, "preset", "0", false);
                         Comports.Add(mav);
                     });
+                }
+            }
+        }
+        //Handle QV panel coloring from warning engine
+        private void WarningEngine_QuickPanelColoring(string name, string color)
+        {
+            // return if we still initialize
+            if (FlightData == null) return;
+
+            //Find panel with
+            foreach (var q in FlightData.tabQuick.Controls["tableLayoutPanelQuick"].Controls)
+            {
+                QuickView qv = (QuickView)q;
+
+                //Get the data field name bind to the control
+                var fieldname = qv.DataBindings[0].BindingMemberInfo.BindingField;
+
+                if (fieldname == name)
+                {
+
+                    if (color == "NoColor")
+                    {
+                        qv.BackColor = ThemeManager.BGColor;
+                        qv.numberColor = qv.numberColorBackup;  //Restore original color from backup :)
+                        qv.ForeColor = ThemeManager.TextColor;
+
+
+                    }
+                    else
+                    {
+                        qv.BackColor = Color.FromName(color);
+                        // Ensure color is readable on the background
+                        qv.numberColor = (((qv.BackColor.R + qv.BackColor.B + qv.BackColor.G) / 3) > 128) ? Color.Black : Color.White;
+                        qv.ForeColor = qv.numberColor;      //Same as the number
+                    }
+                    //We have our panel, color it and exit loop
+                    break;
                 }
             }
         }

--- a/Utilities/ThemeManager.cs
+++ b/Utilities/ThemeManager.cs
@@ -316,6 +316,29 @@ namespace MissionPlanner.Utilities
         }
 
 
+        public static Color getQvNumberColor()
+        {
+            //The mix color is set to the inverse of background color, so white background will get dark colors
+            Color mix = Color.FromArgb(ThemeManager.BGColor.ToArgb() ^ 0xffffff);
+
+            Random random = new Random();
+
+            int red = random.Next(256);
+            int green = random.Next(256);
+            int blue = random.Next(256);
+
+            // mix the color
+            if (mix != null)
+            {
+                red = (red + mix.R) / 2;
+                green = (green + mix.G) / 2;
+                blue = (blue + mix.B) / 2;
+            }
+
+            var col = Color.FromArgb(red, green, blue);
+            return col;
+        }
+
         public static void doxamlgen()
         {
             var asm = Assembly.GetExecutingAssembly();
@@ -1079,6 +1102,7 @@ mc:Ignorable=""d""
                     {
                         but.numberColor = Color.FromArgb((209 + mix.R) / 2, (151 + mix.G) / 2, (248 + mix.B) / 2);
                     }
+                    but.numberColorBackup = but.numberColor;
                     //return;  //return removed to process all quickView controls
                 }
                 else if (ctl.GetType() == typeof(TreeView))

--- a/Warnings/WarningControl.cs
+++ b/Warnings/WarningControl.cs
@@ -20,6 +20,7 @@ namespace MissionPlanner.Warnings
             item.SetField(item.Name);
 
             CMB_condition.DataSource = Enum.GetNames(typeof(CustomWarning.Conditional));
+            CMB_color.DataSource = Enum.GetNames(typeof(CustomWarning.WarningColors));
 
             CMB_Source.DataSource = item.GetOptions();
 
@@ -31,11 +32,27 @@ namespace MissionPlanner.Warnings
 
         public void updateDisplay()
         {
+
             CMB_condition.Text = custwarning.ConditionType.ToString();
             CMB_Source.Text = custwarning.Name;
             NUM_warning.Value = (decimal)custwarning.Warning;
-            NUM_repeattime.Value = custwarning.RepeatTime;
-            TXT_warningtext.Text = custwarning.Text;
+
+            if (custwarning.type == CustomWarning.WarningType.SpeakAndText)
+            {
+                NUM_repeattime.Value = custwarning.RepeatTime;
+                TXT_warningtext.Text = custwarning.Text;
+                CMB_color.Text = "NoColor";
+                CB_type.Checked = false;
+                //Fire the checkedchange event to enable/disable fields
+                CB_type_CheckedChanged(null, EventArgs.Empty);
+            }
+            else
+            {
+                CB_type.Checked = true;
+                CMB_color.Text = custwarning.color;
+                CB_type_CheckedChanged(null, EventArgs.Empty);
+            }
+
         }
 
         CustomWarning _custwarn;
@@ -52,6 +69,8 @@ namespace MissionPlanner.Warnings
         public TextBox TXT_warningtext;
         private Controls.MyButton but_addchild;
         private Controls.MyButton but_remove;
+        private CheckBox CB_type;
+        private ComboBox CMB_color;
         private ComboBox CMB_Source;
         // posible child
         //private CustomWarning item;
@@ -66,99 +85,118 @@ namespace MissionPlanner.Warnings
             this.TXT_warningtext = new System.Windows.Forms.TextBox();
             this.but_addchild = new MissionPlanner.Controls.MyButton();
             this.but_remove = new MissionPlanner.Controls.MyButton();
+            this.CB_type = new System.Windows.Forms.CheckBox();
+            this.CMB_color = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_warning)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_repeattime)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // CMB_Source
-            // 
+            //
             this.CMB_Source.FormattingEnabled = true;
-            this.CMB_Source.Location = new System.Drawing.Point(3, 2);
+            this.CMB_Source.Location = new System.Drawing.Point(131, 3);
             this.CMB_Source.Name = "CMB_Source";
-            this.CMB_Source.Size = new System.Drawing.Size(121, 21);
+            this.CMB_Source.Size = new System.Drawing.Size(116, 21);
             this.CMB_Source.TabIndex = 0;
-            this.CMB_Source.Text = "hdop";
+            this.CMB_Source.Text = "gpsstat";
             this.CMB_Source.SelectedIndexChanged += new System.EventHandler(this.CMB_Source_SelectedIndexChanged);
-            // 
+            //
             // CMB_condition
-            // 
+            //
             this.CMB_condition.FormattingEnabled = true;
-            this.CMB_condition.Location = new System.Drawing.Point(130, 2);
+            this.CMB_condition.Location = new System.Drawing.Point(253, 3);
             this.CMB_condition.Name = "CMB_condition";
             this.CMB_condition.Size = new System.Drawing.Size(54, 21);
             this.CMB_condition.TabIndex = 1;
             this.CMB_condition.Text = "EQ";
             this.CMB_condition.SelectedIndexChanged += new System.EventHandler(this.CMB_condition_SelectedIndexChanged);
-            // 
+            //
             // NUM_warning
-            // 
+            //
             this.NUM_warning.DecimalPlaces = 2;
-            this.NUM_warning.Location = new System.Drawing.Point(190, 3);
-            this.NUM_warning.Maximum = new decimal(new int[]
-            {
-                99999,
-                0,
-                0,
-                0
-            });
-            this.NUM_warning.Minimum = new decimal(new int[]
-            {
-                99999,
-                0,
-                0,
-                -2147483648
-            });
+            this.NUM_warning.Location = new System.Drawing.Point(313, 4);
+            this.NUM_warning.Maximum = new decimal(new int[] {
+            99999,
+            0,
+            0,
+            0});
+            this.NUM_warning.Minimum = new decimal(new int[] {
+            99999,
+            0,
+            0,
+            -2147483648});
             this.NUM_warning.Name = "NUM_warning";
             this.NUM_warning.Size = new System.Drawing.Size(65, 20);
             this.NUM_warning.TabIndex = 2;
             this.NUM_warning.ValueChanged += new System.EventHandler(this.NUM_warning_ValueChanged);
-            // 
+            //
             // NUM_repeattime
-            // 
-            this.NUM_repeattime.Location = new System.Drawing.Point(503, 3);
+            //
+            this.NUM_repeattime.Location = new System.Drawing.Point(745, 4);
             this.NUM_repeattime.Name = "NUM_repeattime";
             this.NUM_repeattime.Size = new System.Drawing.Size(39, 20);
             this.NUM_repeattime.TabIndex = 3;
-            this.NUM_repeattime.Value = new decimal(new int[]
-            {
-                10,
-                0,
-                0,
-                0
-            });
+            this.NUM_repeattime.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
             this.NUM_repeattime.ValueChanged += new System.EventHandler(this.NUM_repeattime_ValueChanged);
-            // 
+            //
             // TXT_warningtext
-            // 
-            this.TXT_warningtext.Location = new System.Drawing.Point(261, 2);
+            //
+            this.TXT_warningtext.Location = new System.Drawing.Point(494, 3);
             this.TXT_warningtext.Name = "TXT_warningtext";
             this.TXT_warningtext.Size = new System.Drawing.Size(236, 20);
             this.TXT_warningtext.TabIndex = 4;
             this.TXT_warningtext.Text = "WARNING: {name} is {value}";
             this.TXT_warningtext.TextChanged += new System.EventHandler(this.TXT_warningtext_TextChanged);
-            // 
+            //
             // but_addchild
-            // 
-            this.but_addchild.Location = new System.Drawing.Point(549, 3);
+            //
+            this.but_addchild.Location = new System.Drawing.Point(791, 4);
             this.but_addchild.Name = "but_addchild";
             this.but_addchild.Size = new System.Drawing.Size(25, 20);
             this.but_addchild.TabIndex = 5;
             this.but_addchild.Text = "+";
             this.but_addchild.UseVisualStyleBackColor = true;
             this.but_addchild.Click += new System.EventHandler(this.but_addchild_Click);
-            // 
+            //
             // but_remove
-            // 
-            this.but_remove.Location = new System.Drawing.Point(580, 3);
+            //
+            this.but_remove.Location = new System.Drawing.Point(822, 4);
             this.but_remove.Name = "but_remove";
             this.but_remove.Size = new System.Drawing.Size(25, 20);
             this.but_remove.TabIndex = 6;
             this.but_remove.Text = "-";
             this.but_remove.UseVisualStyleBackColor = true;
             this.but_remove.Click += new System.EventHandler(this.but_remove_Click);
-            // 
+            //
+            // cbType
+            //
+            this.CB_type.AutoSize = true;
+            this.CB_type.Location = new System.Drawing.Point(3, 5);
+            this.CB_type.Name = "cbType";
+            this.CB_type.Size = new System.Drawing.Size(122, 17);
+            this.CB_type.TabIndex = 7;
+            this.CB_type.Text = "QuickPanel Coloring";
+            this.CB_type.UseVisualStyleBackColor = true;
+            this.CB_type.CheckedChanged += new System.EventHandler(this.CB_type_CheckedChanged);
+            //
+            // cmbColor
+            //
+            this.CMB_color.FormattingEnabled = true;
+            this.CMB_color.Location = new System.Drawing.Point(384, 3);
+            this.CMB_color.Name = "cmbColor";
+            this.CMB_color.Size = new System.Drawing.Size(104, 21);
+            this.CMB_color.TabIndex = 8;
+            this.CMB_color.Text = "NoColor";
+            this.CMB_color.SelectedIndexChanged += new System.EventHandler(this.cmbColor_SelectedIndexChanged);
+            //
             // WarningControl
-            // 
+            //
+            this.Controls.Add(this.CMB_color);
+            this.Controls.Add(this.CB_type);
             this.Controls.Add(this.but_remove);
             this.Controls.Add(this.but_addchild);
             this.Controls.Add(this.TXT_warningtext);
@@ -167,11 +205,12 @@ namespace MissionPlanner.Warnings
             this.Controls.Add(this.CMB_condition);
             this.Controls.Add(this.CMB_Source);
             this.Name = "WarningControl";
-            this.Size = new System.Drawing.Size(619, 27);
+            this.Size = new System.Drawing.Size(850, 27);
             ((System.ComponentModel.ISupportInitialize)(this.NUM_warning)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_repeattime)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         private void CMB_Source_SelectedIndexChanged(object sender, EventArgs e)
@@ -185,6 +224,13 @@ namespace MissionPlanner.Warnings
             if (custwarning != null)
                 custwarning.ConditionType =
                     (CustomWarning.Conditional)Enum.Parse(typeof(CustomWarning.Conditional), CMB_condition.Text);
+        }
+
+        private void cmbColor_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (custwarning != null)
+                custwarning.color = CMB_color.Text;
+
         }
 
         private void NUM_warning_ValueChanged(object sender, EventArgs e)
@@ -246,6 +292,38 @@ namespace MissionPlanner.Warnings
                     lookin.Child = null;
                 }
                 return;
+            }
+        }
+
+        private void CB_type_CheckedChanged(object sender, EventArgs e)
+        {
+            if (CB_type.Checked)
+            {
+                //It is a coloring item
+                but_addchild.Enabled = false;
+                TXT_warningtext.Text = "";
+                TXT_warningtext.Enabled = false;
+                NUM_repeattime.Value = 0;
+                NUM_repeattime.Enabled = false;
+
+                CMB_color.Enabled = true;
+
+                _custwarn.type = CustomWarning.WarningType.Coloring;
+
+            }
+            else
+            {
+                //It is regular SpeakAndText item
+                but_addchild.Enabled = true;
+                TXT_warningtext.Text = "WARNING: {name} is {value}";
+                TXT_warningtext.Enabled = true;
+                NUM_repeattime.Value = 10;
+                NUM_repeattime.Enabled = true;
+
+                CMB_color.Enabled = false;
+
+                _custwarn.type = CustomWarning.WarningType.SpeakAndText;
+
             }
         }
     }

--- a/Warnings/WarningsManager.Designer.cs
+++ b/Warnings/WarningsManager.Designer.cs
@@ -30,15 +30,17 @@ namespace MissionPlanner.Warnings
         private void InitializeComponent()
         {
             this.panel1 = new System.Windows.Forms.Panel();
-            this.BUT_Add = new MyButton();
-            this.BUT_save = new MyButton();
+            this.warningControl1 = new MissionPlanner.Warnings.WarningControl();
+            this.label4 = new System.Windows.Forms.Label();
+            this.BUT_Add = new MissionPlanner.Controls.MyButton();
+            this.BUT_save = new MissionPlanner.Controls.MyButton();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
-            this.warningControl1 = new MissionPlanner.Warnings.WarningControl();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -51,8 +53,25 @@ namespace MissionPlanner.Warnings
             this.panel1.Controls.Add(this.label4);
             this.panel1.Location = new System.Drawing.Point(4, 53);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(705, 175);
+            this.panel1.Size = new System.Drawing.Size(866, 175);
             this.panel1.TabIndex = 0;
+            // 
+            // warningControl1
+            // 
+            this.warningControl1.custwarning = null;
+            this.warningControl1.Location = new System.Drawing.Point(2, 2);
+            this.warningControl1.Name = "warningControl1";
+            this.warningControl1.Size = new System.Drawing.Size(857, 27);
+            this.warningControl1.TabIndex = 6;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(200, -14);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(29, 13);
+            this.label4.TabIndex = 5;
+            this.label4.Text = "Field";
             // 
             // BUT_Add
             // 
@@ -77,7 +96,7 @@ namespace MissionPlanner.Warnings
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 39);
+            this.label1.Location = new System.Drawing.Point(129, 39);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(29, 13);
             this.label1.TabIndex = 0;
@@ -86,7 +105,7 @@ namespace MissionPlanner.Warnings
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(131, 39);
+            this.label2.Location = new System.Drawing.Point(258, 39);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(62, 13);
             this.label2.TabIndex = 3;
@@ -95,25 +114,16 @@ namespace MissionPlanner.Warnings
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(199, 39);
+            this.label3.Location = new System.Drawing.Point(314, 39);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(40, 13);
             this.label3.TabIndex = 4;
             this.label3.Text = "Trigger";
             // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(200, -14);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(29, 13);
-            this.label4.TabIndex = 5;
-            this.label4.Text = "Field";
-            // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(487, 39);
+            this.label5.Location = new System.Drawing.Point(748, 39);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(80, 13);
             this.label5.TabIndex = 6;
@@ -122,25 +132,35 @@ namespace MissionPlanner.Warnings
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(271, 39);
+            this.label6.Location = new System.Drawing.Point(507, 39);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(50, 13);
             this.label6.TabIndex = 7;
             this.label6.Text = "Message";
             // 
-            // warningControl1
+            // label7
             // 
-            this.warningControl1.custwarning = null;
-            this.warningControl1.Location = new System.Drawing.Point(2, 2);
-            this.warningControl1.Name = "warningControl1";
-            this.warningControl1.Size = new System.Drawing.Size(619, 27);
-            this.warningControl1.TabIndex = 6;
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(3, 39);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(50, 13);
+            this.label7.TabIndex = 8;
+            this.label7.Text = "Item type";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(398, 39);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(31, 13);
+            this.label8.TabIndex = 9;
+            this.label8.Text = "Color";
             // 
             // WarningsManager
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            
-            this.ClientSize = new System.Drawing.Size(711, 238);
+            this.ClientSize = new System.Drawing.Size(872, 238);
+            this.Controls.Add(this.label8);
+            this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label3);
@@ -170,5 +190,7 @@ namespace MissionPlanner.Warnings
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label6;
         private WarningControl warningControl1;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label8;
     }
 }


### PR DESCRIPTION
This update extends the WarningEngine with a new type of warning, where it changes color of the QV item background if condition is met.
I find it useful with QuickView's where there are a large number of items. 
It also goes well with the next upcoming patch which makes QuickView Tab undockable, for multi monitor GCS setups.