### PR TITLE
Global: Set the way point radius to a floating value

### DIFF
--- a/ExtLibs/Maps/GMapMarkerRect.cs
+++ b/ExtLibs/Maps/GMapMarkerRect.cs
@@ -30,7 +30,7 @@ namespace GMap.NET.WindowsForms
 
         public GMapMarker InnerMarker;
 
-        public int wprad = 0;
+        public double wprad = 0; 
 
         public void ResetColor()
         {

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -833,8 +833,8 @@ namespace MissionPlanner.GCSViews
                     mBorders.InnerMarker = m;
                     try
                     {
-                        mBorders.wprad =
-                            (int) (Settings.Instance.GetFloat("TXT_WPRad") / CurrentState.multiplierdist);
+                        mBorders.wprad = 
+                            (Settings.Instance.GetFloat("TXT_WPRad") / CurrentState.multiplierdist);
                     }
                     catch
                     {

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1558,8 +1558,8 @@ namespace MissionPlanner.GCSViews
                     mBorders.InnerMarker = m;
                     try
                     {
-                        mBorders.wprad =
-                            (int)(Settings.Instance.GetFloat("TXT_WPRad") / CurrentState.multiplieralt);
+                        mBorders.wprad = 
+                            (Settings.Instance.GetFloat("TXT_WPRad") / CurrentState.multiplieralt);
                     }
                     catch (Exception ex)
                     {
@@ -5858,11 +5858,11 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
 
                 if (param.ContainsKey("WP_RADIUS"))
                 {
-                    TXT_WPRad.Text = (((double)param["WP_RADIUS"] * CurrentState.multiplierdist)).ToString();
+                    TXT_WPRad.Text = string.Format("{0:N2}", (((double)param["WP_RADIUS"] * CurrentState.multiplierdist)));
                 }
                 if (param.ContainsKey("WPNAV_RADIUS"))
                 {
-                    TXT_WPRad.Text = (((double)param["WPNAV_RADIUS"] * CurrentState.multiplierdist / 100.0)).ToString();
+                    TXT_WPRad.Text = string.Format("{0:N2}", (((double)param["WPNAV_RADIUS"] * CurrentState.multiplierdist / 100.0)));
                 }
 
                 log.Info("param WP_RADIUS " + TXT_WPRad.Text);
@@ -6192,6 +6192,10 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
             float isNumber = 0;
             if (e.KeyChar.ToString() == "\b")
                 return;
+
+            if (e.KeyChar == '.')  // Allow floating values to be set.
+                return;
+
             e.Handled = !float.TryParse(e.KeyChar.ToString(), out isNumber);
         }
 


### PR DESCRIPTION
I can't set a value of centimeters for the WAY point radius in the flight planner.
I can set the centimeter value in the config parameter.
I would like to be able to set a floating value.