### PR TITLE
GCSViews: Add options for RC15 and 16

### DIFF
--- a/GCSViews/ConfigurationView/ConfigUserDefined.cs
+++ b/GCSViews/ConfigurationView/ConfigUserDefined.cs
@@ -27,6 +27,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             "CH12_OPT",
             "CH13_OPT",
             "CH14_OPT",
+            "CH15_OPT",
+            "CH16_OPT",
 
             "RC6_OPTION",
             "RC7_OPTION",
@@ -36,7 +38,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             "RC11_OPTION",
             "RC12_OPTION",
             "RC13_OPTION",
-            "RC14_OPTION"
+            "RC14_OPTION",
+            "RC15_OPTION",
+            "RC16_OPTION"
         };
 
         public void LoadOptions()


### PR DESCRIPTION
I found out that there is no option for RC15 and RC16 in the user parameters.
I made it possible to set the options for RC15 and RC16.

AFTER:
![Screenshot from 2021-05-03 03-12-24](https://user-images.githubusercontent.com/646194/116823994-b7c3ce00-abc2-11eb-9987-75db5844f42e.png)

BEFORE:
![Screenshot from 2021-05-03 02-22-45](https://user-images.githubusercontent.com/646194/116824010-cd38f800-abc2-11eb-96f6-7c476b27fbb9.png)
