### PR TITLE
ExtLibs: Change the judgment value

### DIFF
--- a/ExtLibs/Utilities/dfgpslag.cs
+++ b/ExtLibs/Utilities/dfgpslag.cs
@@ -69,7 +69,7 @@ namespace MissionPlanner.Utilities
             foreach (var i in Enumerable.Range(0, 100))
             {
                 var err = velocity_error(timestamps, vel, gaccel, accel_indexes, imu_dt, i);
-                if (err == null)
+                if (err == 0)
                     break;
                 errors.Add(err);
                 delays.Add(i * imu_dt);


### PR DESCRIPTION
I want to reduce the build warnings.
I set null to 0, because I want the return value to be a number.