### PR TITLE
Global: delete unused variables

### DIFF
--- a/Controls/OpenGLtest2.cs
+++ b/Controls/OpenGLtest2.cs
@@ -1427,7 +1427,6 @@ void main(void) {
                 }
             }
 
-            private Dictionary<string, int> _uniformLocations;
             private bool init;
             private IGraphicsContext Context;
             private IWindowInfo WindowInfo;

--- a/Controls/UAVCANInspector.cs
+++ b/Controls/UAVCANInspector.cs
@@ -118,13 +118,11 @@ namespace MissionPlanner.Controls
 
         private static void PopulateMSG(FieldInfo[] Fields, TreeNode MsgIdNode, object message)
         {
-            bool added;
             foreach (var field in Fields)
             {
                 if (!MsgIdNode.Nodes.ContainsKey(field.Name))
                 {
                     MsgIdNode.Nodes.Add(new TreeNode() {Name = field.Name});
-                    added = true;
                 }
 
                 object value = field.GetValue(message);
@@ -331,7 +329,6 @@ namespace MissionPlanner.Controls
             if (e == null || e.Node == null || e.Node.Parent == null)
                 return;
 
-            int throwaway = 0;
             //if (int.TryParse(e.Node.Parent.Name, out throwaway))
             {
                 selectedmsgid = e.Node.Name;

--- a/Controls/UAVCANParams.cs
+++ b/Controls/UAVCANParams.cs
@@ -35,7 +35,6 @@ namespace MissionPlanner.Controls
         private byte _node;
         private List<UAVCAN.uavcan.uavcan_protocol_param_GetSet_res> _paramlist;
         private readonly System.Timers.Timer _filterTimer = new System.Timers.Timer();
-        private List<GitHubContent.FileInfo> paramfiles;
         public UAVCANParams(UAVCAN.uavcan can, byte node, List<UAVCAN.uavcan.uavcan_protocol_param_GetSet_res> paramlist)
         {
             _can = can;

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4022,7 +4022,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             const ushort MAVLINK_SET_POS_TYPE_MASK_ALT_IGNORE = ((0 << 0) | (0 << 1) | (1 << 2));
             const ushort MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE = ((1 << 3) | (1 << 4) | (1 << 5));
             const ushort MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE = ((1 << 6) | (1 << 7) | (1 << 8));
-            const ushort MAVLINK_SET_POS_TYPE_MASK_FORCE = ((1 << 9));
             const ushort MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE = ((1 << 10) | (1 << 11));
 
             mavlink_set_position_target_global_int_t target = new mavlink_set_position_target_global_int_t()

--- a/ExtLibs/Comms/CommsWebSocket.cs
+++ b/ExtLibs/Comms/CommsWebSocket.cs
@@ -20,8 +20,6 @@ namespace MissionPlanner.Comms
         public ClientWebSocket client = new ClientWebSocket();
         private DateTime lastReconnectTime = DateTime.MinValue;
 
-        private bool reconnectnoprompt;
-
         public int retrys = 3;
 
         public WebSocket()

--- a/ExtLibs/MissionPlanner.Drawing/Bitmap.cs
+++ b/ExtLibs/MissionPlanner.Drawing/Bitmap.cs
@@ -16,9 +16,6 @@ namespace System.Drawing
     [Serializable]
     public class Bitmap : Image, ISerializable, ICloneable, IDisposable
     {
-        private object p;
-        private Size size;
-
         public Bitmap(int width, int height, int stride, SKColorType bgra8888 = (SKColorType.Bgra8888),
             IntPtr data = default(IntPtr))
         {

--- a/ExtLibs/MissionPlanner.Gridv2/GridUIv2.cs
+++ b/ExtLibs/MissionPlanner.Gridv2/GridUIv2.cs
@@ -883,7 +883,6 @@ namespace MissionPlanner
         }
 
         bool mousedown = false;
-        bool mousedragging = false;
         PointLatLng mousestart = PointLatLng.Empty;
 
         private void map_MouseDown(object sender, MouseEventArgs e)
@@ -895,7 +894,6 @@ namespace MissionPlanner
         private void map_MouseUp(object sender, MouseEventArgs e)
         {
             mousedown = false;
-            mousedragging = false;
 
             domainUpDown1_ValueChanged(null, null);
         }
@@ -906,8 +904,6 @@ namespace MissionPlanner
 
             if (mousedown)
             {
-                mousedragging = true;
-
                 if (currentmode == mode.panmode)
                 {
                     if (e.Button == MouseButtons.Left)
@@ -1033,8 +1029,6 @@ namespace MissionPlanner
                     mousestart = mousecurrent;
                 }
             }
-
-            mousedragging = false;
         }
 
         private void UpdateListFromBox()

--- a/ExtLibs/SimpleGrid/SimpleGridUI.cs
+++ b/ExtLibs/SimpleGrid/SimpleGridUI.cs
@@ -114,7 +114,6 @@ namespace MissionPlanner.SimpleGrid
         internal PointLatLng MouseDownEnd;
         internal PointLatLngAlt CurrentGMapMarkerStartPos;
         PointLatLng currentMousePosition;
-        GMapMarker marker;
         GMapMarker CurrentGMapMarker = null;
         int CurrentGMapMarkerIndex = 0;
         bool isMouseDown = false;

--- a/ExtLibs/TestPlugin/TestPlugin.cs
+++ b/ExtLibs/TestPlugin/TestPlugin.cs
@@ -21,7 +21,6 @@ public class TestPlugin : Plugin
     string _Version = "0.1";
     string _Author = "Michael Oborne";
     private TelstraUTM UTM;
-    private JArray UAVS;
     private string clientid = "michael";
 
     public override string Name

--- a/ExtLibs/UAVCAN/Canard.cs
+++ b/ExtLibs/UAVCAN/Canard.cs
@@ -115,40 +115,32 @@ namespace UAVCAN
         {
             union storage = new union(false);
 
-            Byte std_byte_length = 0;
-
             // Extra most significant bits can be safely ignored here.
             if (bit_length == 1)
             {
-                std_byte_length = sizeof(bool);
                 storage.boolean = (bool) (dynamic) value;
             }
             else if (bit_length <= 8)
             {
-                std_byte_length = 1;
                 storage.u8 = ((Byte) (dynamic) value);
             }
             else if (bit_length <= 16)
             {
-                std_byte_length = 2;
                 storage.u16 = ((UInt16) (dynamic) value);
             }
             else if (bit_length <= 32)
             {
                 if (value is float)
                 {
-                    std_byte_length = 4;
                     storage.f32 = ((float)(dynamic)value);
                 }
                 else
                 {
-                    std_byte_length = 4;
                     storage.u32 = ((UInt32) (dynamic) value);
                 }
             }
             else if (bit_length <= 64)
             {
-                std_byte_length = 8;
                 storage.u64 = ((UInt64) (dynamic) value);
             }
 

--- a/ExtLibs/UAVCAN/UAVCan.cs
+++ b/ExtLibs/UAVCAN/UAVCan.cs
@@ -1156,7 +1156,6 @@ namespace UAVCAN
             // getfile crc
             using (var stream = File.OpenRead(fileServerList[Path.GetFileName("fw.bin".ToLower())]))
             {
-                string app_descriptor_fmt = "<8cQI";
                 var SHARED_APP_DESCRIPTOR_SIGNATURES = new byte[][]
                 {
                     new byte[] {0xd7, 0xe4, 0xf7, 0xba, 0xd0, 0x0f, 0x9b, 0xee},

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5405,8 +5405,6 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                     throw new Exception("Please connect first!");
                 }
 
-                int a = 0;
-
                 // define the home point
                 Locationwp home = new Locationwp();
                 try
@@ -6928,7 +6926,6 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                         var length = (int)list.First().p1;
                         if (length == 0)
                             length = 1;
-                        int cnt = 0;
                         var sublist = list.Take(length).ToList();
 
                         if (sublist.Contains(rowdelete))

--- a/Utilities/POI.cs
+++ b/Utilities/POI.cs
@@ -39,7 +39,6 @@ namespace MissionPlanner.Utilities
 
         private static string filename = Settings.GetUserDataDirectory() + "poi.txt";
         private static bool loading;
-        private static bool bulkadd;
 
         static POI()
         {

--- a/plugins/FaceMap/FaceMapUI.cs
+++ b/plugins/FaceMap/FaceMapUI.cs
@@ -583,7 +583,6 @@ namespace MissionPlanner
             const decimal BENCH_ANGLE_MIN = 45;
 
             int strips = 0;
-            int images = 0;
             int a = 1;
             float routetotal = 0;
             List<PointLatLng> segment = new List<PointLatLng>();


### PR DESCRIPTION
I found a warning about unused variables.
I know that many warnings can obscure critical warnings.
I want to reduce the number of warnings by one or more.