### PR TITLE
ExtLibs: Draw the WP radius as a floating value

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -402,7 +402,7 @@ namespace MissionPlanner.ArduPilot
                 {
                     mBorders.InnerMarker = m;
                     mBorders.Tag = tag;
-                    mBorders.wprad = (int)wpradius;
+                    mBorders.wprad = wpradius;
                     if (color.HasValue)
                     {
                         mBorders.Color = color.Value;


### PR DESCRIPTION
I learned that the WAY POINT radius drawing shows in meters.
I draw the WAY POINT radius in floating values.
By RTK, the positioning error is in centimeters.

AFTER：
![0606-8](https://user-images.githubusercontent.com/646194/120909816-011ca700-c6b4-11eb-86c8-59efdeceaa3c.png)