### PR TITLE
Updated Config -> Extended Tuning to include new filter values

### DIFF
--- a/ExtLibs/Mavlink/Mavlink.cs
+++ b/ExtLibs/Mavlink/Mavlink.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 public partial class MAVLink
 {
-    public const string MAVLINK_BUILD_DATE = "Thu Jun 10 2021";
+    public const string MAVLINK_BUILD_DATE = "Wed Jun 30 2021";
     public const string MAVLINK_WIRE_PROTOCOL_VERSION = "2.0";
     public const int MAVLINK_MAX_PAYLOAD_LEN = 255;
 
@@ -128,7 +128,7 @@ public partial class MAVLink
         new message_info(121, "LOG_ERASE", 237, 2, 2, typeof( mavlink_log_erase_t )),
         new message_info(122, "LOG_REQUEST_END", 203, 2, 2, typeof( mavlink_log_request_end_t )),
         new message_info(123, "GPS_INJECT_DATA", 250, 113, 113, typeof( mavlink_gps_inject_data_t )),
-        new message_info(124, "GPS2_RAW", 87, 35, 37, typeof( mavlink_gps2_raw_t )),
+        new message_info(124, "GPS2_RAW", 87, 35, 57, typeof( mavlink_gps2_raw_t )),
         new message_info(125, "POWER_STATUS", 203, 6, 6, typeof( mavlink_power_status_t )),
         new message_info(126, "SERIAL_CONTROL", 220, 79, 79, typeof( mavlink_serial_control_t )),
         new message_info(127, "GPS_RTK", 25, 35, 35, typeof( mavlink_gps_rtk_t )),
@@ -248,6 +248,7 @@ public partial class MAVLink
         new message_info(339, "RAW_RPM", 199, 5, 5, typeof( mavlink_raw_rpm_t )),
         new message_info(340, "UTM_GLOBAL_POSITION", 99, 70, 70, typeof( mavlink_utm_global_position_t )),
         new message_info(350, "DEBUG_FLOAT_ARRAY", 232, 20, 252, typeof( mavlink_debug_float_array_t )),
+        new message_info(370, "SMART_BATTERY_INFO", 75, 87, 109, typeof( mavlink_smart_battery_info_t )),
         new message_info(373, "GENERATOR_STATUS", 117, 42, 42, typeof( mavlink_generator_status_t )),
         new message_info(375, "ACTUATOR_OUTPUT_STATUS", 251, 140, 140, typeof( mavlink_actuator_output_status_t )),
         new message_info(9000, "WHEEL_DISTANCE", 113, 137, 137, typeof( mavlink_wheel_distance_t )),
@@ -273,6 +274,7 @@ public partial class MAVLink
         new message_info(11035, "OSD_PARAM_SHOW_CONFIG", 128, 8, 8, typeof( mavlink_osd_param_show_config_t )),
         new message_info(11036, "OSD_PARAM_SHOW_CONFIG_REPLY", 177, 34, 34, typeof( mavlink_osd_param_show_config_reply_t )),
         new message_info(11037, "OBSTACLE_DISTANCE_3D", 130, 28, 28, typeof( mavlink_obstacle_distance_3d_t )),
+        new message_info(11038, "WATER_DEPTH", 47, 38, 38, typeof( mavlink_water_depth_t )),
         new message_info(42000, "ICAROUS_HEARTBEAT", 227, 1, 1, typeof( mavlink_icarous_heartbeat_t )),
         new message_info(42001, "ICAROUS_KINEMATIC_BANDS", 239, 46, 46, typeof( mavlink_icarous_kinematic_bands_t )),
         new message_info(99269, "VIDEO_STREAM_INFORMATION99", 251, 213, 213, typeof( mavlink_video_stream_information99_t )),
@@ -525,6 +527,7 @@ public partial class MAVLink
         RAW_RPM = 339,
         UTM_GLOBAL_POSITION = 340,
         DEBUG_FLOAT_ARRAY = 350,
+        SMART_BATTERY_INFO = 370,
         GENERATOR_STATUS = 373,
         ACTUATOR_OUTPUT_STATUS = 375,
         WHEEL_DISTANCE = 9000,
@@ -550,6 +553,7 @@ public partial class MAVLink
         OSD_PARAM_SHOW_CONFIG = 11035,
         OSD_PARAM_SHOW_CONFIG_REPLY = 11036,
         OBSTACLE_DISTANCE_3D = 11037,
+        WATER_DEPTH = 11038,
         ICAROUS_HEARTBEAT = 42000,
         ICAROUS_KINEMATIC_BANDS = 42001,
         VIDEO_STREAM_INFORMATION99 = 99269,
@@ -870,6 +874,9 @@ public partial class MAVLink
         ///<summary> Arms / Disarms a component |0: disarm, 1: arm| 0: arm-disarm unless prevented by safety checks (i.e. when landed), 21196: force arming/disarming (e.g. allow arming to override preflight checks and disarming in flight)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)|  </summary>
         [Description("Arms / Disarms a component")]
         COMPONENT_ARM_DISARM=400, 
+        ///<summary> Instructs system to run pre-arm checks.  This command should return MAV_RESULT_TEMPORARILY_REJECTED in the case the system is armed, otherwse MAV_RESULT_ACCEPTED.  Note that the return value from executing this command does not indicate whether the vehicle is armable or not, just whether the system has successfully run/is currently running the checks.  The result of the checks is reflected in the SYS_STATUS message. |Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)|  </summary>
+        [Description("Instructs system to run pre-arm checks.  This command should return MAV_RESULT_TEMPORARILY_REJECTED in the case the system is armed, otherwse MAV_RESULT_ACCEPTED.  Note that the return value from executing this command does not indicate whether the vehicle is armable or not, just whether the system has successfully run/is currently running the checks.  The result of the checks is reflected in the SYS_STATUS message.")]
+        RUN_PREARM_CHECKS=401, 
         ///<summary> Request the home position from the vehicle. |Reserved| Reserved| Reserved| Reserved| Reserved| Reserved| Reserved|  </summary>
         [Description("Request the home position from the vehicle.")]
         GET_HOME_POSITION=410, 
@@ -882,7 +889,7 @@ public partial class MAVLink
         ///<summary> Set the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM. |The MAVLink message ID| The interval between two messages. Set to -1 to disable and 0 to request default rate.| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requestor, 2: broadcast.|  </summary>
         [Description("Set the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM.")]
         SET_MESSAGE_INTERVAL=511, 
-        ///<summary> Request the target system(s) emit a single instance of a specified message (i.e. a 'one-shot' version of MAV_CMD_SET_MESSAGE_INTERVAL). |The MAVLink message ID of the requested message.| Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| ress fields). 0: Flight-stack default, 1: address of requestor, 2: broadcast.|  </summary>
+        ///<summary> Request the target system(s) emit a single instance of a specified message (i.e. a 'one-shot' version of MAV_CMD_SET_MESSAGE_INTERVAL). |The MAVLink message ID of the requested message.| Use for index ID, if required. Otherwise, the use of this parameter (if any) must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| f any), must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).| Target address for requested message (if message has target address fields). 0: Flight-stack default, 1: address of requestor, 2: broadcast.|  </summary>
         [Description("Request the target system(s) emit a single instance of a specified message (i.e. a 'one-shot' version of MAV_CMD_SET_MESSAGE_INTERVAL).")]
         REQUEST_MESSAGE=512, 
         ///<summary> Request MAVLink protocol version compatibility. All receivers should ACK the command and then emit their capabilities in an PROTOCOL_VERSION message |1: Request supported protocol versions by all nodes on the network| Reserved (all remaining params)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)| Reserved (default:0)|  </summary>
@@ -1005,7 +1012,7 @@ public partial class MAVLink
         ///<summary> Commands the vehicle to respond with a sequence of messages UAVCAN_NODE_INFO, one message per every UAVCAN node that is online. Note that some of the response messages can be lost, which the receiver can detect easily by checking whether every received UAVCAN_NODE_STATUS has a matching message UAVCAN_NODE_INFO received earlier; if not, this command should be sent again in order to request re-transmission of the node information messages. |Reserved (set to 0)| Reserved (set to 0)| Reserved (set to 0)| Reserved (set to 0)| Reserved (set to 0)| Reserved (set to 0)| Reserved (set to 0)|  </summary>
         [Description("Commands the vehicle to respond with a sequence of messages UAVCAN_NODE_INFO, one message per every UAVCAN node that is online. Note that some of the response messages can be lost, which the receiver can detect easily by checking whether every received UAVCAN_NODE_STATUS has a matching message UAVCAN_NODE_INFO received earlier; if not, this command should be sent again in order to request re-transmission of the node information messages.")]
         UAVCAN_GET_NODE_INFO=5200, 
-        ///<summary> Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity. |Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.| Desired approach vector in compass heading. A negative value indicates the system can define the approach vector at will.| Desired ground speed at release time. This can be overridden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.| Minimum altitude clearance to the release position. A negative value indicates the system can define the clearance at will.| Latitude. Note, if used in MISSION_ITEM (deprecated) the units are degrees (unscaled)| Longitude. Note, if used in MISSION_ITEM (deprecated) the units are degrees (unscaled)| Altitude (MSL)|  </summary>
+        ///<summary> Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity. |Operation mode. 0: prepare single payload deploy (overwriting previous requests), but do not execute it. 1: execute payload deploy immediately (rejecting further deploy commands during execution, but allowing abort). 2: add payload deploy to existing deployment list.| Desired approach vector in compass heading. A negative value indicates the system can define the approach vector at will.| round speed at release time. This can be overridden by the airframe in case it needs to meet minimum airspeed. A negative value indicates the system can define the ground speed at will.| Minimum altitude clearance to the release position. A negative value indicates the system can define the clearance at will.| Latitude. Note, if used in MISSION_ITEM (deprecated) the units are degrees (unscaled)| Longitude. Note, if used in MISSION_ITEM (deprecated) the units are degrees (unscaled)| Altitude (MSL)|  </summary>
         [Description("Deploy payload on a Lat / Lon / Alt position. This includes the navigation to reach the required release position and velocity.")]
         PAYLOAD_PREPARE_DEPLOY=30001, 
         ///<summary> Control the payload deployment. |Operation mode. 0: Abort deployment, continue normal mission. 1: switch to payload deployment mode. 100: delete first payload deployment request. 101: delete all payload deployment requests.| Reserved| Reserved| Reserved| Reserved| Reserved| Reserved|  </summary>
@@ -1041,7 +1048,7 @@ public partial class MAVLink
         ///<summary> User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item. |User defined| User defined| User defined| User defined| Latitude unscaled| Longitude unscaled| Altitude (MSL)|  </summary>
         [Description("User defined spatial item. Ground Station will not show the Vehicle as flying through this item. Example: ROI item.")]
         SPATIAL_USER_5=31009, 
-        ///<summary> User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item. |User defined| User defined| User defined| User defined| User defined| User defined| User defined|  </summary>
+        ///<summary> User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item. |User defined| User defined| fined| User defined| User defined| User defined| User defined|  </summary>
         [Description("User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item.")]
         USER_1=31010, 
         ///<summary> User defined command. Ground Station will not show the Vehicle as flying through this item. Example: MAV_CMD_DO_SET_PARAMETER item. |User defined| User defined| User defined| User defined| User defined| User defined| User defined|  </summary>
@@ -1074,7 +1081,7 @@ public partial class MAVLink
         ///<summary> Magnetometer calibration based on fixed expected field values. |Field strength X.| Field strength Y.| Field strength Z.| Empty.| Empty.| Empty.| Empty.|  </summary>
         [Description("Magnetometer calibration based on fixed expected field values.")]
         FIXED_MAG_CAL_FIELD=42005, 
-        ///<summary> Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location. |Yaw of vehicle in earth frame.| CompassMask, 0 for all.| Latitude.| Longitude.| Empty.| Empty.| Empty.|  </summary>
+        ///<summary> Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location. |vehicle in earth frame.| CompassMask, 0 for all.| Latitude.| Longitude.| Empty.| Empty.| Empty.|  </summary>
         [Description("Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.")]
         FIXED_MAG_CAL_YAW=42006, 
         ///<summary> Initiate a magnetometer calibration. |Bitmask of magnetometers to calibrate. Use 0 to calibrate all sensors that can be started (sensors may not start if disabled, unhealthy, etc.). The command will NACK if calibration does not start for a sensor explicitly specified by the bitmask.| Automatically retry on failure (0=no retry, 1=retry).| Save without user input (0=require input, 1=autosave).| Delay.| Autoreboot (0=user reboot, 1=autoreboot).| Empty.| Empty.|  </summary>
@@ -8327,6 +8334,74 @@ public partial class MAVLink
     
     };
 
+    
+    /// extensions_start 0
+    [StructLayout(LayoutKind.Sequential,Pack=1,Size=38)]
+    ///<summary> Water depth </summary>
+    public struct mavlink_water_depth_t
+    {
+        public mavlink_water_depth_t(uint time_boot_ms,int lat,int lng,float alt,float roll,float pitch,float yaw,float distance,float temperature,byte id,byte healthy) 
+        {
+              this.time_boot_ms = time_boot_ms;
+              this.lat = lat;
+              this.lng = lng;
+              this.alt = alt;
+              this.roll = roll;
+              this.pitch = pitch;
+              this.yaw = yaw;
+              this.distance = distance;
+              this.temperature = temperature;
+              this.id = id;
+              this.healthy = healthy;
+            
+        }
+        /// <summary>Timestamp (time since system boot)  [ms] </summary>
+        [Units("[ms]")]
+        [Description("Timestamp (time since system boot)")]
+        public  uint time_boot_ms;
+            /// <summary>Latitude  [degE7] </summary>
+        [Units("[degE7]")]
+        [Description("Latitude")]
+        public  int lat;
+            /// <summary>Longitude  [degE7] </summary>
+        [Units("[degE7]")]
+        [Description("Longitude")]
+        public  int lng;
+            /// <summary>Altitude (MSL) of vehicle  [m] </summary>
+        [Units("[m]")]
+        [Description("Altitude (MSL) of vehicle")]
+        public  float alt;
+            /// <summary>Roll angle  [rad] </summary>
+        [Units("[rad]")]
+        [Description("Roll angle")]
+        public  float roll;
+            /// <summary>Pitch angle  [rad] </summary>
+        [Units("[rad]")]
+        [Description("Pitch angle")]
+        public  float pitch;
+            /// <summary>Yaw angle  [rad] </summary>
+        [Units("[rad]")]
+        [Description("Yaw angle")]
+        public  float yaw;
+            /// <summary>Distance (uncorrected)  [m] </summary>
+        [Units("[m]")]
+        [Description("Distance (uncorrected)")]
+        public  float distance;
+            /// <summary>Water temperature  [degC] </summary>
+        [Units("[degC]")]
+        [Description("Water temperature")]
+        public  float temperature;
+            /// <summary>Onboard ID of the sensor   </summary>
+        [Units("")]
+        [Description("Onboard ID of the sensor")]
+        public  byte id;
+            /// <summary>Sensor data healthy (0=unhealthy, 1=healthy)   </summary>
+        [Units("")]
+        [Description("Sensor data healthy (0=unhealthy, 1=healthy)")]
+        public  byte healthy;
+    
+    };
+
     [Obsolete]
     /// extensions_start 0
     [StructLayout(LayoutKind.Sequential,Pack=1,Size=246)]
@@ -13263,11 +13338,11 @@ public partial class MAVLink
 
     
     /// extensions_start 12
-    [StructLayout(LayoutKind.Sequential,Pack=1,Size=37)]
+    [StructLayout(LayoutKind.Sequential,Pack=1,Size=57)]
     ///<summary> Second GPS data. </summary>
     public struct mavlink_gps2_raw_t
     {
-        public mavlink_gps2_raw_t(ulong time_usec,int lat,int lon,int alt,uint dgps_age,ushort eph,ushort epv,ushort vel,ushort cog,/*GPS_FIX_TYPE*/byte fix_type,byte satellites_visible,byte dgps_numch,ushort yaw) 
+        public mavlink_gps2_raw_t(ulong time_usec,int lat,int lon,int alt,uint dgps_age,ushort eph,ushort epv,ushort vel,ushort cog,/*GPS_FIX_TYPE*/byte fix_type,byte satellites_visible,byte dgps_numch,ushort yaw,int alt_ellipsoid,uint h_acc,uint v_acc,uint vel_acc,uint hdg_acc) 
         {
               this.time_usec = time_usec;
               this.lat = lat;
@@ -13282,6 +13357,11 @@ public partial class MAVLink
               this.satellites_visible = satellites_visible;
               this.dgps_numch = dgps_numch;
               this.yaw = yaw;
+              this.alt_ellipsoid = alt_ellipsoid;
+              this.h_acc = h_acc;
+              this.v_acc = v_acc;
+              this.vel_acc = vel_acc;
+              this.hdg_acc = hdg_acc;
             
         }
         /// <summary>Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.  [us] </summary>
@@ -13336,6 +13416,26 @@ public partial class MAVLink
         [Units("[cdeg]")]
         [Description("Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.")]
         public  ushort yaw;
+            /// <summary>Altitude (above WGS84, EGM96 ellipsoid). Positive for up.  [mm] </summary>
+        [Units("[mm]")]
+        [Description("Altitude (above WGS84, EGM96 ellipsoid). Positive for up.")]
+        public  int alt_ellipsoid;
+            /// <summary>Position uncertainty.  [mm] </summary>
+        [Units("[mm]")]
+        [Description("Position uncertainty.")]
+        public  uint h_acc;
+            /// <summary>Altitude uncertainty.  [mm] </summary>
+        [Units("[mm]")]
+        [Description("Altitude uncertainty.")]
+        public  uint v_acc;
+            /// <summary>Speed uncertainty.  [mm] </summary>
+        [Units("[mm]")]
+        [Description("Speed uncertainty.")]
+        public  uint vel_acc;
+            /// <summary>Heading / track uncertainty  [degE5] </summary>
+        [Units("[degE5]")]
+        [Description("Heading / track uncertainty")]
+        public  uint hdg_acc;
     
     };
 
@@ -17287,6 +17387,107 @@ public partial class MAVLink
         [Description("data")]
         [MarshalAs(UnmanagedType.ByValArray,SizeConst=58)]
 		public float[] data;
+    
+    };
+
+    
+    /// extensions_start 12
+    [StructLayout(LayoutKind.Sequential,Pack=1,Size=109)]
+    ///<summary> Smart Battery information (static/infrequent update). Use for updates from: smart battery to flight stack, flight stack to GCS. Use BATTERY_STATUS for smart battery frequent updates. </summary>
+    public struct mavlink_smart_battery_info_t
+    {
+        public mavlink_smart_battery_info_t(int capacity_full_specification,int capacity_full,ushort cycle_count,ushort weight,ushort discharge_minimum_voltage,ushort charging_minimum_voltage,ushort resting_minimum_voltage,byte id,/*MAV_BATTERY_FUNCTION*/byte battery_function,/*MAV_BATTERY_TYPE*/byte type,byte[] serial_number,byte[] device_name,ushort charging_maximum_voltage,byte cells_in_series,uint discharge_maximum_current,uint discharge_maximum_burst_current,byte[] manufacture_date) 
+        {
+              this.capacity_full_specification = capacity_full_specification;
+              this.capacity_full = capacity_full;
+              this.cycle_count = cycle_count;
+              this.weight = weight;
+              this.discharge_minimum_voltage = discharge_minimum_voltage;
+              this.charging_minimum_voltage = charging_minimum_voltage;
+              this.resting_minimum_voltage = resting_minimum_voltage;
+              this.id = id;
+              this.battery_function = battery_function;
+              this.type = type;
+              this.serial_number = serial_number;
+              this.device_name = device_name;
+              this.charging_maximum_voltage = charging_maximum_voltage;
+              this.cells_in_series = cells_in_series;
+              this.discharge_maximum_current = discharge_maximum_current;
+              this.discharge_maximum_burst_current = discharge_maximum_burst_current;
+              this.manufacture_date = manufacture_date;
+            
+        }
+        /// <summary>Capacity when full according to manufacturer, -1: field not provided.  [mAh] </summary>
+        [Units("[mAh]")]
+        [Description("Capacity when full according to manufacturer, -1: field not provided.")]
+        public  int capacity_full_specification;
+            /// <summary>Capacity when full (accounting for battery degradation), -1: field not provided.  [mAh] </summary>
+        [Units("[mAh]")]
+        [Description("Capacity when full (accounting for battery degradation), -1: field not provided.")]
+        public  int capacity_full;
+            /// <summary>Charge/discharge cycle count. UINT16_MAX: field not provided.   </summary>
+        [Units("")]
+        [Description("Charge/discharge cycle count. UINT16_MAX: field not provided.")]
+        public  ushort cycle_count;
+            /// <summary>Battery weight. 0: field not provided.  [g] </summary>
+        [Units("[g]")]
+        [Description("Battery weight. 0: field not provided.")]
+        public  ushort weight;
+            /// <summary>Minimum per-cell voltage when discharging. If not supplied set to UINT16_MAX value.  [mV] </summary>
+        [Units("[mV]")]
+        [Description("Minimum per-cell voltage when discharging. If not supplied set to UINT16_MAX value.")]
+        public  ushort discharge_minimum_voltage;
+            /// <summary>Minimum per-cell voltage when charging. If not supplied set to UINT16_MAX value.  [mV] </summary>
+        [Units("[mV]")]
+        [Description("Minimum per-cell voltage when charging. If not supplied set to UINT16_MAX value.")]
+        public  ushort charging_minimum_voltage;
+            /// <summary>Minimum per-cell voltage when resting. If not supplied set to UINT16_MAX value.  [mV] </summary>
+        [Units("[mV]")]
+        [Description("Minimum per-cell voltage when resting. If not supplied set to UINT16_MAX value.")]
+        public  ushort resting_minimum_voltage;
+            /// <summary>Battery ID   </summary>
+        [Units("")]
+        [Description("Battery ID")]
+        public  byte id;
+            /// <summary>Function of the battery MAV_BATTERY_FUNCTION  </summary>
+        [Units("")]
+        [Description("Function of the battery")]
+        public  /*MAV_BATTERY_FUNCTION*/byte battery_function;
+            /// <summary>Type (chemistry) of the battery MAV_BATTERY_TYPE  </summary>
+        [Units("")]
+        [Description("Type (chemistry) of the battery")]
+        public  /*MAV_BATTERY_TYPE*/byte type;
+            /// <summary>Serial number in ASCII characters, 0 terminated. All 0: field not provided.   </summary>
+        [Units("")]
+        [Description("Serial number in ASCII characters, 0 terminated. All 0: field not provided.")]
+        [MarshalAs(UnmanagedType.ByValArray,SizeConst=16)]
+		public byte[] serial_number;
+            /// <summary>Static device name in ASCII characters, 0 terminated. All 0: field not provided. Encode as manufacturer name then product name separated using an underscore.   </summary>
+        [Units("")]
+        [Description("Static device name in ASCII characters, 0 terminated. All 0: field not provided. Encode as manufacturer name then product name separated using an underscore.")]
+        [MarshalAs(UnmanagedType.ByValArray,SizeConst=50)]
+		public byte[] device_name;
+            /// <summary>Maximum per-cell voltage when charged. 0: field not provided.  [mV] </summary>
+        [Units("[mV]")]
+        [Description("Maximum per-cell voltage when charged. 0: field not provided.")]
+        public  ushort charging_maximum_voltage;
+            /// <summary>Number of battery cells in series. 0: field not provided.   </summary>
+        [Units("")]
+        [Description("Number of battery cells in series. 0: field not provided.")]
+        public  byte cells_in_series;
+            /// <summary>Maximum pack discharge current. 0: field not provided.  [mA] </summary>
+        [Units("[mA]")]
+        [Description("Maximum pack discharge current. 0: field not provided.")]
+        public  uint discharge_maximum_current;
+            /// <summary>Maximum pack discharge burst current. 0: field not provided.  [mA] </summary>
+        [Units("[mA]")]
+        [Description("Maximum pack discharge burst current. 0: field not provided.")]
+        public  uint discharge_maximum_burst_current;
+            /// <summary>Manufacture date (DD/MM/YYYY) in ASCII characters, 0 terminated. All 0: field not provided.   </summary>
+        [Units("")]
+        [Description("Manufacture date (DD/MM/YYYY) in ASCII characters, 0 terminated. All 0: field not provided.")]
+        [MarshalAs(UnmanagedType.ByValArray,SizeConst=11)]
+		public byte[] manufacture_date;
     
     };
 

--- a/ExtLibs/Mavlink/message_definitions/ardupilotmega.xml
+++ b/ExtLibs/Mavlink/message_definitions/ardupilotmega.xml
@@ -332,7 +332,7 @@
       </entry>
     </enum>
     <!-- AP_Limits Modules - power of 2 (1,2,4,8,16,32 etc) so we can send as bitfield -->
-    <enum name="LIMIT_MODULE">
+    <enum name="LIMIT_MODULE" bitmask="true">
       <entry value="1" name="LIMIT_GPSLOCK">
         <description>Pre-initialization.</description>
       </entry>
@@ -344,7 +344,7 @@
       </entry>
     </enum>
     <!-- RALLY flags - power of 2 (1,2,4,8,16,32,64,128) so we can send as a bitfield -->
-    <enum name="RALLY_FLAGS">
+    <enum name="RALLY_FLAGS" bitmask="true">
       <description>Flags in RALLY_POINT message.</description>
       <entry value="1" name="FAVORABLE_WIND">
         <description>Flag set when requiring favorable winds for landing.</description>
@@ -467,7 +467,7 @@
         <description>An unrecoverable error was encountered with the connected GoPro, it may require a power cycle.</description>
       </entry>
     </enum>
-    <enum name="GOPRO_HEARTBEAT_FLAGS">
+    <enum name="GOPRO_HEARTBEAT_FLAGS" bitmask="true">
       <!-- each entry is a mask to test a bit in GOPRO_HEARTBEAT_STATUS.flags -->
       <entry value="1" name="GOPRO_FLAG_RECORDING">
         <description>GoPro is currently recording.</description>
@@ -661,7 +661,7 @@
         <description>0x02: Narrow.</description>
       </entry>
     </enum>
-    <enum name="GOPRO_VIDEO_SETTINGS_FLAGS">
+    <enum name="GOPRO_VIDEO_SETTINGS_FLAGS" bitmask="true">
       <entry value="1" name="GOPRO_VIDEO_SETTINGS_TV_MODE">
         <description>0=NTSC, 1=PAL.</description>
       </entry>
@@ -879,7 +879,7 @@
       </entry>
     </enum>
     <!-- EKF_STATUS_FLAGS - these values should be bit-and with the messages flags field to know if flag has been set -->
-    <enum name="EKF_STATUS_FLAGS">
+    <enum name="EKF_STATUS_FLAGS" bitmask="true">
       <description>Flags in EKF_STATUS message.</description>
       <entry value="1" name="EKF_ATTITUDE">
         <description>Set if EKF's attitude estimate is good.</description>
@@ -1707,6 +1707,20 @@
       <field type="float" name="z" units="m"> Z position of the obstacle.</field>
       <field type="float" name="min_distance" units="m">Minimum distance the sensor can measure.</field>
       <field type="float" name="max_distance" units="m">Maximum distance the sensor can measure.</field>
+    </message>
+    <message id="11038" name="WATER_DEPTH">
+      <description>Water depth</description>
+      <field type="uint32_t" name="time_boot_ms" units="ms">Timestamp (time since system boot)</field>
+      <field type="uint8_t" name="id" instance="true">Onboard ID of the sensor</field>
+      <field type="uint8_t" name="healthy">Sensor data healthy (0=unhealthy, 1=healthy)</field>
+      <field type="int32_t" name="lat" units="degE7">Latitude</field>
+      <field type="int32_t" name="lng" units="degE7">Longitude</field>
+      <field type="float" name="alt" units="m">Altitude (MSL) of vehicle</field>
+      <field type="float" name="roll" units="rad">Roll angle</field>
+      <field type="float" name="pitch" units="rad">Pitch angle</field>
+      <field type="float" name="yaw" units="rad">Yaw angle</field>
+      <field type="float" name="distance" units="m">Distance (uncorrected)</field>
+      <field type="float" name="temperature" units="degC">Water temperature</field>
     </message>
   </messages>
 </mavlink>

--- a/ExtLibs/Mavlink/message_definitions/common.xml
+++ b/ExtLibs/Mavlink/message_definitions/common.xml
@@ -1248,6 +1248,9 @@
         <param index="1" label="Arm" minValue="0" maxValue="1" increment="1">0: disarm, 1: arm</param>
         <param index="2" label="Force" minValue="0" maxValue="21196" increment="21196">0: arm-disarm unless prevented by safety checks (i.e. when landed), 21196: force arming/disarming (e.g. allow arming to override preflight checks and disarming in flight)</param>
       </entry>
+      <entry value="401" name="MAV_CMD_RUN_PREARM_CHECKS" hasLocation="false" isDestination="false">
+        <description>Instructs system to run pre-arm checks.  This command should return MAV_RESULT_TEMPORARILY_REJECTED in the case the system is armed, otherwse MAV_RESULT_ACCEPTED.  Note that the return value from executing this command does not indicate whether the vehicle is armable or not, just whether the system has successfully run/is currently running the checks.  The result of the checks is reflected in the SYS_STATUS message.</description>
+      </entry>
       <entry value="410" name="MAV_CMD_GET_HOME_POSITION" hasLocation="false" isDestination="false">
         <description>Request the home position from the vehicle.</description>
         <param index="1">Reserved</param>
@@ -4241,6 +4244,11 @@
       <field type="uint32_t" name="dgps_age" units="ms">Age of DGPS info</field>
       <extensions/>
       <field type="uint16_t" name="yaw" units="cdeg">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
+      <field type="int32_t" name="alt_ellipsoid" units="mm">Altitude (above WGS84, EGM96 ellipsoid). Positive for up.</field>
+      <field type="uint32_t" name="h_acc" units="mm">Position uncertainty.</field>
+      <field type="uint32_t" name="v_acc" units="mm">Altitude uncertainty.</field>
+      <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty.</field>
+      <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
     </message>
     <message id="125" name="POWER_STATUS">
       <description>Power supply status</description>
@@ -5081,6 +5089,27 @@
       <field type="uint16_t" name="array_id" instance="true">Unique ID used to discriminate between arrays</field>
       <extensions/>
       <field type="float[58]" name="data">data</field>
+    </message>
+    <message id="370" name="SMART_BATTERY_INFO">
+      <description>Smart Battery information (static/infrequent update). Use for updates from: smart battery to flight stack, flight stack to GCS. Use BATTERY_STATUS for smart battery frequent updates.</description>
+      <field type="uint8_t" name="id" instance="true">Battery ID</field>
+      <field type="uint8_t" name="battery_function" enum="MAV_BATTERY_FUNCTION">Function of the battery</field>
+      <field type="uint8_t" name="type" enum="MAV_BATTERY_TYPE">Type (chemistry) of the battery</field>
+      <field type="int32_t" name="capacity_full_specification" units="mAh">Capacity when full according to manufacturer, -1: field not provided.</field>
+      <field type="int32_t" name="capacity_full" units="mAh">Capacity when full (accounting for battery degradation), -1: field not provided.</field>
+      <field type="uint16_t" name="cycle_count">Charge/discharge cycle count. UINT16_MAX: field not provided.</field>
+      <field type="char[16]" name="serial_number">Serial number in ASCII characters, 0 terminated. All 0: field not provided.</field>
+      <field type="char[50]" name="device_name">Static device name in ASCII characters, 0 terminated. All 0: field not provided. Encode as manufacturer name then product name separated using an underscore.</field>
+      <field type="uint16_t" name="weight" units="g">Battery weight. 0: field not provided.</field>
+      <field type="uint16_t" name="discharge_minimum_voltage" units="mV">Minimum per-cell voltage when discharging. If not supplied set to UINT16_MAX value.</field>
+      <field type="uint16_t" name="charging_minimum_voltage" units="mV">Minimum per-cell voltage when charging. If not supplied set to UINT16_MAX value.</field>
+      <field type="uint16_t" name="resting_minimum_voltage" units="mV">Minimum per-cell voltage when resting. If not supplied set to UINT16_MAX value.</field>
+      <extensions/>
+      <field type="uint16_t" name="charging_maximum_voltage" units="mV">Maximum per-cell voltage when charged. 0: field not provided.</field>
+      <field type="uint8_t" name="cells_in_series">Number of battery cells in series. 0: field not provided.</field>
+      <field type="uint32_t" name="discharge_maximum_current" units="mA">Maximum pack discharge current. 0: field not provided.</field>
+      <field type="uint32_t" name="discharge_maximum_burst_current" units="mA">Maximum pack discharge burst current. 0: field not provided.</field>
+      <field type="char[11]" name="manufacture_date">Manufacture date (DD/MM/YYYY) in ASCII characters, 0 terminated. All 0: field not provided.</field>
     </message>
     <message id="373" name="GENERATOR_STATUS">
       <description>Telemetry of power generation system. Alternator or mechanical generator.</description>

--- a/GCSViews/ConfigurationView/ConfigArducopter.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.Designer.cs
@@ -75,6 +75,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.STB_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label46 = new System.Windows.Forms.Label();
             this.groupBox23 = new System.Windows.Forms.GroupBox();
+            this.ATC_RAT_YAW_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label33 = new System.Windows.Forms.Label();
+            this.ATC_RAT_YAW_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label32 = new System.Windows.Forms.Label();
             this.RATE_YAW_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label18 = new System.Windows.Forms.Label();
             this.RATE_YAW_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
@@ -86,6 +90,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.RATE_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label82 = new System.Windows.Forms.Label();
             this.groupBox24 = new System.Windows.Forms.GroupBox();
+            this.ATC_RAT_RLL_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label30 = new System.Windows.Forms.Label();
+            this.ATC_RAT_RLL_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label29 = new System.Windows.Forms.Label();
             this.RATE_PIT_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label14 = new System.Windows.Forms.Label();
             this.RATE_PIT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
@@ -97,6 +105,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.RATE_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label87 = new System.Windows.Forms.Label();
             this.groupBox25 = new System.Windows.Forms.GroupBox();
+            this.ATC_RAT_PIT_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label28 = new System.Windows.Forms.Label();
+            this.ATC_RAT_PIT_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.P_FLTD = new System.Windows.Forms.Label();
             this.RATE_RLL_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label12 = new System.Windows.Forms.Label();
             this.RATE_RLL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
@@ -138,6 +150,44 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.CH9_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.myLabel6 = new System.Windows.Forms.Label();
             this.CH10_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.INS_ACCEL_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label26 = new System.Windows.Forms.Label();
+            this.INS_GYRO_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label24 = new System.Windows.Forms.Label();
+            this.groupBox9 = new System.Windows.Forms.GroupBox();
+            this.INS_HNTCH_HMNCS = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label51 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_OPTS = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label50 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label49 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label48 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label41 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_REF = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label43 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_MODE = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label44 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_ENABLE = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label45 = new System.Windows.Forms.Label();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.INS_NOTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label40 = new System.Windows.Forms.Label();
+            this.INS_NOTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label39 = new System.Windows.Forms.Label();
+            this.INS_NOTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label38 = new System.Windows.Forms.Label();
+            this.INS_NOTCH_ENABLE = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label37 = new System.Windows.Forms.Label();
+            this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.INS_LOG_BAT_OPT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label36 = new System.Windows.Forms.Label();
+            this.INS_LOG_BAT_MASK = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.label34 = new System.Windows.Forms.Label();
+            this.label52 = new System.Windows.Forms.Label();
+            this.CH6_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).BeginInit();
             this.groupBox5.SuspendLayout();
@@ -163,18 +213,24 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).BeginInit();
             this.groupBox23.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_D)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).BeginInit();
             this.groupBox24.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).BeginInit();
             this.groupBox25.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).BeginInit();
@@ -190,6 +246,26 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).BeginInit();
+            this.groupBox3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).BeginInit();
+            this.groupBox9.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ATT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ENABLE)).BeginInit();
+            this.groupBox8.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ENABLE)).BeginInit();
+            this.groupBox6.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_OPT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_MASK)).BeginInit();
             this.SuspendLayout();
             // 
             // TUNE_LOW
@@ -524,6 +600,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // groupBox23
             // 
+            this.groupBox23.Controls.Add(this.ATC_RAT_YAW_FLTT);
+            this.groupBox23.Controls.Add(this.label33);
+            this.groupBox23.Controls.Add(this.ATC_RAT_YAW_FLTD);
+            this.groupBox23.Controls.Add(this.label32);
             this.groupBox23.Controls.Add(this.RATE_YAW_FILT);
             this.groupBox23.Controls.Add(this.label18);
             this.groupBox23.Controls.Add(this.RATE_YAW_D);
@@ -537,6 +617,34 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox23, "groupBox23");
             this.groupBox23.Name = "groupBox23";
             this.groupBox23.TabStop = false;
+            // 
+            // ATC_RAT_YAW_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_YAW_FLTT, "ATC_RAT_YAW_FLTT");
+            this.ATC_RAT_YAW_FLTT.Max = 1F;
+            this.ATC_RAT_YAW_FLTT.Min = 0F;
+            this.ATC_RAT_YAW_FLTT.Name = "ATC_RAT_YAW_FLTT";
+            this.ATC_RAT_YAW_FLTT.ParamName = null;
+            this.ATC_RAT_YAW_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label33
+            // 
+            resources.ApplyResources(this.label33, "label33");
+            this.label33.Name = "label33";
+            // 
+            // ATC_RAT_YAW_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_YAW_FLTD, "ATC_RAT_YAW_FLTD");
+            this.ATC_RAT_YAW_FLTD.Max = 1F;
+            this.ATC_RAT_YAW_FLTD.Min = 0F;
+            this.ATC_RAT_YAW_FLTD.Name = "ATC_RAT_YAW_FLTD";
+            this.ATC_RAT_YAW_FLTD.ParamName = null;
+            this.ATC_RAT_YAW_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label32
+            // 
+            resources.ApplyResources(this.label32, "label32");
+            this.label32.Name = "label32";
             // 
             // RATE_YAW_FILT
             // 
@@ -610,6 +718,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // groupBox24
             // 
+            this.groupBox24.Controls.Add(this.ATC_RAT_RLL_FLTT);
+            this.groupBox24.Controls.Add(this.label30);
+            this.groupBox24.Controls.Add(this.ATC_RAT_RLL_FLTD);
+            this.groupBox24.Controls.Add(this.label29);
             this.groupBox24.Controls.Add(this.RATE_PIT_FILT);
             this.groupBox24.Controls.Add(this.label14);
             this.groupBox24.Controls.Add(this.RATE_PIT_D);
@@ -623,6 +735,34 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox24, "groupBox24");
             this.groupBox24.Name = "groupBox24";
             this.groupBox24.TabStop = false;
+            // 
+            // ATC_RAT_RLL_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_RLL_FLTT, "ATC_RAT_RLL_FLTT");
+            this.ATC_RAT_RLL_FLTT.Max = 1F;
+            this.ATC_RAT_RLL_FLTT.Min = 0F;
+            this.ATC_RAT_RLL_FLTT.Name = "ATC_RAT_RLL_FLTT";
+            this.ATC_RAT_RLL_FLTT.ParamName = null;
+            this.ATC_RAT_RLL_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label30
+            // 
+            resources.ApplyResources(this.label30, "label30");
+            this.label30.Name = "label30";
+            // 
+            // ATC_RAT_RLL_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_RLL_FLTD, "ATC_RAT_RLL_FLTD");
+            this.ATC_RAT_RLL_FLTD.Max = 1F;
+            this.ATC_RAT_RLL_FLTD.Min = 0F;
+            this.ATC_RAT_RLL_FLTD.Name = "ATC_RAT_RLL_FLTD";
+            this.ATC_RAT_RLL_FLTD.ParamName = null;
+            this.ATC_RAT_RLL_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label29
+            // 
+            resources.ApplyResources(this.label29, "label29");
+            this.label29.Name = "label29";
             // 
             // RATE_PIT_FILT
             // 
@@ -696,6 +836,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // groupBox25
             // 
+            this.groupBox25.Controls.Add(this.ATC_RAT_PIT_FLTT);
+            this.groupBox25.Controls.Add(this.label28);
+            this.groupBox25.Controls.Add(this.ATC_RAT_PIT_FLTD);
+            this.groupBox25.Controls.Add(this.P_FLTD);
             this.groupBox25.Controls.Add(this.RATE_RLL_FILT);
             this.groupBox25.Controls.Add(this.label12);
             this.groupBox25.Controls.Add(this.RATE_RLL_D);
@@ -709,6 +853,34 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox25, "groupBox25");
             this.groupBox25.Name = "groupBox25";
             this.groupBox25.TabStop = false;
+            // 
+            // ATC_RAT_PIT_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_PIT_FLTT, "ATC_RAT_PIT_FLTT");
+            this.ATC_RAT_PIT_FLTT.Max = 1F;
+            this.ATC_RAT_PIT_FLTT.Min = 0F;
+            this.ATC_RAT_PIT_FLTT.Name = "ATC_RAT_PIT_FLTT";
+            this.ATC_RAT_PIT_FLTT.ParamName = null;
+            this.ATC_RAT_PIT_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label28
+            // 
+            resources.ApplyResources(this.label28, "label28");
+            this.label28.Name = "label28";
+            // 
+            // ATC_RAT_PIT_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_PIT_FLTD, "ATC_RAT_PIT_FLTD");
+            this.ATC_RAT_PIT_FLTD.Max = 1F;
+            this.ATC_RAT_PIT_FLTD.Min = 0F;
+            this.ATC_RAT_PIT_FLTD.Name = "ATC_RAT_PIT_FLTD";
+            this.ATC_RAT_PIT_FLTD.ParamName = null;
+            this.ATC_RAT_PIT_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // P_FLTD
+            // 
+            resources.ApplyResources(this.P_FLTD, "P_FLTD");
+            this.P_FLTD.Name = "P_FLTD";
             // 
             // RATE_RLL_FILT
             // 
@@ -1013,9 +1185,311 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.CH10_OPTION.ParamName = null;
             this.CH10_OPTION.SubControl = null;
             // 
+            // groupBox3
+            // 
+            this.groupBox3.Controls.Add(this.INS_ACCEL_FILTER);
+            this.groupBox3.Controls.Add(this.label26);
+            this.groupBox3.Controls.Add(this.INS_GYRO_FILTER);
+            this.groupBox3.Controls.Add(this.label24);
+            resources.ApplyResources(this.groupBox3, "groupBox3");
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.TabStop = false;
+            // 
+            // INS_ACCEL_FILTER
+            // 
+            resources.ApplyResources(this.INS_ACCEL_FILTER, "INS_ACCEL_FILTER");
+            this.INS_ACCEL_FILTER.Max = 1F;
+            this.INS_ACCEL_FILTER.Min = 0F;
+            this.INS_ACCEL_FILTER.Name = "INS_ACCEL_FILTER";
+            this.INS_ACCEL_FILTER.ParamName = null;
+            this.INS_ACCEL_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label26
+            // 
+            resources.ApplyResources(this.label26, "label26");
+            this.label26.Name = "label26";
+            // 
+            // INS_GYRO_FILTER
+            // 
+            resources.ApplyResources(this.INS_GYRO_FILTER, "INS_GYRO_FILTER");
+            this.INS_GYRO_FILTER.Max = 1F;
+            this.INS_GYRO_FILTER.Min = 0F;
+            this.INS_GYRO_FILTER.Name = "INS_GYRO_FILTER";
+            this.INS_GYRO_FILTER.ParamName = null;
+            this.INS_GYRO_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label24
+            // 
+            resources.ApplyResources(this.label24, "label24");
+            this.label24.Name = "label24";
+            // 
+            // groupBox9
+            // 
+            this.groupBox9.Controls.Add(this.INS_HNTCH_HMNCS);
+            this.groupBox9.Controls.Add(this.label51);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_OPTS);
+            this.groupBox9.Controls.Add(this.label50);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_BW);
+            this.groupBox9.Controls.Add(this.label49);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_ATT);
+            this.groupBox9.Controls.Add(this.label48);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_FREQ);
+            this.groupBox9.Controls.Add(this.label41);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_REF);
+            this.groupBox9.Controls.Add(this.label43);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_MODE);
+            this.groupBox9.Controls.Add(this.label44);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_ENABLE);
+            this.groupBox9.Controls.Add(this.label45);
+            resources.ApplyResources(this.groupBox9, "groupBox9");
+            this.groupBox9.Name = "groupBox9";
+            this.groupBox9.TabStop = false;
+            // 
+            // INS_HNTCH_HMNCS
+            // 
+            resources.ApplyResources(this.INS_HNTCH_HMNCS, "INS_HNTCH_HMNCS");
+            this.INS_HNTCH_HMNCS.Max = 1F;
+            this.INS_HNTCH_HMNCS.Min = 0F;
+            this.INS_HNTCH_HMNCS.Name = "INS_HNTCH_HMNCS";
+            this.INS_HNTCH_HMNCS.ParamName = null;
+            this.INS_HNTCH_HMNCS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label51
+            // 
+            resources.ApplyResources(this.label51, "label51");
+            this.label51.Name = "label51";
+            // 
+            // INS_HNTCH_OPTS
+            // 
+            resources.ApplyResources(this.INS_HNTCH_OPTS, "INS_HNTCH_OPTS");
+            this.INS_HNTCH_OPTS.Max = 1F;
+            this.INS_HNTCH_OPTS.Min = 0F;
+            this.INS_HNTCH_OPTS.Name = "INS_HNTCH_OPTS";
+            this.INS_HNTCH_OPTS.ParamName = null;
+            this.INS_HNTCH_OPTS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label50
+            // 
+            resources.ApplyResources(this.label50, "label50");
+            this.label50.Name = "label50";
+            // 
+            // INS_HNTCH_BW
+            // 
+            resources.ApplyResources(this.INS_HNTCH_BW, "INS_HNTCH_BW");
+            this.INS_HNTCH_BW.Max = 1F;
+            this.INS_HNTCH_BW.Min = 0F;
+            this.INS_HNTCH_BW.Name = "INS_HNTCH_BW";
+            this.INS_HNTCH_BW.ParamName = null;
+            this.INS_HNTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label49
+            // 
+            resources.ApplyResources(this.label49, "label49");
+            this.label49.Name = "label49";
+            // 
+            // INS_HNTCH_ATT
+            // 
+            resources.ApplyResources(this.INS_HNTCH_ATT, "INS_HNTCH_ATT");
+            this.INS_HNTCH_ATT.Max = 1F;
+            this.INS_HNTCH_ATT.Min = 0F;
+            this.INS_HNTCH_ATT.Name = "INS_HNTCH_ATT";
+            this.INS_HNTCH_ATT.ParamName = null;
+            this.INS_HNTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label48
+            // 
+            resources.ApplyResources(this.label48, "label48");
+            this.label48.Name = "label48";
+            // 
+            // INS_HNTCH_FREQ
+            // 
+            resources.ApplyResources(this.INS_HNTCH_FREQ, "INS_HNTCH_FREQ");
+            this.INS_HNTCH_FREQ.Max = 1F;
+            this.INS_HNTCH_FREQ.Min = 0F;
+            this.INS_HNTCH_FREQ.Name = "INS_HNTCH_FREQ";
+            this.INS_HNTCH_FREQ.ParamName = null;
+            this.INS_HNTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label41
+            // 
+            resources.ApplyResources(this.label41, "label41");
+            this.label41.Name = "label41";
+            // 
+            // INS_HNTCH_REF
+            // 
+            resources.ApplyResources(this.INS_HNTCH_REF, "INS_HNTCH_REF");
+            this.INS_HNTCH_REF.Max = 1F;
+            this.INS_HNTCH_REF.Min = 0F;
+            this.INS_HNTCH_REF.Name = "INS_HNTCH_REF";
+            this.INS_HNTCH_REF.ParamName = null;
+            this.INS_HNTCH_REF.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label43
+            // 
+            resources.ApplyResources(this.label43, "label43");
+            this.label43.Name = "label43";
+            // 
+            // INS_HNTCH_MODE
+            // 
+            resources.ApplyResources(this.INS_HNTCH_MODE, "INS_HNTCH_MODE");
+            this.INS_HNTCH_MODE.Max = 1F;
+            this.INS_HNTCH_MODE.Min = 0F;
+            this.INS_HNTCH_MODE.Name = "INS_HNTCH_MODE";
+            this.INS_HNTCH_MODE.ParamName = null;
+            this.INS_HNTCH_MODE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label44
+            // 
+            resources.ApplyResources(this.label44, "label44");
+            this.label44.Name = "label44";
+            // 
+            // INS_HNTCH_ENABLE
+            // 
+            resources.ApplyResources(this.INS_HNTCH_ENABLE, "INS_HNTCH_ENABLE");
+            this.INS_HNTCH_ENABLE.Max = 1F;
+            this.INS_HNTCH_ENABLE.Min = 0F;
+            this.INS_HNTCH_ENABLE.Name = "INS_HNTCH_ENABLE";
+            this.INS_HNTCH_ENABLE.ParamName = null;
+            this.INS_HNTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label45
+            // 
+            resources.ApplyResources(this.label45, "label45");
+            this.label45.Name = "label45";
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.Controls.Add(this.INS_NOTCH_ATT);
+            this.groupBox8.Controls.Add(this.label40);
+            this.groupBox8.Controls.Add(this.INS_NOTCH_BW);
+            this.groupBox8.Controls.Add(this.label39);
+            this.groupBox8.Controls.Add(this.INS_NOTCH_FREQ);
+            this.groupBox8.Controls.Add(this.label38);
+            this.groupBox8.Controls.Add(this.INS_NOTCH_ENABLE);
+            this.groupBox8.Controls.Add(this.label37);
+            resources.ApplyResources(this.groupBox8, "groupBox8");
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.TabStop = false;
+            // 
+            // INS_NOTCH_ATT
+            // 
+            resources.ApplyResources(this.INS_NOTCH_ATT, "INS_NOTCH_ATT");
+            this.INS_NOTCH_ATT.Max = 1F;
+            this.INS_NOTCH_ATT.Min = 0F;
+            this.INS_NOTCH_ATT.Name = "INS_NOTCH_ATT";
+            this.INS_NOTCH_ATT.ParamName = null;
+            this.INS_NOTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label40
+            // 
+            resources.ApplyResources(this.label40, "label40");
+            this.label40.Name = "label40";
+            // 
+            // INS_NOTCH_BW
+            // 
+            resources.ApplyResources(this.INS_NOTCH_BW, "INS_NOTCH_BW");
+            this.INS_NOTCH_BW.Max = 1F;
+            this.INS_NOTCH_BW.Min = 0F;
+            this.INS_NOTCH_BW.Name = "INS_NOTCH_BW";
+            this.INS_NOTCH_BW.ParamName = null;
+            this.INS_NOTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label39
+            // 
+            resources.ApplyResources(this.label39, "label39");
+            this.label39.Name = "label39";
+            // 
+            // INS_NOTCH_FREQ
+            // 
+            resources.ApplyResources(this.INS_NOTCH_FREQ, "INS_NOTCH_FREQ");
+            this.INS_NOTCH_FREQ.Max = 1F;
+            this.INS_NOTCH_FREQ.Min = 0F;
+            this.INS_NOTCH_FREQ.Name = "INS_NOTCH_FREQ";
+            this.INS_NOTCH_FREQ.ParamName = null;
+            this.INS_NOTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label38
+            // 
+            resources.ApplyResources(this.label38, "label38");
+            this.label38.Name = "label38";
+            // 
+            // INS_NOTCH_ENABLE
+            // 
+            resources.ApplyResources(this.INS_NOTCH_ENABLE, "INS_NOTCH_ENABLE");
+            this.INS_NOTCH_ENABLE.Max = 1F;
+            this.INS_NOTCH_ENABLE.Min = 0F;
+            this.INS_NOTCH_ENABLE.Name = "INS_NOTCH_ENABLE";
+            this.INS_NOTCH_ENABLE.ParamName = null;
+            this.INS_NOTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label37
+            // 
+            resources.ApplyResources(this.label37, "label37");
+            this.label37.Name = "label37";
+            // 
+            // groupBox6
+            // 
+            this.groupBox6.Controls.Add(this.INS_LOG_BAT_OPT);
+            this.groupBox6.Controls.Add(this.label36);
+            this.groupBox6.Controls.Add(this.INS_LOG_BAT_MASK);
+            this.groupBox6.Controls.Add(this.label34);
+            resources.ApplyResources(this.groupBox6, "groupBox6");
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.TabStop = false;
+            // 
+            // INS_LOG_BAT_OPT
+            // 
+            resources.ApplyResources(this.INS_LOG_BAT_OPT, "INS_LOG_BAT_OPT");
+            this.INS_LOG_BAT_OPT.Max = 1F;
+            this.INS_LOG_BAT_OPT.Min = 0F;
+            this.INS_LOG_BAT_OPT.Name = "INS_LOG_BAT_OPT";
+            this.INS_LOG_BAT_OPT.ParamName = null;
+            this.INS_LOG_BAT_OPT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label36
+            // 
+            resources.ApplyResources(this.label36, "label36");
+            this.label36.Name = "label36";
+            // 
+            // INS_LOG_BAT_MASK
+            // 
+            resources.ApplyResources(this.INS_LOG_BAT_MASK, "INS_LOG_BAT_MASK");
+            this.INS_LOG_BAT_MASK.Max = 1F;
+            this.INS_LOG_BAT_MASK.Min = 0F;
+            this.INS_LOG_BAT_MASK.Name = "INS_LOG_BAT_MASK";
+            this.INS_LOG_BAT_MASK.ParamName = null;
+            this.INS_LOG_BAT_MASK.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // label34
+            // 
+            resources.ApplyResources(this.label34, "label34");
+            this.label34.Name = "label34";
+            // 
+            // label52
+            // 
+            resources.ApplyResources(this.label52, "label52");
+            this.label52.Name = "label52";
+            // 
+            // CH6_OPTION
+            // 
+            this.CH6_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CH6_OPTION.DropDownWidth = 170;
+            resources.ApplyResources(this.CH6_OPTION, "CH6_OPTION");
+            this.CH6_OPTION.FormattingEnabled = true;
+            this.CH6_OPTION.Name = "CH6_OPTION";
+            this.CH6_OPTION.ParamName = null;
+            this.CH6_OPTION.SubControl = null;
+            this.CH6_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
             // ConfigArducopter
             // 
             resources.ApplyResources(this, "$this");
+            this.Controls.Add(this.groupBox8);
+            this.Controls.Add(this.groupBox9);
+            this.Controls.Add(this.label52);
+            this.Controls.Add(this.CH6_OPTION);
+            this.Controls.Add(this.groupBox6);
+            this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.myLabel6);
             this.Controls.Add(this.CH10_OPTION);
             this.Controls.Add(this.myLabel5);
@@ -1071,18 +1545,27 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).EndInit();
             this.groupBox23.ResumeLayout(false);
+            this.groupBox23.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_D)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).EndInit();
             this.groupBox24.ResumeLayout(false);
+            this.groupBox24.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).EndInit();
             this.groupBox25.ResumeLayout(false);
+            this.groupBox25.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).EndInit();
@@ -1098,6 +1581,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).EndInit();
+            this.groupBox3.ResumeLayout(false);
+            this.groupBox3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).EndInit();
+            this.groupBox9.ResumeLayout(false);
+            this.groupBox9.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ATT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ENABLE)).EndInit();
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ENABLE)).EndInit();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_OPT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_MASK)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1213,5 +1720,55 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private Label label20;
         private Controls.MavlinkNumericUpDown mavlinkNumericUpDownatc_accel_r_max;
         private Label label19;
+        private GroupBox groupBox3;
+        private Controls.MavlinkNumericUpDown INS_GYRO_FILTER;
+        private Label label24;
+        private Controls.MavlinkNumericUpDown INS_ACCEL_FILTER;
+        private Label label26;
+        private GroupBox groupBox6;
+        private Controls.MavlinkNumericUpDown INS_LOG_BAT_OPT;
+        private Label label36;
+        private Controls.MavlinkNumericUpDown INS_LOG_BAT_MASK;
+        private Label label34;
+        private GroupBox groupBox9;
+        private GroupBox groupBox8;
+        private Controls.MavlinkNumericUpDown INS_NOTCH_ENABLE;
+        private Label label37;
+        private Controls.MavlinkNumericUpDown INS_NOTCH_ATT;
+        private Label label40;
+        private Controls.MavlinkNumericUpDown INS_NOTCH_BW;
+        private Label label39;
+        private Controls.MavlinkNumericUpDown INS_NOTCH_FREQ;
+        private Label label38;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_FREQ;
+        private Label label41;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_REF;
+        private Label label43;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_MODE;
+        private Label label44;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_ENABLE;
+        private Label label45;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_HMNCS;
+        private Label label51;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_OPTS;
+        private Label label50;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_BW;
+        private Label label49;
+        private Controls.MavlinkNumericUpDown INS_HNTCH_ATT;
+        private Label label48;
+        private Label label52;
+        private Controls.MavlinkComboBox CH6_OPTION;
+        private Controls.MavlinkNumericUpDown ATC_RAT_PIT_FLTT;
+        private Label label28;
+        private Controls.MavlinkNumericUpDown ATC_RAT_PIT_FLTD;
+        private Label P_FLTD;
+        private Controls.MavlinkNumericUpDown ATC_RAT_YAW_FLTT;
+        private Label label33;
+        private Controls.MavlinkNumericUpDown ATC_RAT_YAW_FLTD;
+        private Label label32;
+        private Controls.MavlinkNumericUpDown ATC_RAT_RLL_FLTT;
+        private Label label30;
+        private Controls.MavlinkNumericUpDown ATC_RAT_RLL_FLTD;
+        private Label label29;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigArducopter.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.Designer.cs
@@ -32,102 +32,58 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConfigArducopter));
-            this.TUNE_LOW = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.TUNE_HIGH = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.TUNE = new MissionPlanner.Controls.MavlinkComboBox();
-            this.CH7_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
-            this.THR_RATE_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label25 = new System.Windows.Forms.Label();
             this.CHK_lockrollpitch = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.WPNAV_SPEED_UP = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label27 = new System.Windows.Forms.Label();
-            this.WPNAV_LOIT_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label9 = new System.Windows.Forms.Label();
-            this.WPNAV_SPEED_DN = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label13 = new System.Windows.Forms.Label();
-            this.WPNAV_RADIUS = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label15 = new System.Windows.Forms.Label();
-            this.WPNAV_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label16 = new System.Windows.Forms.Label();
             this.groupBox7 = new System.Windows.Forms.GroupBox();
-            this.THR_ALT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label22 = new System.Windows.Forms.Label();
             this.groupBox19 = new System.Windows.Forms.GroupBox();
-            this.mavlinkNumericUpDownatc_input_tc = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label23 = new System.Windows.Forms.Label();
-            this.HLD_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label31 = new System.Windows.Forms.Label();
             this.groupBox20 = new System.Windows.Forms.GroupBox();
-            this.mavlinkNumericUpDownatc_accel_y_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label21 = new System.Windows.Forms.Label();
-            this.STB_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label35 = new System.Windows.Forms.Label();
             this.groupBox21 = new System.Windows.Forms.GroupBox();
-            this.mavlinkNumericUpDownatc_accel_p_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label20 = new System.Windows.Forms.Label();
-            this.STB_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label42 = new System.Windows.Forms.Label();
             this.groupBox22 = new System.Windows.Forms.GroupBox();
-            this.mavlinkNumericUpDownatc_accel_r_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label19 = new System.Windows.Forms.Label();
-            this.STB_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label46 = new System.Windows.Forms.Label();
             this.groupBox23 = new System.Windows.Forms.GroupBox();
-            this.ATC_RAT_YAW_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label33 = new System.Windows.Forms.Label();
-            this.ATC_RAT_YAW_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label32 = new System.Windows.Forms.Label();
-            this.RATE_YAW_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label18 = new System.Windows.Forms.Label();
-            this.RATE_YAW_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label10 = new System.Windows.Forms.Label();
-            this.RATE_YAW_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label47 = new System.Windows.Forms.Label();
-            this.RATE_YAW_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label77 = new System.Windows.Forms.Label();
-            this.RATE_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label82 = new System.Windows.Forms.Label();
             this.groupBox24 = new System.Windows.Forms.GroupBox();
-            this.ATC_RAT_RLL_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label30 = new System.Windows.Forms.Label();
-            this.ATC_RAT_RLL_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label29 = new System.Windows.Forms.Label();
-            this.RATE_PIT_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label14 = new System.Windows.Forms.Label();
-            this.RATE_PIT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label11 = new System.Windows.Forms.Label();
-            this.RATE_PIT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label84 = new System.Windows.Forms.Label();
-            this.RATE_PIT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label86 = new System.Windows.Forms.Label();
-            this.RATE_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label87 = new System.Windows.Forms.Label();
             this.groupBox25 = new System.Windows.Forms.GroupBox();
-            this.ATC_RAT_PIT_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label28 = new System.Windows.Forms.Label();
-            this.ATC_RAT_PIT_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.P_FLTD = new System.Windows.Forms.Label();
-            this.RATE_RLL_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label12 = new System.Windows.Forms.Label();
-            this.RATE_RLL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label17 = new System.Windows.Forms.Label();
-            this.RATE_RLL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label88 = new System.Windows.Forms.Label();
-            this.RATE_RLL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label90 = new System.Windows.Forms.Label();
-            this.RATE_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label91 = new System.Windows.Forms.Label();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.LOITER_LAT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
-            this.LOITER_LAT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
-            this.LOITER_LAT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label3 = new System.Windows.Forms.Label();
-            this.LOITER_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label4 = new System.Windows.Forms.Label();
             this.BUT_rerequestparams = new MissionPlanner.Controls.MyButton();
             this.BUT_writePIDS = new MissionPlanner.Controls.MyButton();
@@ -135,121 +91,122 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.myLabel2 = new System.Windows.Forms.Label();
             this.myLabel1 = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.THR_ACCEL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
-            this.THR_ACCEL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.THR_ACCEL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label7 = new System.Windows.Forms.Label();
-            this.THR_ACCEL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label8 = new System.Windows.Forms.Label();
             this.BUT_refreshpart = new MissionPlanner.Controls.MyButton();
             this.myLabel4 = new System.Windows.Forms.Label();
-            this.CH8_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.myLabel5 = new System.Windows.Forms.Label();
-            this.CH9_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.myLabel6 = new System.Windows.Forms.Label();
-            this.CH10_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.INS_ACCEL_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label26 = new System.Windows.Forms.Label();
-            this.INS_GYRO_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label24 = new System.Windows.Forms.Label();
             this.groupBox9 = new System.Windows.Forms.GroupBox();
-            this.INS_HNTCH_HMNCS = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label51 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_OPTS = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label50 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label49 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label48 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label41 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_REF = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label43 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_MODE = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label44 = new System.Windows.Forms.Label();
-            this.INS_HNTCH_ENABLE = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label45 = new System.Windows.Forms.Label();
             this.groupBox8 = new System.Windows.Forms.GroupBox();
-            this.INS_NOTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label40 = new System.Windows.Forms.Label();
-            this.INS_NOTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label39 = new System.Windows.Forms.Label();
-            this.INS_NOTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label38 = new System.Windows.Forms.Label();
-            this.INS_NOTCH_ENABLE = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label37 = new System.Windows.Forms.Label();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
-            this.INS_LOG_BAT_OPT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label36 = new System.Windows.Forms.Label();
-            this.INS_LOG_BAT_MASK = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label34 = new System.Windows.Forms.Label();
             this.label52 = new System.Windows.Forms.Label();
+            this.INS_NOTCH_ENABLE = new MissionPlanner.Controls.MavlinkComboBox();
+            this.INS_NOTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_NOTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_NOTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_HMNCS = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_OPTS = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_REF = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_MODE = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CH6_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).BeginInit();
+            this.INS_LOG_BAT_MASK = new MissionPlanner.Controls.MavlinkComboBox();
+            this.INS_ACCEL_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_GYRO_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.CH10_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
+            this.CH9_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
+            this.CH8_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
+            this.THR_ACCEL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.THR_ACCEL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.THR_ACCEL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.THR_ACCEL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.LOITER_LAT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.LOITER_LAT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.LOITER_LAT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.LOITER_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.TUNE_LOW = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.TUNE_HIGH = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.TUNE = new MissionPlanner.Controls.MavlinkComboBox();
+            this.CH7_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
+            this.THR_RATE_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.WPNAV_SPEED_UP = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.WPNAV_LOIT_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.WPNAV_SPEED_DN = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.WPNAV_RADIUS = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.WPNAV_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.THR_ALT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownatc_input_tc = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.HLD_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownatc_accel_y_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.STB_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownatc_accel_p_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.STB_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownatc_accel_r_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.STB_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.ATC_RAT_YAW_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.ATC_RAT_YAW_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_YAW_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_YAW_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_YAW_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_YAW_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.ATC_RAT_RLL_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.ATC_RAT_RLL_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_PIT_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_PIT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_PIT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_PIT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.ATC_RAT_PIT_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.ATC_RAT_PIT_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_RLL_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_RLL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_RLL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_RLL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.RATE_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_LOG_BAT_OPT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_HNTCH_ENABLE = new MissionPlanner.Controls.MavlinkComboBox();
             this.groupBox5.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_RATE_P)).BeginInit();
             this.groupBox4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_UP)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_LOIT_SPEED)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_DN)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_RADIUS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED)).BeginInit();
             this.groupBox7.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ALT_P)).BeginInit();
             this.groupBox19.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_input_tc)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.HLD_LAT_P)).BeginInit();
             this.groupBox20.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_y_max)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.STB_YAW_P)).BeginInit();
             this.groupBox21.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_p_max)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.STB_PIT_P)).BeginInit();
             this.groupBox22.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).BeginInit();
             this.groupBox23.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).BeginInit();
             this.groupBox24.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).BeginInit();
             this.groupBox25.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_P)).BeginInit();
             this.groupBox1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).BeginInit();
             this.groupBox2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).BeginInit();
             this.groupBox3.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).BeginInit();
             this.groupBox9.SuspendLayout();
+            this.groupBox8.SuspendLayout();
+            this.groupBox6.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).BeginInit();
@@ -257,56 +214,56 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ENABLE)).BeginInit();
-            this.groupBox8.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ENABLE)).BeginInit();
-            this.groupBox6.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_RATE_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_UP)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_LOIT_SPEED)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_DN)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_RADIUS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ALT_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_input_tc)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.HLD_LAT_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_y_max)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.STB_YAW_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_p_max)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.STB_PIT_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_P)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_OPT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_MASK)).BeginInit();
             this.SuspendLayout();
-            // 
-            // TUNE_LOW
-            // 
-            resources.ApplyResources(this.TUNE_LOW, "TUNE_LOW");
-            this.TUNE_LOW.Max = 1F;
-            this.TUNE_LOW.Min = 0F;
-            this.TUNE_LOW.Name = "TUNE_LOW";
-            this.TUNE_LOW.ParamName = null;
-            this.TUNE_LOW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // TUNE_HIGH
-            // 
-            resources.ApplyResources(this.TUNE_HIGH, "TUNE_HIGH");
-            this.TUNE_HIGH.Max = 1F;
-            this.TUNE_HIGH.Min = 0F;
-            this.TUNE_HIGH.Name = "TUNE_HIGH";
-            this.TUNE_HIGH.ParamName = null;
-            this.TUNE_HIGH.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // TUNE
-            // 
-            this.TUNE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.TUNE.DropDownWidth = 170;
-            resources.ApplyResources(this.TUNE, "TUNE");
-            this.TUNE.FormattingEnabled = true;
-            this.TUNE.Name = "TUNE";
-            this.TUNE.ParamName = null;
-            this.TUNE.SubControl = null;
-            this.TUNE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // CH7_OPTION
-            // 
-            this.CH7_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CH7_OPTION.DropDownWidth = 170;
-            resources.ApplyResources(this.CH7_OPTION, "CH7_OPTION");
-            this.CH7_OPTION.FormattingEnabled = true;
-            this.CH7_OPTION.Name = "CH7_OPTION";
-            this.CH7_OPTION.ParamName = null;
-            this.CH7_OPTION.SubControl = null;
-            this.CH7_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // groupBox5
             // 
@@ -315,15 +272,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox5, "groupBox5");
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.TabStop = false;
-            // 
-            // THR_RATE_P
-            // 
-            resources.ApplyResources(this.THR_RATE_P, "THR_RATE_P");
-            this.THR_RATE_P.Max = 1F;
-            this.THR_RATE_P.Min = 0F;
-            this.THR_RATE_P.Name = "THR_RATE_P";
-            this.THR_RATE_P.ParamName = null;
-            this.THR_RATE_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label25
             // 
@@ -354,70 +302,25 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.TabStop = false;
             // 
-            // WPNAV_SPEED_UP
-            // 
-            resources.ApplyResources(this.WPNAV_SPEED_UP, "WPNAV_SPEED_UP");
-            this.WPNAV_SPEED_UP.Max = 1F;
-            this.WPNAV_SPEED_UP.Min = 0F;
-            this.WPNAV_SPEED_UP.Name = "WPNAV_SPEED_UP";
-            this.WPNAV_SPEED_UP.ParamName = null;
-            this.WPNAV_SPEED_UP.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label27
             // 
             resources.ApplyResources(this.label27, "label27");
             this.label27.Name = "label27";
-            // 
-            // WPNAV_LOIT_SPEED
-            // 
-            resources.ApplyResources(this.WPNAV_LOIT_SPEED, "WPNAV_LOIT_SPEED");
-            this.WPNAV_LOIT_SPEED.Max = 1F;
-            this.WPNAV_LOIT_SPEED.Min = 0F;
-            this.WPNAV_LOIT_SPEED.Name = "WPNAV_LOIT_SPEED";
-            this.WPNAV_LOIT_SPEED.ParamName = null;
-            this.WPNAV_LOIT_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label9
             // 
             resources.ApplyResources(this.label9, "label9");
             this.label9.Name = "label9";
             // 
-            // WPNAV_SPEED_DN
-            // 
-            resources.ApplyResources(this.WPNAV_SPEED_DN, "WPNAV_SPEED_DN");
-            this.WPNAV_SPEED_DN.Max = 1F;
-            this.WPNAV_SPEED_DN.Min = 0F;
-            this.WPNAV_SPEED_DN.Name = "WPNAV_SPEED_DN";
-            this.WPNAV_SPEED_DN.ParamName = null;
-            this.WPNAV_SPEED_DN.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label13
             // 
             resources.ApplyResources(this.label13, "label13");
             this.label13.Name = "label13";
             // 
-            // WPNAV_RADIUS
-            // 
-            resources.ApplyResources(this.WPNAV_RADIUS, "WPNAV_RADIUS");
-            this.WPNAV_RADIUS.Max = 1F;
-            this.WPNAV_RADIUS.Min = 0F;
-            this.WPNAV_RADIUS.Name = "WPNAV_RADIUS";
-            this.WPNAV_RADIUS.ParamName = null;
-            this.WPNAV_RADIUS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label15
             // 
             resources.ApplyResources(this.label15, "label15");
             this.label15.Name = "label15";
-            // 
-            // WPNAV_SPEED
-            // 
-            resources.ApplyResources(this.WPNAV_SPEED, "WPNAV_SPEED");
-            this.WPNAV_SPEED.Max = 1F;
-            this.WPNAV_SPEED.Min = 0F;
-            this.WPNAV_SPEED.Name = "WPNAV_SPEED";
-            this.WPNAV_SPEED.ParamName = null;
-            this.WPNAV_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label16
             // 
@@ -431,15 +334,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox7, "groupBox7");
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.TabStop = false;
-            // 
-            // THR_ALT_P
-            // 
-            resources.ApplyResources(this.THR_ALT_P, "THR_ALT_P");
-            this.THR_ALT_P.Max = 1F;
-            this.THR_ALT_P.Min = 0F;
-            this.THR_ALT_P.Name = "THR_ALT_P";
-            this.THR_ALT_P.ParamName = null;
-            this.THR_ALT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label22
             // 
@@ -456,28 +350,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox19.Name = "groupBox19";
             this.groupBox19.TabStop = false;
             // 
-            // mavlinkNumericUpDownatc_input_tc
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_input_tc, "mavlinkNumericUpDownatc_input_tc");
-            this.mavlinkNumericUpDownatc_input_tc.Max = 1F;
-            this.mavlinkNumericUpDownatc_input_tc.Min = 0F;
-            this.mavlinkNumericUpDownatc_input_tc.Name = "mavlinkNumericUpDownatc_input_tc";
-            this.mavlinkNumericUpDownatc_input_tc.ParamName = null;
-            this.mavlinkNumericUpDownatc_input_tc.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label23
             // 
             resources.ApplyResources(this.label23, "label23");
             this.label23.Name = "label23";
-            // 
-            // HLD_LAT_P
-            // 
-            resources.ApplyResources(this.HLD_LAT_P, "HLD_LAT_P");
-            this.HLD_LAT_P.Max = 1F;
-            this.HLD_LAT_P.Min = 0F;
-            this.HLD_LAT_P.Name = "HLD_LAT_P";
-            this.HLD_LAT_P.ParamName = null;
-            this.HLD_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label31
             // 
@@ -494,28 +370,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox20.Name = "groupBox20";
             this.groupBox20.TabStop = false;
             // 
-            // mavlinkNumericUpDownatc_accel_y_max
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_y_max, "mavlinkNumericUpDownatc_accel_y_max");
-            this.mavlinkNumericUpDownatc_accel_y_max.Max = 1F;
-            this.mavlinkNumericUpDownatc_accel_y_max.Min = 0F;
-            this.mavlinkNumericUpDownatc_accel_y_max.Name = "mavlinkNumericUpDownatc_accel_y_max";
-            this.mavlinkNumericUpDownatc_accel_y_max.ParamName = null;
-            this.mavlinkNumericUpDownatc_accel_y_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label21
             // 
             resources.ApplyResources(this.label21, "label21");
             this.label21.Name = "label21";
-            // 
-            // STB_YAW_P
-            // 
-            resources.ApplyResources(this.STB_YAW_P, "STB_YAW_P");
-            this.STB_YAW_P.Max = 1F;
-            this.STB_YAW_P.Min = 0F;
-            this.STB_YAW_P.Name = "STB_YAW_P";
-            this.STB_YAW_P.ParamName = null;
-            this.STB_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label35
             // 
@@ -532,28 +390,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox21.Name = "groupBox21";
             this.groupBox21.TabStop = false;
             // 
-            // mavlinkNumericUpDownatc_accel_p_max
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_p_max, "mavlinkNumericUpDownatc_accel_p_max");
-            this.mavlinkNumericUpDownatc_accel_p_max.Max = 1F;
-            this.mavlinkNumericUpDownatc_accel_p_max.Min = 0F;
-            this.mavlinkNumericUpDownatc_accel_p_max.Name = "mavlinkNumericUpDownatc_accel_p_max";
-            this.mavlinkNumericUpDownatc_accel_p_max.ParamName = null;
-            this.mavlinkNumericUpDownatc_accel_p_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label20
             // 
             resources.ApplyResources(this.label20, "label20");
             this.label20.Name = "label20";
-            // 
-            // STB_PIT_P
-            // 
-            resources.ApplyResources(this.STB_PIT_P, "STB_PIT_P");
-            this.STB_PIT_P.Max = 1F;
-            this.STB_PIT_P.Min = 0F;
-            this.STB_PIT_P.Name = "STB_PIT_P";
-            this.STB_PIT_P.ParamName = null;
-            this.STB_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label42
             // 
@@ -570,28 +410,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox22.Name = "groupBox22";
             this.groupBox22.TabStop = false;
             // 
-            // mavlinkNumericUpDownatc_accel_r_max
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_r_max, "mavlinkNumericUpDownatc_accel_r_max");
-            this.mavlinkNumericUpDownatc_accel_r_max.Max = 1F;
-            this.mavlinkNumericUpDownatc_accel_r_max.Min = 0F;
-            this.mavlinkNumericUpDownatc_accel_r_max.Name = "mavlinkNumericUpDownatc_accel_r_max";
-            this.mavlinkNumericUpDownatc_accel_r_max.ParamName = null;
-            this.mavlinkNumericUpDownatc_accel_r_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label19
             // 
             resources.ApplyResources(this.label19, "label19");
             this.label19.Name = "label19";
-            // 
-            // STB_RLL_P
-            // 
-            resources.ApplyResources(this.STB_RLL_P, "STB_RLL_P");
-            this.STB_RLL_P.Max = 1F;
-            this.STB_RLL_P.Min = 0F;
-            this.STB_RLL_P.Name = "STB_RLL_P";
-            this.STB_RLL_P.ParamName = null;
-            this.STB_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label46
             // 
@@ -618,98 +440,35 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox23.Name = "groupBox23";
             this.groupBox23.TabStop = false;
             // 
-            // ATC_RAT_YAW_FLTT
-            // 
-            resources.ApplyResources(this.ATC_RAT_YAW_FLTT, "ATC_RAT_YAW_FLTT");
-            this.ATC_RAT_YAW_FLTT.Max = 1F;
-            this.ATC_RAT_YAW_FLTT.Min = 0F;
-            this.ATC_RAT_YAW_FLTT.Name = "ATC_RAT_YAW_FLTT";
-            this.ATC_RAT_YAW_FLTT.ParamName = null;
-            this.ATC_RAT_YAW_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label33
             // 
             resources.ApplyResources(this.label33, "label33");
             this.label33.Name = "label33";
-            // 
-            // ATC_RAT_YAW_FLTD
-            // 
-            resources.ApplyResources(this.ATC_RAT_YAW_FLTD, "ATC_RAT_YAW_FLTD");
-            this.ATC_RAT_YAW_FLTD.Max = 1F;
-            this.ATC_RAT_YAW_FLTD.Min = 0F;
-            this.ATC_RAT_YAW_FLTD.Name = "ATC_RAT_YAW_FLTD";
-            this.ATC_RAT_YAW_FLTD.ParamName = null;
-            this.ATC_RAT_YAW_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label32
             // 
             resources.ApplyResources(this.label32, "label32");
             this.label32.Name = "label32";
             // 
-            // RATE_YAW_FILT
-            // 
-            resources.ApplyResources(this.RATE_YAW_FILT, "RATE_YAW_FILT");
-            this.RATE_YAW_FILT.Max = 1F;
-            this.RATE_YAW_FILT.Min = 0F;
-            this.RATE_YAW_FILT.Name = "RATE_YAW_FILT";
-            this.RATE_YAW_FILT.ParamName = null;
-            this.RATE_YAW_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label18
             // 
             resources.ApplyResources(this.label18, "label18");
             this.label18.Name = "label18";
-            // 
-            // RATE_YAW_D
-            // 
-            resources.ApplyResources(this.RATE_YAW_D, "RATE_YAW_D");
-            this.RATE_YAW_D.Max = 1F;
-            this.RATE_YAW_D.Min = 0F;
-            this.RATE_YAW_D.Name = "RATE_YAW_D";
-            this.RATE_YAW_D.ParamName = null;
-            this.RATE_YAW_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label10
             // 
             resources.ApplyResources(this.label10, "label10");
             this.label10.Name = "label10";
             // 
-            // RATE_YAW_IMAX
-            // 
-            resources.ApplyResources(this.RATE_YAW_IMAX, "RATE_YAW_IMAX");
-            this.RATE_YAW_IMAX.Max = 1F;
-            this.RATE_YAW_IMAX.Min = 0F;
-            this.RATE_YAW_IMAX.Name = "RATE_YAW_IMAX";
-            this.RATE_YAW_IMAX.ParamName = null;
-            this.RATE_YAW_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label47
             // 
             resources.ApplyResources(this.label47, "label47");
             this.label47.Name = "label47";
             // 
-            // RATE_YAW_I
-            // 
-            resources.ApplyResources(this.RATE_YAW_I, "RATE_YAW_I");
-            this.RATE_YAW_I.Max = 1F;
-            this.RATE_YAW_I.Min = 0F;
-            this.RATE_YAW_I.Name = "RATE_YAW_I";
-            this.RATE_YAW_I.ParamName = null;
-            this.RATE_YAW_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label77
             // 
             resources.ApplyResources(this.label77, "label77");
             this.label77.Name = "label77";
-            // 
-            // RATE_YAW_P
-            // 
-            resources.ApplyResources(this.RATE_YAW_P, "RATE_YAW_P");
-            this.RATE_YAW_P.Max = 1F;
-            this.RATE_YAW_P.Min = 0F;
-            this.RATE_YAW_P.Name = "RATE_YAW_P";
-            this.RATE_YAW_P.ParamName = null;
-            this.RATE_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label82
             // 
@@ -736,98 +495,35 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox24.Name = "groupBox24";
             this.groupBox24.TabStop = false;
             // 
-            // ATC_RAT_RLL_FLTT
-            // 
-            resources.ApplyResources(this.ATC_RAT_RLL_FLTT, "ATC_RAT_RLL_FLTT");
-            this.ATC_RAT_RLL_FLTT.Max = 1F;
-            this.ATC_RAT_RLL_FLTT.Min = 0F;
-            this.ATC_RAT_RLL_FLTT.Name = "ATC_RAT_RLL_FLTT";
-            this.ATC_RAT_RLL_FLTT.ParamName = null;
-            this.ATC_RAT_RLL_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label30
             // 
             resources.ApplyResources(this.label30, "label30");
             this.label30.Name = "label30";
-            // 
-            // ATC_RAT_RLL_FLTD
-            // 
-            resources.ApplyResources(this.ATC_RAT_RLL_FLTD, "ATC_RAT_RLL_FLTD");
-            this.ATC_RAT_RLL_FLTD.Max = 1F;
-            this.ATC_RAT_RLL_FLTD.Min = 0F;
-            this.ATC_RAT_RLL_FLTD.Name = "ATC_RAT_RLL_FLTD";
-            this.ATC_RAT_RLL_FLTD.ParamName = null;
-            this.ATC_RAT_RLL_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label29
             // 
             resources.ApplyResources(this.label29, "label29");
             this.label29.Name = "label29";
             // 
-            // RATE_PIT_FILT
-            // 
-            resources.ApplyResources(this.RATE_PIT_FILT, "RATE_PIT_FILT");
-            this.RATE_PIT_FILT.Max = 1F;
-            this.RATE_PIT_FILT.Min = 0F;
-            this.RATE_PIT_FILT.Name = "RATE_PIT_FILT";
-            this.RATE_PIT_FILT.ParamName = null;
-            this.RATE_PIT_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label14
             // 
             resources.ApplyResources(this.label14, "label14");
             this.label14.Name = "label14";
-            // 
-            // RATE_PIT_D
-            // 
-            resources.ApplyResources(this.RATE_PIT_D, "RATE_PIT_D");
-            this.RATE_PIT_D.Max = 1F;
-            this.RATE_PIT_D.Min = 0F;
-            this.RATE_PIT_D.Name = "RATE_PIT_D";
-            this.RATE_PIT_D.ParamName = null;
-            this.RATE_PIT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label11
             // 
             resources.ApplyResources(this.label11, "label11");
             this.label11.Name = "label11";
             // 
-            // RATE_PIT_IMAX
-            // 
-            resources.ApplyResources(this.RATE_PIT_IMAX, "RATE_PIT_IMAX");
-            this.RATE_PIT_IMAX.Max = 1F;
-            this.RATE_PIT_IMAX.Min = 0F;
-            this.RATE_PIT_IMAX.Name = "RATE_PIT_IMAX";
-            this.RATE_PIT_IMAX.ParamName = null;
-            this.RATE_PIT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label84
             // 
             resources.ApplyResources(this.label84, "label84");
             this.label84.Name = "label84";
             // 
-            // RATE_PIT_I
-            // 
-            resources.ApplyResources(this.RATE_PIT_I, "RATE_PIT_I");
-            this.RATE_PIT_I.Max = 1F;
-            this.RATE_PIT_I.Min = 0F;
-            this.RATE_PIT_I.Name = "RATE_PIT_I";
-            this.RATE_PIT_I.ParamName = null;
-            this.RATE_PIT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label86
             // 
             resources.ApplyResources(this.label86, "label86");
             this.label86.Name = "label86";
-            // 
-            // RATE_PIT_P
-            // 
-            resources.ApplyResources(this.RATE_PIT_P, "RATE_PIT_P");
-            this.RATE_PIT_P.Max = 1F;
-            this.RATE_PIT_P.Min = 0F;
-            this.RATE_PIT_P.Name = "RATE_PIT_P";
-            this.RATE_PIT_P.ParamName = null;
-            this.RATE_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label87
             // 
@@ -854,98 +550,35 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox25.Name = "groupBox25";
             this.groupBox25.TabStop = false;
             // 
-            // ATC_RAT_PIT_FLTT
-            // 
-            resources.ApplyResources(this.ATC_RAT_PIT_FLTT, "ATC_RAT_PIT_FLTT");
-            this.ATC_RAT_PIT_FLTT.Max = 1F;
-            this.ATC_RAT_PIT_FLTT.Min = 0F;
-            this.ATC_RAT_PIT_FLTT.Name = "ATC_RAT_PIT_FLTT";
-            this.ATC_RAT_PIT_FLTT.ParamName = null;
-            this.ATC_RAT_PIT_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label28
             // 
             resources.ApplyResources(this.label28, "label28");
             this.label28.Name = "label28";
-            // 
-            // ATC_RAT_PIT_FLTD
-            // 
-            resources.ApplyResources(this.ATC_RAT_PIT_FLTD, "ATC_RAT_PIT_FLTD");
-            this.ATC_RAT_PIT_FLTD.Max = 1F;
-            this.ATC_RAT_PIT_FLTD.Min = 0F;
-            this.ATC_RAT_PIT_FLTD.Name = "ATC_RAT_PIT_FLTD";
-            this.ATC_RAT_PIT_FLTD.ParamName = null;
-            this.ATC_RAT_PIT_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // P_FLTD
             // 
             resources.ApplyResources(this.P_FLTD, "P_FLTD");
             this.P_FLTD.Name = "P_FLTD";
             // 
-            // RATE_RLL_FILT
-            // 
-            resources.ApplyResources(this.RATE_RLL_FILT, "RATE_RLL_FILT");
-            this.RATE_RLL_FILT.Max = 1F;
-            this.RATE_RLL_FILT.Min = 0F;
-            this.RATE_RLL_FILT.Name = "RATE_RLL_FILT";
-            this.RATE_RLL_FILT.ParamName = null;
-            this.RATE_RLL_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label12
             // 
             resources.ApplyResources(this.label12, "label12");
             this.label12.Name = "label12";
-            // 
-            // RATE_RLL_D
-            // 
-            resources.ApplyResources(this.RATE_RLL_D, "RATE_RLL_D");
-            this.RATE_RLL_D.Max = 1F;
-            this.RATE_RLL_D.Min = 0F;
-            this.RATE_RLL_D.Name = "RATE_RLL_D";
-            this.RATE_RLL_D.ParamName = null;
-            this.RATE_RLL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label17
             // 
             resources.ApplyResources(this.label17, "label17");
             this.label17.Name = "label17";
             // 
-            // RATE_RLL_IMAX
-            // 
-            resources.ApplyResources(this.RATE_RLL_IMAX, "RATE_RLL_IMAX");
-            this.RATE_RLL_IMAX.Max = 1F;
-            this.RATE_RLL_IMAX.Min = 0F;
-            this.RATE_RLL_IMAX.Name = "RATE_RLL_IMAX";
-            this.RATE_RLL_IMAX.ParamName = null;
-            this.RATE_RLL_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label88
             // 
             resources.ApplyResources(this.label88, "label88");
             this.label88.Name = "label88";
             // 
-            // RATE_RLL_I
-            // 
-            resources.ApplyResources(this.RATE_RLL_I, "RATE_RLL_I");
-            this.RATE_RLL_I.Max = 1F;
-            this.RATE_RLL_I.Min = 0F;
-            this.RATE_RLL_I.Name = "RATE_RLL_I";
-            this.RATE_RLL_I.ParamName = null;
-            this.RATE_RLL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label90
             // 
             resources.ApplyResources(this.label90, "label90");
             this.label90.Name = "label90";
-            // 
-            // RATE_RLL_P
-            // 
-            resources.ApplyResources(this.RATE_RLL_P, "RATE_RLL_P");
-            this.RATE_RLL_P.Max = 1F;
-            this.RATE_RLL_P.Min = 0F;
-            this.RATE_RLL_P.Name = "RATE_RLL_P";
-            this.RATE_RLL_P.ParamName = null;
-            this.RATE_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label91
             // 
@@ -972,56 +605,20 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.TabStop = false;
             // 
-            // LOITER_LAT_D
-            // 
-            resources.ApplyResources(this.LOITER_LAT_D, "LOITER_LAT_D");
-            this.LOITER_LAT_D.Max = 1F;
-            this.LOITER_LAT_D.Min = 0F;
-            this.LOITER_LAT_D.Name = "LOITER_LAT_D";
-            this.LOITER_LAT_D.ParamName = null;
-            this.LOITER_LAT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
-            // 
-            // LOITER_LAT_IMAX
-            // 
-            resources.ApplyResources(this.LOITER_LAT_IMAX, "LOITER_LAT_IMAX");
-            this.LOITER_LAT_IMAX.Max = 1F;
-            this.LOITER_LAT_IMAX.Min = 0F;
-            this.LOITER_LAT_IMAX.Name = "LOITER_LAT_IMAX";
-            this.LOITER_LAT_IMAX.ParamName = null;
-            this.LOITER_LAT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label2
             // 
             resources.ApplyResources(this.label2, "label2");
             this.label2.Name = "label2";
             // 
-            // LOITER_LAT_I
-            // 
-            resources.ApplyResources(this.LOITER_LAT_I, "LOITER_LAT_I");
-            this.LOITER_LAT_I.Max = 1F;
-            this.LOITER_LAT_I.Min = 0F;
-            this.LOITER_LAT_I.Name = "LOITER_LAT_I";
-            this.LOITER_LAT_I.ParamName = null;
-            this.LOITER_LAT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label3
             // 
             resources.ApplyResources(this.label3, "label3");
             this.label3.Name = "label3";
-            // 
-            // LOITER_LAT_P
-            // 
-            resources.ApplyResources(this.LOITER_LAT_P, "LOITER_LAT_P");
-            this.LOITER_LAT_P.Max = 1F;
-            this.LOITER_LAT_P.Min = 0F;
-            this.LOITER_LAT_P.Name = "LOITER_LAT_P";
-            this.LOITER_LAT_P.ParamName = null;
-            this.LOITER_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // label4
             // 
@@ -1071,15 +668,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.TabStop = false;
             // 
-            // THR_ACCEL_D
-            // 
-            resources.ApplyResources(this.THR_ACCEL_D, "THR_ACCEL_D");
-            this.THR_ACCEL_D.Max = 1F;
-            this.THR_ACCEL_D.Min = 0F;
-            this.THR_ACCEL_D.Name = "THR_ACCEL_D";
-            this.THR_ACCEL_D.ParamName = null;
-            this.THR_ACCEL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // label5
             // 
             resources.ApplyResources(this.label5, "label5");
@@ -1089,6 +677,360 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.label6, "label6");
             this.label6.Name = "label6";
+            // 
+            // label7
+            // 
+            resources.ApplyResources(this.label7, "label7");
+            this.label7.Name = "label7";
+            // 
+            // label8
+            // 
+            resources.ApplyResources(this.label8, "label8");
+            this.label8.Name = "label8";
+            // 
+            // BUT_refreshpart
+            // 
+            resources.ApplyResources(this.BUT_refreshpart, "BUT_refreshpart");
+            this.BUT_refreshpart.Name = "BUT_refreshpart";
+            this.BUT_refreshpart.UseVisualStyleBackColor = true;
+            this.BUT_refreshpart.Click += new System.EventHandler(this.BUT_refreshpart_Click);
+            // 
+            // myLabel4
+            // 
+            resources.ApplyResources(this.myLabel4, "myLabel4");
+            this.myLabel4.Name = "myLabel4";
+            // 
+            // myLabel5
+            // 
+            resources.ApplyResources(this.myLabel5, "myLabel5");
+            this.myLabel5.Name = "myLabel5";
+            // 
+            // myLabel6
+            // 
+            resources.ApplyResources(this.myLabel6, "myLabel6");
+            this.myLabel6.Name = "myLabel6";
+            // 
+            // groupBox3
+            // 
+            this.groupBox3.Controls.Add(this.INS_ACCEL_FILTER);
+            this.groupBox3.Controls.Add(this.label26);
+            this.groupBox3.Controls.Add(this.INS_GYRO_FILTER);
+            this.groupBox3.Controls.Add(this.label24);
+            resources.ApplyResources(this.groupBox3, "groupBox3");
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.TabStop = false;
+            // 
+            // label26
+            // 
+            resources.ApplyResources(this.label26, "label26");
+            this.label26.Name = "label26";
+            // 
+            // label24
+            // 
+            resources.ApplyResources(this.label24, "label24");
+            this.label24.Name = "label24";
+            // 
+            // groupBox9
+            // 
+            this.groupBox9.Controls.Add(this.INS_HNTCH_ENABLE);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_HMNCS);
+            this.groupBox9.Controls.Add(this.label51);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_OPTS);
+            this.groupBox9.Controls.Add(this.label50);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_BW);
+            this.groupBox9.Controls.Add(this.label49);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_ATT);
+            this.groupBox9.Controls.Add(this.label48);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_FREQ);
+            this.groupBox9.Controls.Add(this.label41);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_REF);
+            this.groupBox9.Controls.Add(this.label43);
+            this.groupBox9.Controls.Add(this.INS_HNTCH_MODE);
+            this.groupBox9.Controls.Add(this.label44);
+            this.groupBox9.Controls.Add(this.label45);
+            resources.ApplyResources(this.groupBox9, "groupBox9");
+            this.groupBox9.Name = "groupBox9";
+            this.groupBox9.TabStop = false;
+            // 
+            // label51
+            // 
+            resources.ApplyResources(this.label51, "label51");
+            this.label51.Name = "label51";
+            // 
+            // label50
+            // 
+            resources.ApplyResources(this.label50, "label50");
+            this.label50.Name = "label50";
+            // 
+            // label49
+            // 
+            resources.ApplyResources(this.label49, "label49");
+            this.label49.Name = "label49";
+            // 
+            // label48
+            // 
+            resources.ApplyResources(this.label48, "label48");
+            this.label48.Name = "label48";
+            // 
+            // label41
+            // 
+            resources.ApplyResources(this.label41, "label41");
+            this.label41.Name = "label41";
+            // 
+            // label43
+            // 
+            resources.ApplyResources(this.label43, "label43");
+            this.label43.Name = "label43";
+            // 
+            // label44
+            // 
+            resources.ApplyResources(this.label44, "label44");
+            this.label44.Name = "label44";
+            // 
+            // label45
+            // 
+            resources.ApplyResources(this.label45, "label45");
+            this.label45.Name = "label45";
+            // 
+            // groupBox8
+            // 
+            this.groupBox8.Controls.Add(this.INS_NOTCH_ENABLE);
+            this.groupBox8.Controls.Add(this.INS_NOTCH_ATT);
+            this.groupBox8.Controls.Add(this.label40);
+            this.groupBox8.Controls.Add(this.INS_NOTCH_BW);
+            this.groupBox8.Controls.Add(this.label39);
+            this.groupBox8.Controls.Add(this.INS_NOTCH_FREQ);
+            this.groupBox8.Controls.Add(this.label38);
+            this.groupBox8.Controls.Add(this.label37);
+            resources.ApplyResources(this.groupBox8, "groupBox8");
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.TabStop = false;
+            // 
+            // label40
+            // 
+            resources.ApplyResources(this.label40, "label40");
+            this.label40.Name = "label40";
+            // 
+            // label39
+            // 
+            resources.ApplyResources(this.label39, "label39");
+            this.label39.Name = "label39";
+            // 
+            // label38
+            // 
+            resources.ApplyResources(this.label38, "label38");
+            this.label38.Name = "label38";
+            // 
+            // label37
+            // 
+            resources.ApplyResources(this.label37, "label37");
+            this.label37.Name = "label37";
+            // 
+            // groupBox6
+            // 
+            this.groupBox6.Controls.Add(this.INS_LOG_BAT_OPT);
+            this.groupBox6.Controls.Add(this.INS_LOG_BAT_MASK);
+            this.groupBox6.Controls.Add(this.label36);
+            this.groupBox6.Controls.Add(this.label34);
+            resources.ApplyResources(this.groupBox6, "groupBox6");
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.TabStop = false;
+            // 
+            // label36
+            // 
+            resources.ApplyResources(this.label36, "label36");
+            this.label36.Name = "label36";
+            // 
+            // label34
+            // 
+            resources.ApplyResources(this.label34, "label34");
+            this.label34.Name = "label34";
+            // 
+            // label52
+            // 
+            resources.ApplyResources(this.label52, "label52");
+            this.label52.Name = "label52";
+            // 
+            // INS_NOTCH_ENABLE
+            // 
+            this.INS_NOTCH_ENABLE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.INS_NOTCH_ENABLE.DropDownWidth = 170;
+            resources.ApplyResources(this.INS_NOTCH_ENABLE, "INS_NOTCH_ENABLE");
+            this.INS_NOTCH_ENABLE.FormattingEnabled = true;
+            this.INS_NOTCH_ENABLE.Name = "INS_NOTCH_ENABLE";
+            this.INS_NOTCH_ENABLE.ParamName = null;
+            this.INS_NOTCH_ENABLE.SubControl = null;
+            this.INS_NOTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_NOTCH_ATT
+            // 
+            resources.ApplyResources(this.INS_NOTCH_ATT, "INS_NOTCH_ATT");
+            this.INS_NOTCH_ATT.Max = 1F;
+            this.INS_NOTCH_ATT.Min = 0F;
+            this.INS_NOTCH_ATT.Name = "INS_NOTCH_ATT";
+            this.INS_NOTCH_ATT.ParamName = null;
+            this.INS_NOTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_NOTCH_BW
+            // 
+            resources.ApplyResources(this.INS_NOTCH_BW, "INS_NOTCH_BW");
+            this.INS_NOTCH_BW.Max = 1F;
+            this.INS_NOTCH_BW.Min = 0F;
+            this.INS_NOTCH_BW.Name = "INS_NOTCH_BW";
+            this.INS_NOTCH_BW.ParamName = null;
+            this.INS_NOTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_NOTCH_FREQ
+            // 
+            resources.ApplyResources(this.INS_NOTCH_FREQ, "INS_NOTCH_FREQ");
+            this.INS_NOTCH_FREQ.Max = 1F;
+            this.INS_NOTCH_FREQ.Min = 0F;
+            this.INS_NOTCH_FREQ.Name = "INS_NOTCH_FREQ";
+            this.INS_NOTCH_FREQ.ParamName = null;
+            this.INS_NOTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_HMNCS
+            // 
+            resources.ApplyResources(this.INS_HNTCH_HMNCS, "INS_HNTCH_HMNCS");
+            this.INS_HNTCH_HMNCS.Max = 1F;
+            this.INS_HNTCH_HMNCS.Min = 0F;
+            this.INS_HNTCH_HMNCS.Name = "INS_HNTCH_HMNCS";
+            this.INS_HNTCH_HMNCS.ParamName = null;
+            this.INS_HNTCH_HMNCS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_OPTS
+            // 
+            resources.ApplyResources(this.INS_HNTCH_OPTS, "INS_HNTCH_OPTS");
+            this.INS_HNTCH_OPTS.Max = 1F;
+            this.INS_HNTCH_OPTS.Min = 0F;
+            this.INS_HNTCH_OPTS.Name = "INS_HNTCH_OPTS";
+            this.INS_HNTCH_OPTS.ParamName = null;
+            this.INS_HNTCH_OPTS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_BW
+            // 
+            resources.ApplyResources(this.INS_HNTCH_BW, "INS_HNTCH_BW");
+            this.INS_HNTCH_BW.Max = 1F;
+            this.INS_HNTCH_BW.Min = 0F;
+            this.INS_HNTCH_BW.Name = "INS_HNTCH_BW";
+            this.INS_HNTCH_BW.ParamName = null;
+            this.INS_HNTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_ATT
+            // 
+            resources.ApplyResources(this.INS_HNTCH_ATT, "INS_HNTCH_ATT");
+            this.INS_HNTCH_ATT.Max = 1F;
+            this.INS_HNTCH_ATT.Min = 0F;
+            this.INS_HNTCH_ATT.Name = "INS_HNTCH_ATT";
+            this.INS_HNTCH_ATT.ParamName = null;
+            this.INS_HNTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_FREQ
+            // 
+            resources.ApplyResources(this.INS_HNTCH_FREQ, "INS_HNTCH_FREQ");
+            this.INS_HNTCH_FREQ.Max = 1F;
+            this.INS_HNTCH_FREQ.Min = 0F;
+            this.INS_HNTCH_FREQ.Name = "INS_HNTCH_FREQ";
+            this.INS_HNTCH_FREQ.ParamName = null;
+            this.INS_HNTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_REF
+            // 
+            resources.ApplyResources(this.INS_HNTCH_REF, "INS_HNTCH_REF");
+            this.INS_HNTCH_REF.Max = 1F;
+            this.INS_HNTCH_REF.Min = 0F;
+            this.INS_HNTCH_REF.Name = "INS_HNTCH_REF";
+            this.INS_HNTCH_REF.ParamName = null;
+            this.INS_HNTCH_REF.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_MODE
+            // 
+            resources.ApplyResources(this.INS_HNTCH_MODE, "INS_HNTCH_MODE");
+            this.INS_HNTCH_MODE.Max = 1F;
+            this.INS_HNTCH_MODE.Min = 0F;
+            this.INS_HNTCH_MODE.Name = "INS_HNTCH_MODE";
+            this.INS_HNTCH_MODE.ParamName = null;
+            this.INS_HNTCH_MODE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // CH6_OPTION
+            // 
+            this.CH6_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CH6_OPTION.DropDownWidth = 170;
+            resources.ApplyResources(this.CH6_OPTION, "CH6_OPTION");
+            this.CH6_OPTION.FormattingEnabled = true;
+            this.CH6_OPTION.Name = "CH6_OPTION";
+            this.CH6_OPTION.ParamName = null;
+            this.CH6_OPTION.SubControl = null;
+            this.CH6_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_LOG_BAT_MASK
+            // 
+            this.INS_LOG_BAT_MASK.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.INS_LOG_BAT_MASK.DropDownWidth = 170;
+            resources.ApplyResources(this.INS_LOG_BAT_MASK, "INS_LOG_BAT_MASK");
+            this.INS_LOG_BAT_MASK.FormattingEnabled = true;
+            this.INS_LOG_BAT_MASK.Name = "INS_LOG_BAT_MASK";
+            this.INS_LOG_BAT_MASK.ParamName = null;
+            this.INS_LOG_BAT_MASK.SubControl = null;
+            this.INS_LOG_BAT_MASK.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_ACCEL_FILTER
+            // 
+            resources.ApplyResources(this.INS_ACCEL_FILTER, "INS_ACCEL_FILTER");
+            this.INS_ACCEL_FILTER.Max = 1F;
+            this.INS_ACCEL_FILTER.Min = 0F;
+            this.INS_ACCEL_FILTER.Name = "INS_ACCEL_FILTER";
+            this.INS_ACCEL_FILTER.ParamName = null;
+            this.INS_ACCEL_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_GYRO_FILTER
+            // 
+            resources.ApplyResources(this.INS_GYRO_FILTER, "INS_GYRO_FILTER");
+            this.INS_GYRO_FILTER.Max = 1F;
+            this.INS_GYRO_FILTER.Min = 0F;
+            this.INS_GYRO_FILTER.Name = "INS_GYRO_FILTER";
+            this.INS_GYRO_FILTER.ParamName = null;
+            this.INS_GYRO_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // CH10_OPTION
+            // 
+            this.CH10_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CH10_OPTION.DropDownWidth = 170;
+            resources.ApplyResources(this.CH10_OPTION, "CH10_OPTION");
+            this.CH10_OPTION.FormattingEnabled = true;
+            this.CH10_OPTION.Name = "CH10_OPTION";
+            this.CH10_OPTION.ParamName = null;
+            this.CH10_OPTION.SubControl = null;
+            // 
+            // CH9_OPTION
+            // 
+            this.CH9_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CH9_OPTION.DropDownWidth = 170;
+            resources.ApplyResources(this.CH9_OPTION, "CH9_OPTION");
+            this.CH9_OPTION.FormattingEnabled = true;
+            this.CH9_OPTION.Name = "CH9_OPTION";
+            this.CH9_OPTION.ParamName = null;
+            this.CH9_OPTION.SubControl = null;
+            // 
+            // CH8_OPTION
+            // 
+            this.CH8_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CH8_OPTION.DropDownWidth = 170;
+            resources.ApplyResources(this.CH8_OPTION, "CH8_OPTION");
+            this.CH8_OPTION.FormattingEnabled = true;
+            this.CH8_OPTION.Name = "CH8_OPTION";
+            this.CH8_OPTION.ParamName = null;
+            this.CH8_OPTION.SubControl = null;
+            this.CH8_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // THR_ACCEL_D
+            // 
+            resources.ApplyResources(this.THR_ACCEL_D, "THR_ACCEL_D");
+            this.THR_ACCEL_D.Max = 1F;
+            this.THR_ACCEL_D.Min = 0F;
+            this.THR_ACCEL_D.Name = "THR_ACCEL_D";
+            this.THR_ACCEL_D.ParamName = null;
+            this.THR_ACCEL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // THR_ACCEL_IMAX
             // 
@@ -1113,11 +1055,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.THR_ACCEL_I.ParamName = null;
             this.THR_ACCEL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
-            // label7
-            // 
-            resources.ApplyResources(this.label7, "label7");
-            this.label7.Name = "label7";
-            // 
             // THR_ACCEL_P
             // 
             resources.ApplyResources(this.THR_ACCEL_P, "THR_ACCEL_P");
@@ -1127,315 +1064,405 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.THR_ACCEL_P.ParamName = null;
             this.THR_ACCEL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
-            // label8
-            // 
-            resources.ApplyResources(this.label8, "label8");
-            this.label8.Name = "label8";
-            // 
-            // BUT_refreshpart
-            // 
-            resources.ApplyResources(this.BUT_refreshpart, "BUT_refreshpart");
-            this.BUT_refreshpart.Name = "BUT_refreshpart";
-            this.BUT_refreshpart.UseVisualStyleBackColor = true;
-            this.BUT_refreshpart.Click += new System.EventHandler(this.BUT_refreshpart_Click);
-            // 
-            // myLabel4
-            // 
-            resources.ApplyResources(this.myLabel4, "myLabel4");
-            this.myLabel4.Name = "myLabel4";
-            // 
-            // CH8_OPTION
-            // 
-            this.CH8_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CH8_OPTION.DropDownWidth = 170;
-            resources.ApplyResources(this.CH8_OPTION, "CH8_OPTION");
-            this.CH8_OPTION.FormattingEnabled = true;
-            this.CH8_OPTION.Name = "CH8_OPTION";
-            this.CH8_OPTION.ParamName = null;
-            this.CH8_OPTION.SubControl = null;
-            this.CH8_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // myLabel5
-            // 
-            resources.ApplyResources(this.myLabel5, "myLabel5");
-            this.myLabel5.Name = "myLabel5";
-            // 
-            // CH9_OPTION
-            // 
-            this.CH9_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CH9_OPTION.DropDownWidth = 170;
-            resources.ApplyResources(this.CH9_OPTION, "CH9_OPTION");
-            this.CH9_OPTION.FormattingEnabled = true;
-            this.CH9_OPTION.Name = "CH9_OPTION";
-            this.CH9_OPTION.ParamName = null;
-            this.CH9_OPTION.SubControl = null;
-            // 
-            // myLabel6
-            // 
-            resources.ApplyResources(this.myLabel6, "myLabel6");
-            this.myLabel6.Name = "myLabel6";
-            // 
-            // CH10_OPTION
-            // 
-            this.CH10_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CH10_OPTION.DropDownWidth = 170;
-            resources.ApplyResources(this.CH10_OPTION, "CH10_OPTION");
-            this.CH10_OPTION.FormattingEnabled = true;
-            this.CH10_OPTION.Name = "CH10_OPTION";
-            this.CH10_OPTION.ParamName = null;
-            this.CH10_OPTION.SubControl = null;
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.INS_ACCEL_FILTER);
-            this.groupBox3.Controls.Add(this.label26);
-            this.groupBox3.Controls.Add(this.INS_GYRO_FILTER);
-            this.groupBox3.Controls.Add(this.label24);
-            resources.ApplyResources(this.groupBox3, "groupBox3");
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.TabStop = false;
-            // 
-            // INS_ACCEL_FILTER
-            // 
-            resources.ApplyResources(this.INS_ACCEL_FILTER, "INS_ACCEL_FILTER");
-            this.INS_ACCEL_FILTER.Max = 1F;
-            this.INS_ACCEL_FILTER.Min = 0F;
-            this.INS_ACCEL_FILTER.Name = "INS_ACCEL_FILTER";
-            this.INS_ACCEL_FILTER.ParamName = null;
-            this.INS_ACCEL_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label26
-            // 
-            resources.ApplyResources(this.label26, "label26");
-            this.label26.Name = "label26";
-            // 
-            // INS_GYRO_FILTER
-            // 
-            resources.ApplyResources(this.INS_GYRO_FILTER, "INS_GYRO_FILTER");
-            this.INS_GYRO_FILTER.Max = 1F;
-            this.INS_GYRO_FILTER.Min = 0F;
-            this.INS_GYRO_FILTER.Name = "INS_GYRO_FILTER";
-            this.INS_GYRO_FILTER.ParamName = null;
-            this.INS_GYRO_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label24
-            // 
-            resources.ApplyResources(this.label24, "label24");
-            this.label24.Name = "label24";
-            // 
-            // groupBox9
-            // 
-            this.groupBox9.Controls.Add(this.INS_HNTCH_HMNCS);
-            this.groupBox9.Controls.Add(this.label51);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_OPTS);
-            this.groupBox9.Controls.Add(this.label50);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_BW);
-            this.groupBox9.Controls.Add(this.label49);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_ATT);
-            this.groupBox9.Controls.Add(this.label48);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_FREQ);
-            this.groupBox9.Controls.Add(this.label41);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_REF);
-            this.groupBox9.Controls.Add(this.label43);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_MODE);
-            this.groupBox9.Controls.Add(this.label44);
-            this.groupBox9.Controls.Add(this.INS_HNTCH_ENABLE);
-            this.groupBox9.Controls.Add(this.label45);
-            resources.ApplyResources(this.groupBox9, "groupBox9");
-            this.groupBox9.Name = "groupBox9";
-            this.groupBox9.TabStop = false;
-            // 
-            // INS_HNTCH_HMNCS
-            // 
-            resources.ApplyResources(this.INS_HNTCH_HMNCS, "INS_HNTCH_HMNCS");
-            this.INS_HNTCH_HMNCS.Max = 1F;
-            this.INS_HNTCH_HMNCS.Min = 0F;
-            this.INS_HNTCH_HMNCS.Name = "INS_HNTCH_HMNCS";
-            this.INS_HNTCH_HMNCS.ParamName = null;
-            this.INS_HNTCH_HMNCS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label51
-            // 
-            resources.ApplyResources(this.label51, "label51");
-            this.label51.Name = "label51";
-            // 
-            // INS_HNTCH_OPTS
-            // 
-            resources.ApplyResources(this.INS_HNTCH_OPTS, "INS_HNTCH_OPTS");
-            this.INS_HNTCH_OPTS.Max = 1F;
-            this.INS_HNTCH_OPTS.Min = 0F;
-            this.INS_HNTCH_OPTS.Name = "INS_HNTCH_OPTS";
-            this.INS_HNTCH_OPTS.ParamName = null;
-            this.INS_HNTCH_OPTS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label50
-            // 
-            resources.ApplyResources(this.label50, "label50");
-            this.label50.Name = "label50";
-            // 
-            // INS_HNTCH_BW
-            // 
-            resources.ApplyResources(this.INS_HNTCH_BW, "INS_HNTCH_BW");
-            this.INS_HNTCH_BW.Max = 1F;
-            this.INS_HNTCH_BW.Min = 0F;
-            this.INS_HNTCH_BW.Name = "INS_HNTCH_BW";
-            this.INS_HNTCH_BW.ParamName = null;
-            this.INS_HNTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label49
-            // 
-            resources.ApplyResources(this.label49, "label49");
-            this.label49.Name = "label49";
-            // 
-            // INS_HNTCH_ATT
-            // 
-            resources.ApplyResources(this.INS_HNTCH_ATT, "INS_HNTCH_ATT");
-            this.INS_HNTCH_ATT.Max = 1F;
-            this.INS_HNTCH_ATT.Min = 0F;
-            this.INS_HNTCH_ATT.Name = "INS_HNTCH_ATT";
-            this.INS_HNTCH_ATT.ParamName = null;
-            this.INS_HNTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label48
-            // 
-            resources.ApplyResources(this.label48, "label48");
-            this.label48.Name = "label48";
-            // 
-            // INS_HNTCH_FREQ
-            // 
-            resources.ApplyResources(this.INS_HNTCH_FREQ, "INS_HNTCH_FREQ");
-            this.INS_HNTCH_FREQ.Max = 1F;
-            this.INS_HNTCH_FREQ.Min = 0F;
-            this.INS_HNTCH_FREQ.Name = "INS_HNTCH_FREQ";
-            this.INS_HNTCH_FREQ.ParamName = null;
-            this.INS_HNTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label41
-            // 
-            resources.ApplyResources(this.label41, "label41");
-            this.label41.Name = "label41";
-            // 
-            // INS_HNTCH_REF
-            // 
-            resources.ApplyResources(this.INS_HNTCH_REF, "INS_HNTCH_REF");
-            this.INS_HNTCH_REF.Max = 1F;
-            this.INS_HNTCH_REF.Min = 0F;
-            this.INS_HNTCH_REF.Name = "INS_HNTCH_REF";
-            this.INS_HNTCH_REF.ParamName = null;
-            this.INS_HNTCH_REF.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label43
-            // 
-            resources.ApplyResources(this.label43, "label43");
-            this.label43.Name = "label43";
-            // 
-            // INS_HNTCH_MODE
-            // 
-            resources.ApplyResources(this.INS_HNTCH_MODE, "INS_HNTCH_MODE");
-            this.INS_HNTCH_MODE.Max = 1F;
-            this.INS_HNTCH_MODE.Min = 0F;
-            this.INS_HNTCH_MODE.Name = "INS_HNTCH_MODE";
-            this.INS_HNTCH_MODE.ParamName = null;
-            this.INS_HNTCH_MODE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label44
-            // 
-            resources.ApplyResources(this.label44, "label44");
-            this.label44.Name = "label44";
-            // 
-            // INS_HNTCH_ENABLE
-            // 
-            resources.ApplyResources(this.INS_HNTCH_ENABLE, "INS_HNTCH_ENABLE");
-            this.INS_HNTCH_ENABLE.Max = 1F;
-            this.INS_HNTCH_ENABLE.Min = 0F;
-            this.INS_HNTCH_ENABLE.Name = "INS_HNTCH_ENABLE";
-            this.INS_HNTCH_ENABLE.ParamName = null;
-            this.INS_HNTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label45
-            // 
-            resources.ApplyResources(this.label45, "label45");
-            this.label45.Name = "label45";
-            // 
-            // groupBox8
-            // 
-            this.groupBox8.Controls.Add(this.INS_NOTCH_ATT);
-            this.groupBox8.Controls.Add(this.label40);
-            this.groupBox8.Controls.Add(this.INS_NOTCH_BW);
-            this.groupBox8.Controls.Add(this.label39);
-            this.groupBox8.Controls.Add(this.INS_NOTCH_FREQ);
-            this.groupBox8.Controls.Add(this.label38);
-            this.groupBox8.Controls.Add(this.INS_NOTCH_ENABLE);
-            this.groupBox8.Controls.Add(this.label37);
-            resources.ApplyResources(this.groupBox8, "groupBox8");
-            this.groupBox8.Name = "groupBox8";
-            this.groupBox8.TabStop = false;
-            // 
-            // INS_NOTCH_ATT
-            // 
-            resources.ApplyResources(this.INS_NOTCH_ATT, "INS_NOTCH_ATT");
-            this.INS_NOTCH_ATT.Max = 1F;
-            this.INS_NOTCH_ATT.Min = 0F;
-            this.INS_NOTCH_ATT.Name = "INS_NOTCH_ATT";
-            this.INS_NOTCH_ATT.ParamName = null;
-            this.INS_NOTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label40
-            // 
-            resources.ApplyResources(this.label40, "label40");
-            this.label40.Name = "label40";
-            // 
-            // INS_NOTCH_BW
-            // 
-            resources.ApplyResources(this.INS_NOTCH_BW, "INS_NOTCH_BW");
-            this.INS_NOTCH_BW.Max = 1F;
-            this.INS_NOTCH_BW.Min = 0F;
-            this.INS_NOTCH_BW.Name = "INS_NOTCH_BW";
-            this.INS_NOTCH_BW.ParamName = null;
-            this.INS_NOTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label39
-            // 
-            resources.ApplyResources(this.label39, "label39");
-            this.label39.Name = "label39";
-            // 
-            // INS_NOTCH_FREQ
-            // 
-            resources.ApplyResources(this.INS_NOTCH_FREQ, "INS_NOTCH_FREQ");
-            this.INS_NOTCH_FREQ.Max = 1F;
-            this.INS_NOTCH_FREQ.Min = 0F;
-            this.INS_NOTCH_FREQ.Name = "INS_NOTCH_FREQ";
-            this.INS_NOTCH_FREQ.ParamName = null;
-            this.INS_NOTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label38
-            // 
-            resources.ApplyResources(this.label38, "label38");
-            this.label38.Name = "label38";
-            // 
-            // INS_NOTCH_ENABLE
-            // 
-            resources.ApplyResources(this.INS_NOTCH_ENABLE, "INS_NOTCH_ENABLE");
-            this.INS_NOTCH_ENABLE.Max = 1F;
-            this.INS_NOTCH_ENABLE.Min = 0F;
-            this.INS_NOTCH_ENABLE.Name = "INS_NOTCH_ENABLE";
-            this.INS_NOTCH_ENABLE.ParamName = null;
-            this.INS_NOTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label37
-            // 
-            resources.ApplyResources(this.label37, "label37");
-            this.label37.Name = "label37";
-            // 
-            // groupBox6
-            // 
-            this.groupBox6.Controls.Add(this.INS_LOG_BAT_OPT);
-            this.groupBox6.Controls.Add(this.label36);
-            this.groupBox6.Controls.Add(this.INS_LOG_BAT_MASK);
-            this.groupBox6.Controls.Add(this.label34);
-            resources.ApplyResources(this.groupBox6, "groupBox6");
-            this.groupBox6.Name = "groupBox6";
-            this.groupBox6.TabStop = false;
+            // LOITER_LAT_D
+            // 
+            resources.ApplyResources(this.LOITER_LAT_D, "LOITER_LAT_D");
+            this.LOITER_LAT_D.Max = 1F;
+            this.LOITER_LAT_D.Min = 0F;
+            this.LOITER_LAT_D.Name = "LOITER_LAT_D";
+            this.LOITER_LAT_D.ParamName = null;
+            this.LOITER_LAT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // LOITER_LAT_IMAX
+            // 
+            resources.ApplyResources(this.LOITER_LAT_IMAX, "LOITER_LAT_IMAX");
+            this.LOITER_LAT_IMAX.Max = 1F;
+            this.LOITER_LAT_IMAX.Min = 0F;
+            this.LOITER_LAT_IMAX.Name = "LOITER_LAT_IMAX";
+            this.LOITER_LAT_IMAX.ParamName = null;
+            this.LOITER_LAT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // LOITER_LAT_I
+            // 
+            resources.ApplyResources(this.LOITER_LAT_I, "LOITER_LAT_I");
+            this.LOITER_LAT_I.Max = 1F;
+            this.LOITER_LAT_I.Min = 0F;
+            this.LOITER_LAT_I.Name = "LOITER_LAT_I";
+            this.LOITER_LAT_I.ParamName = null;
+            this.LOITER_LAT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // LOITER_LAT_P
+            // 
+            resources.ApplyResources(this.LOITER_LAT_P, "LOITER_LAT_P");
+            this.LOITER_LAT_P.Max = 1F;
+            this.LOITER_LAT_P.Min = 0F;
+            this.LOITER_LAT_P.Name = "LOITER_LAT_P";
+            this.LOITER_LAT_P.ParamName = null;
+            this.LOITER_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // TUNE_LOW
+            // 
+            resources.ApplyResources(this.TUNE_LOW, "TUNE_LOW");
+            this.TUNE_LOW.Max = 1F;
+            this.TUNE_LOW.Min = 0F;
+            this.TUNE_LOW.Name = "TUNE_LOW";
+            this.TUNE_LOW.ParamName = null;
+            this.TUNE_LOW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // TUNE_HIGH
+            // 
+            resources.ApplyResources(this.TUNE_HIGH, "TUNE_HIGH");
+            this.TUNE_HIGH.Max = 1F;
+            this.TUNE_HIGH.Min = 0F;
+            this.TUNE_HIGH.Name = "TUNE_HIGH";
+            this.TUNE_HIGH.ParamName = null;
+            this.TUNE_HIGH.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // TUNE
+            // 
+            this.TUNE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.TUNE.DropDownWidth = 170;
+            resources.ApplyResources(this.TUNE, "TUNE");
+            this.TUNE.FormattingEnabled = true;
+            this.TUNE.Name = "TUNE";
+            this.TUNE.ParamName = null;
+            this.TUNE.SubControl = null;
+            this.TUNE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // CH7_OPTION
+            // 
+            this.CH7_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CH7_OPTION.DropDownWidth = 170;
+            resources.ApplyResources(this.CH7_OPTION, "CH7_OPTION");
+            this.CH7_OPTION.FormattingEnabled = true;
+            this.CH7_OPTION.Name = "CH7_OPTION";
+            this.CH7_OPTION.ParamName = null;
+            this.CH7_OPTION.SubControl = null;
+            this.CH7_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // THR_RATE_P
+            // 
+            resources.ApplyResources(this.THR_RATE_P, "THR_RATE_P");
+            this.THR_RATE_P.Max = 1F;
+            this.THR_RATE_P.Min = 0F;
+            this.THR_RATE_P.Name = "THR_RATE_P";
+            this.THR_RATE_P.ParamName = null;
+            this.THR_RATE_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // WPNAV_SPEED_UP
+            // 
+            resources.ApplyResources(this.WPNAV_SPEED_UP, "WPNAV_SPEED_UP");
+            this.WPNAV_SPEED_UP.Max = 1F;
+            this.WPNAV_SPEED_UP.Min = 0F;
+            this.WPNAV_SPEED_UP.Name = "WPNAV_SPEED_UP";
+            this.WPNAV_SPEED_UP.ParamName = null;
+            this.WPNAV_SPEED_UP.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // WPNAV_LOIT_SPEED
+            // 
+            resources.ApplyResources(this.WPNAV_LOIT_SPEED, "WPNAV_LOIT_SPEED");
+            this.WPNAV_LOIT_SPEED.Max = 1F;
+            this.WPNAV_LOIT_SPEED.Min = 0F;
+            this.WPNAV_LOIT_SPEED.Name = "WPNAV_LOIT_SPEED";
+            this.WPNAV_LOIT_SPEED.ParamName = null;
+            this.WPNAV_LOIT_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // WPNAV_SPEED_DN
+            // 
+            resources.ApplyResources(this.WPNAV_SPEED_DN, "WPNAV_SPEED_DN");
+            this.WPNAV_SPEED_DN.Max = 1F;
+            this.WPNAV_SPEED_DN.Min = 0F;
+            this.WPNAV_SPEED_DN.Name = "WPNAV_SPEED_DN";
+            this.WPNAV_SPEED_DN.ParamName = null;
+            this.WPNAV_SPEED_DN.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // WPNAV_RADIUS
+            // 
+            resources.ApplyResources(this.WPNAV_RADIUS, "WPNAV_RADIUS");
+            this.WPNAV_RADIUS.Max = 1F;
+            this.WPNAV_RADIUS.Min = 0F;
+            this.WPNAV_RADIUS.Name = "WPNAV_RADIUS";
+            this.WPNAV_RADIUS.ParamName = null;
+            this.WPNAV_RADIUS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // WPNAV_SPEED
+            // 
+            resources.ApplyResources(this.WPNAV_SPEED, "WPNAV_SPEED");
+            this.WPNAV_SPEED.Max = 1F;
+            this.WPNAV_SPEED.Min = 0F;
+            this.WPNAV_SPEED.Name = "WPNAV_SPEED";
+            this.WPNAV_SPEED.ParamName = null;
+            this.WPNAV_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // THR_ALT_P
+            // 
+            resources.ApplyResources(this.THR_ALT_P, "THR_ALT_P");
+            this.THR_ALT_P.Max = 1F;
+            this.THR_ALT_P.Min = 0F;
+            this.THR_ALT_P.Name = "THR_ALT_P";
+            this.THR_ALT_P.ParamName = null;
+            this.THR_ALT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // mavlinkNumericUpDownatc_input_tc
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_input_tc, "mavlinkNumericUpDownatc_input_tc");
+            this.mavlinkNumericUpDownatc_input_tc.Max = 1F;
+            this.mavlinkNumericUpDownatc_input_tc.Min = 0F;
+            this.mavlinkNumericUpDownatc_input_tc.Name = "mavlinkNumericUpDownatc_input_tc";
+            this.mavlinkNumericUpDownatc_input_tc.ParamName = null;
+            this.mavlinkNumericUpDownatc_input_tc.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // HLD_LAT_P
+            // 
+            resources.ApplyResources(this.HLD_LAT_P, "HLD_LAT_P");
+            this.HLD_LAT_P.Max = 1F;
+            this.HLD_LAT_P.Min = 0F;
+            this.HLD_LAT_P.Name = "HLD_LAT_P";
+            this.HLD_LAT_P.ParamName = null;
+            this.HLD_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // mavlinkNumericUpDownatc_accel_y_max
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_y_max, "mavlinkNumericUpDownatc_accel_y_max");
+            this.mavlinkNumericUpDownatc_accel_y_max.Max = 1F;
+            this.mavlinkNumericUpDownatc_accel_y_max.Min = 0F;
+            this.mavlinkNumericUpDownatc_accel_y_max.Name = "mavlinkNumericUpDownatc_accel_y_max";
+            this.mavlinkNumericUpDownatc_accel_y_max.ParamName = null;
+            this.mavlinkNumericUpDownatc_accel_y_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // STB_YAW_P
+            // 
+            resources.ApplyResources(this.STB_YAW_P, "STB_YAW_P");
+            this.STB_YAW_P.Max = 1F;
+            this.STB_YAW_P.Min = 0F;
+            this.STB_YAW_P.Name = "STB_YAW_P";
+            this.STB_YAW_P.ParamName = null;
+            this.STB_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // mavlinkNumericUpDownatc_accel_p_max
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_p_max, "mavlinkNumericUpDownatc_accel_p_max");
+            this.mavlinkNumericUpDownatc_accel_p_max.Max = 1F;
+            this.mavlinkNumericUpDownatc_accel_p_max.Min = 0F;
+            this.mavlinkNumericUpDownatc_accel_p_max.Name = "mavlinkNumericUpDownatc_accel_p_max";
+            this.mavlinkNumericUpDownatc_accel_p_max.ParamName = null;
+            this.mavlinkNumericUpDownatc_accel_p_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // STB_PIT_P
+            // 
+            resources.ApplyResources(this.STB_PIT_P, "STB_PIT_P");
+            this.STB_PIT_P.Max = 1F;
+            this.STB_PIT_P.Min = 0F;
+            this.STB_PIT_P.Name = "STB_PIT_P";
+            this.STB_PIT_P.ParamName = null;
+            this.STB_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // mavlinkNumericUpDownatc_accel_r_max
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_r_max, "mavlinkNumericUpDownatc_accel_r_max");
+            this.mavlinkNumericUpDownatc_accel_r_max.Max = 1F;
+            this.mavlinkNumericUpDownatc_accel_r_max.Min = 0F;
+            this.mavlinkNumericUpDownatc_accel_r_max.Name = "mavlinkNumericUpDownatc_accel_r_max";
+            this.mavlinkNumericUpDownatc_accel_r_max.ParamName = null;
+            this.mavlinkNumericUpDownatc_accel_r_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // STB_RLL_P
+            // 
+            resources.ApplyResources(this.STB_RLL_P, "STB_RLL_P");
+            this.STB_RLL_P.Max = 1F;
+            this.STB_RLL_P.Min = 0F;
+            this.STB_RLL_P.Name = "STB_RLL_P";
+            this.STB_RLL_P.ParamName = null;
+            this.STB_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // ATC_RAT_YAW_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_YAW_FLTT, "ATC_RAT_YAW_FLTT");
+            this.ATC_RAT_YAW_FLTT.Max = 1F;
+            this.ATC_RAT_YAW_FLTT.Min = 0F;
+            this.ATC_RAT_YAW_FLTT.Name = "ATC_RAT_YAW_FLTT";
+            this.ATC_RAT_YAW_FLTT.ParamName = null;
+            this.ATC_RAT_YAW_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // ATC_RAT_YAW_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_YAW_FLTD, "ATC_RAT_YAW_FLTD");
+            this.ATC_RAT_YAW_FLTD.Max = 1F;
+            this.ATC_RAT_YAW_FLTD.Min = 0F;
+            this.ATC_RAT_YAW_FLTD.Name = "ATC_RAT_YAW_FLTD";
+            this.ATC_RAT_YAW_FLTD.ParamName = null;
+            this.ATC_RAT_YAW_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_YAW_FILT
+            // 
+            resources.ApplyResources(this.RATE_YAW_FILT, "RATE_YAW_FILT");
+            this.RATE_YAW_FILT.Max = 1F;
+            this.RATE_YAW_FILT.Min = 0F;
+            this.RATE_YAW_FILT.Name = "RATE_YAW_FILT";
+            this.RATE_YAW_FILT.ParamName = null;
+            this.RATE_YAW_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_YAW_D
+            // 
+            resources.ApplyResources(this.RATE_YAW_D, "RATE_YAW_D");
+            this.RATE_YAW_D.Max = 1F;
+            this.RATE_YAW_D.Min = 0F;
+            this.RATE_YAW_D.Name = "RATE_YAW_D";
+            this.RATE_YAW_D.ParamName = null;
+            this.RATE_YAW_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_YAW_IMAX
+            // 
+            resources.ApplyResources(this.RATE_YAW_IMAX, "RATE_YAW_IMAX");
+            this.RATE_YAW_IMAX.Max = 1F;
+            this.RATE_YAW_IMAX.Min = 0F;
+            this.RATE_YAW_IMAX.Name = "RATE_YAW_IMAX";
+            this.RATE_YAW_IMAX.ParamName = null;
+            this.RATE_YAW_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_YAW_I
+            // 
+            resources.ApplyResources(this.RATE_YAW_I, "RATE_YAW_I");
+            this.RATE_YAW_I.Max = 1F;
+            this.RATE_YAW_I.Min = 0F;
+            this.RATE_YAW_I.Name = "RATE_YAW_I";
+            this.RATE_YAW_I.ParamName = null;
+            this.RATE_YAW_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_YAW_P
+            // 
+            resources.ApplyResources(this.RATE_YAW_P, "RATE_YAW_P");
+            this.RATE_YAW_P.Max = 1F;
+            this.RATE_YAW_P.Min = 0F;
+            this.RATE_YAW_P.Name = "RATE_YAW_P";
+            this.RATE_YAW_P.ParamName = null;
+            this.RATE_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // ATC_RAT_RLL_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_RLL_FLTT, "ATC_RAT_RLL_FLTT");
+            this.ATC_RAT_RLL_FLTT.Max = 1F;
+            this.ATC_RAT_RLL_FLTT.Min = 0F;
+            this.ATC_RAT_RLL_FLTT.Name = "ATC_RAT_RLL_FLTT";
+            this.ATC_RAT_RLL_FLTT.ParamName = null;
+            this.ATC_RAT_RLL_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // ATC_RAT_RLL_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_RLL_FLTD, "ATC_RAT_RLL_FLTD");
+            this.ATC_RAT_RLL_FLTD.Max = 1F;
+            this.ATC_RAT_RLL_FLTD.Min = 0F;
+            this.ATC_RAT_RLL_FLTD.Name = "ATC_RAT_RLL_FLTD";
+            this.ATC_RAT_RLL_FLTD.ParamName = null;
+            this.ATC_RAT_RLL_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_PIT_FILT
+            // 
+            resources.ApplyResources(this.RATE_PIT_FILT, "RATE_PIT_FILT");
+            this.RATE_PIT_FILT.Max = 1F;
+            this.RATE_PIT_FILT.Min = 0F;
+            this.RATE_PIT_FILT.Name = "RATE_PIT_FILT";
+            this.RATE_PIT_FILT.ParamName = null;
+            this.RATE_PIT_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_PIT_D
+            // 
+            resources.ApplyResources(this.RATE_PIT_D, "RATE_PIT_D");
+            this.RATE_PIT_D.Max = 1F;
+            this.RATE_PIT_D.Min = 0F;
+            this.RATE_PIT_D.Name = "RATE_PIT_D";
+            this.RATE_PIT_D.ParamName = null;
+            this.RATE_PIT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_PIT_IMAX
+            // 
+            resources.ApplyResources(this.RATE_PIT_IMAX, "RATE_PIT_IMAX");
+            this.RATE_PIT_IMAX.Max = 1F;
+            this.RATE_PIT_IMAX.Min = 0F;
+            this.RATE_PIT_IMAX.Name = "RATE_PIT_IMAX";
+            this.RATE_PIT_IMAX.ParamName = null;
+            this.RATE_PIT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_PIT_I
+            // 
+            resources.ApplyResources(this.RATE_PIT_I, "RATE_PIT_I");
+            this.RATE_PIT_I.Max = 1F;
+            this.RATE_PIT_I.Min = 0F;
+            this.RATE_PIT_I.Name = "RATE_PIT_I";
+            this.RATE_PIT_I.ParamName = null;
+            this.RATE_PIT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_PIT_P
+            // 
+            resources.ApplyResources(this.RATE_PIT_P, "RATE_PIT_P");
+            this.RATE_PIT_P.Max = 1F;
+            this.RATE_PIT_P.Min = 0F;
+            this.RATE_PIT_P.Name = "RATE_PIT_P";
+            this.RATE_PIT_P.ParamName = null;
+            this.RATE_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // ATC_RAT_PIT_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_PIT_FLTT, "ATC_RAT_PIT_FLTT");
+            this.ATC_RAT_PIT_FLTT.Max = 1F;
+            this.ATC_RAT_PIT_FLTT.Min = 0F;
+            this.ATC_RAT_PIT_FLTT.Name = "ATC_RAT_PIT_FLTT";
+            this.ATC_RAT_PIT_FLTT.ParamName = null;
+            this.ATC_RAT_PIT_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // ATC_RAT_PIT_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_PIT_FLTD, "ATC_RAT_PIT_FLTD");
+            this.ATC_RAT_PIT_FLTD.Max = 1F;
+            this.ATC_RAT_PIT_FLTD.Min = 0F;
+            this.ATC_RAT_PIT_FLTD.Name = "ATC_RAT_PIT_FLTD";
+            this.ATC_RAT_PIT_FLTD.ParamName = null;
+            this.ATC_RAT_PIT_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_RLL_FILT
+            // 
+            resources.ApplyResources(this.RATE_RLL_FILT, "RATE_RLL_FILT");
+            this.RATE_RLL_FILT.Max = 1F;
+            this.RATE_RLL_FILT.Min = 0F;
+            this.RATE_RLL_FILT.Name = "RATE_RLL_FILT";
+            this.RATE_RLL_FILT.ParamName = null;
+            this.RATE_RLL_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_RLL_D
+            // 
+            resources.ApplyResources(this.RATE_RLL_D, "RATE_RLL_D");
+            this.RATE_RLL_D.Max = 1F;
+            this.RATE_RLL_D.Min = 0F;
+            this.RATE_RLL_D.Name = "RATE_RLL_D";
+            this.RATE_RLL_D.ParamName = null;
+            this.RATE_RLL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_RLL_IMAX
+            // 
+            resources.ApplyResources(this.RATE_RLL_IMAX, "RATE_RLL_IMAX");
+            this.RATE_RLL_IMAX.Max = 1F;
+            this.RATE_RLL_IMAX.Min = 0F;
+            this.RATE_RLL_IMAX.Name = "RATE_RLL_IMAX";
+            this.RATE_RLL_IMAX.ParamName = null;
+            this.RATE_RLL_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_RLL_I
+            // 
+            resources.ApplyResources(this.RATE_RLL_I, "RATE_RLL_I");
+            this.RATE_RLL_I.Max = 1F;
+            this.RATE_RLL_I.Min = 0F;
+            this.RATE_RLL_I.Name = "RATE_RLL_I";
+            this.RATE_RLL_I.ParamName = null;
+            this.RATE_RLL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // RATE_RLL_P
+            // 
+            resources.ApplyResources(this.RATE_RLL_P, "RATE_RLL_P");
+            this.RATE_RLL_P.Max = 1F;
+            this.RATE_RLL_P.Min = 0F;
+            this.RATE_RLL_P.Name = "RATE_RLL_P";
+            this.RATE_RLL_P.ParamName = null;
+            this.RATE_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // INS_LOG_BAT_OPT
             // 
@@ -1446,40 +1473,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.INS_LOG_BAT_OPT.ParamName = null;
             this.INS_LOG_BAT_OPT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
-            // label36
+            // INS_HNTCH_ENABLE
             // 
-            resources.ApplyResources(this.label36, "label36");
-            this.label36.Name = "label36";
-            // 
-            // INS_LOG_BAT_MASK
-            // 
-            resources.ApplyResources(this.INS_LOG_BAT_MASK, "INS_LOG_BAT_MASK");
-            this.INS_LOG_BAT_MASK.Max = 1F;
-            this.INS_LOG_BAT_MASK.Min = 0F;
-            this.INS_LOG_BAT_MASK.Name = "INS_LOG_BAT_MASK";
-            this.INS_LOG_BAT_MASK.ParamName = null;
-            this.INS_LOG_BAT_MASK.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // label34
-            // 
-            resources.ApplyResources(this.label34, "label34");
-            this.label34.Name = "label34";
-            // 
-            // label52
-            // 
-            resources.ApplyResources(this.label52, "label52");
-            this.label52.Name = "label52";
-            // 
-            // CH6_OPTION
-            // 
-            this.CH6_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CH6_OPTION.DropDownWidth = 170;
-            resources.ApplyResources(this.CH6_OPTION, "CH6_OPTION");
-            this.CH6_OPTION.FormattingEnabled = true;
-            this.CH6_OPTION.Name = "CH6_OPTION";
-            this.CH6_OPTION.ParamName = null;
-            this.CH6_OPTION.SubControl = null;
-            this.CH6_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_ENABLE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.INS_HNTCH_ENABLE.DropDownWidth = 170;
+            resources.ApplyResources(this.INS_HNTCH_ENABLE, "INS_HNTCH_ENABLE");
+            this.INS_HNTCH_ENABLE.FormattingEnabled = true;
+            this.INS_HNTCH_ENABLE.Name = "INS_HNTCH_ENABLE";
+            this.INS_HNTCH_ENABLE.ParamName = null;
+            this.INS_HNTCH_ENABLE.SubControl = null;
+            this.INS_HNTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // ConfigArducopter
             // 
@@ -1520,73 +1523,32 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Controls.Add(this.groupBox24);
             this.Controls.Add(this.groupBox25);
             this.Name = "ConfigArducopter";
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).EndInit();
             this.groupBox5.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.THR_RATE_P)).EndInit();
             this.groupBox4.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_UP)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_LOIT_SPEED)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_DN)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_RADIUS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED)).EndInit();
             this.groupBox7.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ALT_P)).EndInit();
             this.groupBox19.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_input_tc)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.HLD_LAT_P)).EndInit();
             this.groupBox20.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_y_max)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.STB_YAW_P)).EndInit();
             this.groupBox21.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_p_max)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.STB_PIT_P)).EndInit();
             this.groupBox22.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).EndInit();
             this.groupBox23.ResumeLayout(false);
             this.groupBox23.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).EndInit();
             this.groupBox24.ResumeLayout(false);
             this.groupBox24.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).EndInit();
             this.groupBox25.ResumeLayout(false);
             this.groupBox25.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_P)).EndInit();
             this.groupBox1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).EndInit();
             this.groupBox2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).EndInit();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).EndInit();
             this.groupBox9.ResumeLayout(false);
             this.groupBox9.PerformLayout();
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).EndInit();
@@ -1594,17 +1556,55 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ENABLE)).EndInit();
-            this.groupBox8.ResumeLayout(false);
-            this.groupBox8.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ENABLE)).EndInit();
-            this.groupBox6.ResumeLayout(false);
-            this.groupBox6.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_RATE_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_UP)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_LOIT_SPEED)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_DN)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_RADIUS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ALT_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_input_tc)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.HLD_LAT_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_y_max)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.STB_YAW_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_p_max)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.STB_PIT_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_P)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_OPT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_MASK)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1726,13 +1726,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private Controls.MavlinkNumericUpDown INS_ACCEL_FILTER;
         private Label label26;
         private GroupBox groupBox6;
-        private Controls.MavlinkNumericUpDown INS_LOG_BAT_OPT;
         private Label label36;
-        private Controls.MavlinkNumericUpDown INS_LOG_BAT_MASK;
         private Label label34;
         private GroupBox groupBox9;
         private GroupBox groupBox8;
-        private Controls.MavlinkNumericUpDown INS_NOTCH_ENABLE;
         private Label label37;
         private Controls.MavlinkNumericUpDown INS_NOTCH_ATT;
         private Label label40;
@@ -1746,7 +1743,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private Label label43;
         private Controls.MavlinkNumericUpDown INS_HNTCH_MODE;
         private Label label44;
-        private Controls.MavlinkNumericUpDown INS_HNTCH_ENABLE;
         private Label label45;
         private Controls.MavlinkNumericUpDown INS_HNTCH_HMNCS;
         private Label label51;
@@ -1770,5 +1766,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private Label label30;
         private Controls.MavlinkNumericUpDown ATC_RAT_RLL_FLTD;
         private Label label29;
+        private Controls.MavlinkComboBox INS_LOG_BAT_MASK;
+        private Controls.MavlinkComboBox INS_NOTCH_ENABLE;
+        private Controls.MavlinkComboBox INS_HNTCH_ENABLE;
+        private Controls.MavlinkNumericUpDown INS_LOG_BAT_OPT;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigArducopter.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.cs
@@ -51,11 +51,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     .GetParameterOptionsInt("TUNE", MainV2.comPort.MAV.cs.firmware.ToString())
                     .ToList(), "TUNE", MainV2.comPort.MAV.param);
 
+            CH6_OPTION.setup(new[] { "CH6_OPT", "CH6_OPTION", "RC6_OPTION", "RC6_OPTION" }, MainV2.comPort.MAV.param);
             CH7_OPTION.setup(new[] {"CH7_OPT", "CH7_OPTION", "RC7_OPTION", "RC7_OPTION"}, MainV2.comPort.MAV.param);
             CH8_OPTION.setup(new[] {"CH8_OPT", "CH8_OPTION", "RC8_OPTION", "RC8_OPTION"}, MainV2.comPort.MAV.param);
             CH9_OPTION.setup(new[] {"CH9_OPT", "CH9_OPTION", "RC9_OPTION", "RC9_OPTION"}, MainV2.comPort.MAV.param);
-            CH10_OPTION.setup(new[] {"CH10_OPT", "CH10_OPTION", "RC10_OPTION", "RC10_OPTION"},
-                MainV2.comPort.MAV.param);
+            CH10_OPTION.setup(new[] {"CH10_OPT", "CH10_OPTION", "RC10_OPTION", "RC10_OPTION"}, MainV2.comPort.MAV.param);
 
             TUNE_LOW.setup(0, 10000, 1, 0.01f, new[] {"TUNE_LOW", "TUNE_MIN"},
                 MainV2.comPort.MAV.param);
@@ -74,53 +74,38 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             LOITER_LAT_P.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_P", "VEL_XY_P", "PSC_VELXY_P", "Q_P_VELXY_P"},
                 MainV2.comPort.MAV.param);
 
-            RATE_PIT_D.setup(0, 0, 1, 0.001f, new[] {"RATE_PIT_D", "ATC_RAT_PIT_D", "Q_A_RAT_PIT_D"},
-                MainV2.comPort.MAV.param);
-            RATE_PIT_I.setup(0, 0, 1, 0.001f, new[] {"RATE_PIT_I", "ATC_RAT_PIT_I", "Q_A_RAT_PIT_I"},
-                MainV2.comPort.MAV.param);
+            RATE_PIT_P.setup(0, 0, 1, 0.001f, new[] { "RATE_PIT_P", "ATC_RAT_PIT_P", "Q_A_RAT_PIT_P" }, MainV2.comPort.MAV.param);
+            RATE_PIT_I.setup(0, 0, 1, 0.001f, new[] { "RATE_PIT_I", "ATC_RAT_PIT_I", "Q_A_RAT_PIT_I" }, MainV2.comPort.MAV.param);
+            RATE_PIT_D.setup(0, 0, 1, 0.0001f, new[] {"RATE_PIT_D", "ATC_RAT_PIT_D", "Q_A_RAT_PIT_D"}, MainV2.comPort.MAV.param);
             if (MainV2.comPort.MAV.param.ContainsKey("ATC_RAT_PIT_IMAX")) // 3.4 changes scaling
-                RATE_PIT_IMAX.setup(0, 0, 1, 1f, new[] {"ATC_RAT_PIT_IMAX", "Q_A_RAT_PIT_IMAX"},
-                    MainV2.comPort.MAV.param);
+                RATE_PIT_IMAX.setup(0, 0, 1, 1f, new[] {"ATC_RAT_PIT_IMAX", "Q_A_RAT_PIT_IMAX"},  MainV2.comPort.MAV.param);
             else
-                RATE_PIT_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_PIT_IMAX", "RATE_PIT_IMAX"},
-                    MainV2.comPort.MAV.param);
-            RATE_PIT_P.setup(0, 0, 1, 0.001f, new[] {"RATE_PIT_P", "ATC_RAT_PIT_P", "Q_A_RAT_PIT_P"},
-                MainV2.comPort.MAV.param);
-            RATE_PIT_FILT.setup(0, 0, 1, 0.001f,
-                new[] {"RATE_PIT_FILT", "ATC_RAT_PIT_FILT", "ATC_RAT_PIT_FLTE", "Q_A_RAT_PIT_FLTE"},
-                MainV2.comPort.MAV.param);
+                RATE_PIT_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_PIT_IMAX", "RATE_PIT_IMAX"}, MainV2.comPort.MAV.param);
+            RATE_PIT_FILT.setup(0, 0, 1, 0.001f, new[] {"RATE_PIT_FILT", "ATC_RAT_PIT_FILT", "ATC_RAT_PIT_FLTE", "Q_A_RAT_PIT_FLTE"}, MainV2.comPort.MAV.param);
+            ATC_RAT_PIT_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_PIT_FLTD", "ATC_RAT_PIT_FLTD" }, MainV2.comPort.MAV.param);
+            ATC_RAT_PIT_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_PIT_FLTT", "ATC_RAT_PIT_FLTT" }, MainV2.comPort.MAV.param);
 
-            RATE_RLL_D.setup(0, 0, 1, 0.001f, new[] {"RATE_RLL_D", "ATC_RAT_RLL_D", "Q_A_RAT_RLL_D"},
-                MainV2.comPort.MAV.param);
-            RATE_RLL_I.setup(0, 0, 1, 0.001f, new[] {"RATE_RLL_I", "ATC_RAT_RLL_I", "Q_A_RAT_RLL_I"},
-                MainV2.comPort.MAV.param);
+            RATE_RLL_P.setup(0, 0, 1, 0.001f, new[] { "RATE_RLL_P", "ATC_RAT_RLL_P", "Q_A_RAT_RLL_P" }, MainV2.comPort.MAV.param);
+            RATE_RLL_I.setup(0, 0, 1, 0.001f, new[] { "RATE_RLL_I", "ATC_RAT_RLL_I", "Q_A_RAT_RLL_I" }, MainV2.comPort.MAV.param);
+            RATE_RLL_D.setup(0, 0, 1, 0.0001f, new[] {"RATE_RLL_D", "ATC_RAT_RLL_D", "Q_A_RAT_RLL_D"}, MainV2.comPort.MAV.param);
             if (MainV2.comPort.MAV.param.ContainsKey("ATC_RAT_RLL_IMAX")) // 3.4 changes scaling
-                RATE_RLL_IMAX.setup(0, 0, 1, 1f, new[] {"ATC_RAT_RLL_IMAX", "Q_A_RAT_RLL_IMAX"},
-                    MainV2.comPort.MAV.param);
+                RATE_RLL_IMAX.setup(0, 0, 1, 1f, new[] {"ATC_RAT_RLL_IMAX", "Q_A_RAT_RLL_IMAX"}, MainV2.comPort.MAV.param);
             else
-                RATE_RLL_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_RLL_IMAX"},
-                    MainV2.comPort.MAV.param);
-            RATE_RLL_P.setup(0, 0, 1, 0.001f, new[] {"RATE_RLL_P", "ATC_RAT_RLL_P", "Q_A_RAT_RLL_P"},
-                MainV2.comPort.MAV.param);
-            RATE_RLL_FILT.setup(0, 0, 1, 0.001f,
-                new[] {"RATE_RLL_FILT", "ATC_RAT_RLL_FILT", "ATC_RAT_RLL_FLTE", "Q_A_RAT_RLL_FLTE"},
-                MainV2.comPort.MAV.param);
+                RATE_RLL_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_RLL_IMAX"}, MainV2.comPort.MAV.param);
+            RATE_RLL_FILT.setup(0, 0, 1, 0.001f, new[] {"RATE_RLL_FILT", "ATC_RAT_RLL_FILT", "ATC_RAT_RLL_FLTE", "Q_A_RAT_RLL_FLTE"}, MainV2.comPort.MAV.param);
+            ATC_RAT_RLL_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_RLL_FLTD", "ATC_RAT_RLL_FLTD" }, MainV2.comPort.MAV.param);
+            ATC_RAT_RLL_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_RLL_FLTT", "ATC_RAT_RLL_FLTT" }, MainV2.comPort.MAV.param);
 
-            RATE_YAW_D.setup(0, 0, 1, 0.001f, new[] {"RATE_YAW_D", "ATC_RAT_YAW_D", "Q_A_RAT_YAW_D"},
-                MainV2.comPort.MAV.param);
-            RATE_YAW_I.setup(0, 0, 1, 0.001f, new[] {"RATE_YAW_I", "ATC_RAT_YAW_I", "Q_A_RAT_YAW_I"},
-                MainV2.comPort.MAV.param);
+            RATE_YAW_P.setup(0, 0, 1, 0.001f, new[] { "RATE_YAW_P", "ATC_RAT_YAW_P", "Q_A_RAT_YAW_P" }, MainV2.comPort.MAV.param);
+            RATE_YAW_I.setup(0, 0, 1, 0.001f, new[] { "RATE_YAW_I", "ATC_RAT_YAW_I", "Q_A_RAT_YAW_I" }, MainV2.comPort.MAV.param);
+            RATE_YAW_D.setup(0, 0, 1, 0.0001f, new[] {"RATE_YAW_D", "ATC_RAT_YAW_D", "Q_A_RAT_YAW_D"}, MainV2.comPort.MAV.param);
             if (MainV2.comPort.MAV.param.ContainsKey("ATC_RAT_YAW_IMAX")) // 3.4 changes scaling
-                RATE_YAW_IMAX.setup(0, 0, 1, 1f, new[] {"ATC_RAT_YAW_IMAX", "Q_A_RAT_YAW_IMAX"},
-                    MainV2.comPort.MAV.param);
+                RATE_YAW_IMAX.setup(0, 0, 1, 1f, new[] {"ATC_RAT_YAW_IMAX", "Q_A_RAT_YAW_IMAX"}, MainV2.comPort.MAV.param);
             else
-                RATE_YAW_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_YAW_IMAX"},
-                    MainV2.comPort.MAV.param);
-            RATE_YAW_P.setup(0, 0, 1, 0.001f, new[] {"RATE_YAW_P", "ATC_RAT_YAW_P", "Q_A_RAT_YAW_P"},
-                MainV2.comPort.MAV.param);
-            RATE_YAW_FILT.setup(0, 0, 1, 0.001f,
-                new[] {"RATE_YAW_FILT", "ATC_RAT_YAW_FILT", "ATC_RAT_YAW_FLTE", "Q_A_RAT_YAW_FLTE"},
-                MainV2.comPort.MAV.param);
+                RATE_YAW_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_YAW_IMAX"}, MainV2.comPort.MAV.param);
+            RATE_YAW_FILT.setup(0, 0, 1, 0.001f, new[] {"RATE_YAW_FILT", "ATC_RAT_YAW_FILT", "ATC_RAT_YAW_FLTE", "Q_A_RAT_YAW_FLTE"}, MainV2.comPort.MAV.param);
+            ATC_RAT_YAW_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_YAW_FLTD", "ATC_RAT_YAW_FLTD" }, MainV2.comPort.MAV.param);
+            ATC_RAT_YAW_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_YAW_FLTT", "ATC_RAT_YAW_FLTT" }, MainV2.comPort.MAV.param);
 
             STB_PIT_P.setup(0, 0, 1, 0.001f, new[] {"STB_PIT_P", "ATC_ANG_PIT_P", "Q_A_ANG_PIT_P"},
                 MainV2.comPort.MAV.param);
@@ -129,15 +114,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             STB_YAW_P.setup(0, 0, 1, 0.001f, new[] {"STB_YAW_P", "ATC_ANG_YAW_P", "Q_A_ANG_YAW_P"},
                 MainV2.comPort.MAV.param);
 
+
+            THR_ACCEL_P.setup(0, 0, 1, 0.001f, new[] { "THR_ACCEL_P", "ACCEL_Z_P", "PSC_ACCZ_P", "Q_P_ACCZ_P" },
+                MainV2.comPort.MAV.param);
+            THR_ACCEL_I.setup(0, 0, 1, 0.001f, new[] { "THR_ACCEL_I", "ACCEL_Z_I", "PSC_ACCZ_I", "Q_P_ACCZ_I" },
+                MainV2.comPort.MAV.param);
             THR_ACCEL_D.setup(0, 0, 1, 0.001f, new[] {"THR_ACCEL_D", "ACCEL_Z_D", "PSC_ACCZ_D", "Q_P_ACCZ_D"},
                 MainV2.comPort.MAV.param);
-            THR_ACCEL_I.setup(0, 0, 1, 0.001f, new[] {"THR_ACCEL_I", "ACCEL_Z_I", "PSC_ACCZ_I", "Q_P_ACCZ_I"},
+            THR_ACCEL_IMAX.setup(0, 0, 10, 1f, new[] {"THR_ACCEL_IMAX", "ACCEL_Z_IMAX", "PSC_ACCZ_IMAX", "Q_P_ACCZ_IMAX"},
                 MainV2.comPort.MAV.param);
-            THR_ACCEL_IMAX.setup(0, 0, 10, 1f,
-                new[] {"THR_ACCEL_IMAX", "ACCEL_Z_IMAX", "PSC_ACCZ_IMAX", "Q_P_ACCZ_IMAX"},
-                MainV2.comPort.MAV.param);
-            THR_ACCEL_P.setup(0, 0, 1, 0.001f, new[] {"THR_ACCEL_P", "ACCEL_Z_P", "PSC_ACCZ_P", "Q_P_ACCZ_P"},
-                MainV2.comPort.MAV.param);
+
             THR_ALT_P.setup(0, 0, 1, 0.001f, new[] {"THR_ALT_P", "POS_Z_P", "PSC_POSZ_P", "Q_P_POSZ_P"},
                 MainV2.comPort.MAV.param);
             THR_RATE_P.setup(0, 0, 1, 0.001f, new[] {"THR_RATE_P", "VEL_Z_P", "PSC_VELZ_P", "Q_P_VELZ_P"},
@@ -149,6 +135,26 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             WPNAV_SPEED.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED", "Q_WP_SPEED"}, MainV2.comPort.MAV.param);
             WPNAV_SPEED_DN.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_DN", "Q_WP_SPEED_DN"}, MainV2.comPort.MAV.param);
             WPNAV_SPEED_UP.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_UP", "Q_WP_SPEED_UP"}, MainV2.comPort.MAV.param);
+
+            INS_GYRO_FILTER.setup(0, 0, 1, 1f, new[] { "INS_GYRO_FILTER", "INS_GYRO_FILTER" }, MainV2.comPort.MAV.param);
+            INS_ACCEL_FILTER.setup(0, 0, 1, 1f, new[] { "INS_ACCEL_FILTER", "INS_ACCEL_FILTER" }, MainV2.comPort.MAV.param);
+
+            INS_LOG_BAT_MASK.setup(0, 0, 1, 1f, new[] { "INS_LOG_BAT_MASK", "INS_LOG_BAT_MASK" }, MainV2.comPort.MAV.param);
+            INS_LOG_BAT_OPT.setup(0, 0, 1, 1f, new[] { "INS_LOG_BAT_OPT", "INS_LOG_BAT_OPT" }, MainV2.comPort.MAV.param);
+
+            INS_NOTCH_ENABLE.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_ENABLE", "INS_NOTCH_ENABLE" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_FREQ.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_FREQ", "INS_NOTCH_FREQ" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_BW.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_BW", "INS_NOTCH_BW" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_ATT.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_ATT", "INS_NOTCH_ATT" }, MainV2.comPort.MAV.param);
+
+            INS_HNTCH_ENABLE.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_ENABLE", "INS_HNTCH_ENABLE" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_MODE.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_MODE", "INS_HNTCH_MODE" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_REF.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_REF", "INS_HNTCH_REF" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_FREQ.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_FREQ", "INS_HNTCH_FREQ" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_ATT.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_ATT", "INS_HNTCH_ATT" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_BW.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_BW", "INS_HNTCH_BW" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_OPTS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_OPTS", "INS_HNTCH_OPTS" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_HMNCS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_HMNCS", "INS_HNTCH_HMNCS" }, MainV2.comPort.MAV.param);
 
             mavlinkNumericUpDownatc_accel_r_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_R_MAX", "Q_A_ACCEL_R_MAX"},
                 MainV2.comPort.MAV.param);

--- a/GCSViews/ConfigurationView/ConfigArducopter.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.cs
@@ -93,8 +93,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             else
                 RATE_RLL_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_RLL_IMAX"}, MainV2.comPort.MAV.param);
             RATE_RLL_FILT.setup(0, 0, 1, 0.001f, new[] {"RATE_RLL_FILT", "ATC_RAT_RLL_FILT", "ATC_RAT_RLL_FLTE", "Q_A_RAT_RLL_FLTE"}, MainV2.comPort.MAV.param);
-            ATC_RAT_RLL_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_RLL_FLTD", "ATC_RAT_RLL_FLTD" }, MainV2.comPort.MAV.param);
-            ATC_RAT_RLL_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_RLL_FLTT", "ATC_RAT_RLL_FLTT" }, MainV2.comPort.MAV.param);
+            ATC_RAT_RLL_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_RLL_FLTD" }, MainV2.comPort.MAV.param);
+            ATC_RAT_RLL_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_RLL_FLTT" }, MainV2.comPort.MAV.param);
 
             RATE_YAW_P.setup(0, 0, 1, 0.001f, new[] { "RATE_YAW_P", "ATC_RAT_YAW_P", "Q_A_RAT_YAW_P" }, MainV2.comPort.MAV.param);
             RATE_YAW_I.setup(0, 0, 1, 0.001f, new[] { "RATE_YAW_I", "ATC_RAT_YAW_I", "Q_A_RAT_YAW_I" }, MainV2.comPort.MAV.param);
@@ -104,8 +104,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             else
                 RATE_YAW_IMAX.setup(0, 0, 10, 1f, new[] {"RATE_YAW_IMAX"}, MainV2.comPort.MAV.param);
             RATE_YAW_FILT.setup(0, 0, 1, 0.001f, new[] {"RATE_YAW_FILT", "ATC_RAT_YAW_FILT", "ATC_RAT_YAW_FLTE", "Q_A_RAT_YAW_FLTE"}, MainV2.comPort.MAV.param);
-            ATC_RAT_YAW_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_YAW_FLTD", "ATC_RAT_YAW_FLTD" }, MainV2.comPort.MAV.param);
-            ATC_RAT_YAW_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_YAW_FLTT", "ATC_RAT_YAW_FLTT" }, MainV2.comPort.MAV.param);
+            ATC_RAT_YAW_FLTD.setup(0, 0, 1, 1f, new[] { "ATC_RAT_YAW_FLTD" }, MainV2.comPort.MAV.param);
+            ATC_RAT_YAW_FLTT.setup(0, 0, 1, 1f, new[] { "ATC_RAT_YAW_FLTT" }, MainV2.comPort.MAV.param);
 
             STB_PIT_P.setup(0, 0, 1, 0.001f, new[] {"STB_PIT_P", "ATC_ANG_PIT_P", "Q_A_ANG_PIT_P"},
                 MainV2.comPort.MAV.param);
@@ -136,25 +136,25 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             WPNAV_SPEED_DN.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_DN", "Q_WP_SPEED_DN"}, MainV2.comPort.MAV.param);
             WPNAV_SPEED_UP.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_UP", "Q_WP_SPEED_UP"}, MainV2.comPort.MAV.param);
 
-            INS_GYRO_FILTER.setup(0, 0, 1, 1f, new[] { "INS_GYRO_FILTER", "INS_GYRO_FILTER" }, MainV2.comPort.MAV.param);
-            INS_ACCEL_FILTER.setup(0, 0, 1, 1f, new[] { "INS_ACCEL_FILTER", "INS_ACCEL_FILTER" }, MainV2.comPort.MAV.param);
+            INS_GYRO_FILTER.setup(0, 0, 1, 1f, new[] { "INS_GYRO_FILTER" }, MainV2.comPort.MAV.param);
+            INS_ACCEL_FILTER.setup(0, 0, 1, 1f, new[] { "INS_ACCEL_FILTER" }, MainV2.comPort.MAV.param);
 
-            INS_LOG_BAT_MASK.setup(0, 0, 1, 1f, new[] { "INS_LOG_BAT_MASK", "INS_LOG_BAT_MASK" }, MainV2.comPort.MAV.param);
-            INS_LOG_BAT_OPT.setup(0, 0, 1, 1f, new[] { "INS_LOG_BAT_OPT", "INS_LOG_BAT_OPT" }, MainV2.comPort.MAV.param);
+            INS_LOG_BAT_MASK.setup(new[] { "INS_LOG_BAT_MASK" }, MainV2.comPort.MAV.param);
+            INS_LOG_BAT_OPT.setup(0, 0, 1, 1f, new[] { "INS_LOG_BAT_OPT" }, MainV2.comPort.MAV.param);
 
-            INS_NOTCH_ENABLE.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_ENABLE", "INS_NOTCH_ENABLE" }, MainV2.comPort.MAV.param);
-            INS_NOTCH_FREQ.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_FREQ", "INS_NOTCH_FREQ" }, MainV2.comPort.MAV.param);
-            INS_NOTCH_BW.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_BW", "INS_NOTCH_BW" }, MainV2.comPort.MAV.param);
-            INS_NOTCH_ATT.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_ATT", "INS_NOTCH_ATT" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_ENABLE.setup(new[] { "INS_NOTCH_ENABLE" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_FREQ.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_FREQ" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_BW.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_BW" }, MainV2.comPort.MAV.param);
+            INS_NOTCH_ATT.setup(0, 0, 1, 1f, new[] { "INS_NOTCH_ATT" }, MainV2.comPort.MAV.param);
 
-            INS_HNTCH_ENABLE.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_ENABLE", "INS_HNTCH_ENABLE" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_MODE.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_MODE", "INS_HNTCH_MODE" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_REF.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_REF", "INS_HNTCH_REF" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_FREQ.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_FREQ", "INS_HNTCH_FREQ" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_ATT.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_ATT", "INS_HNTCH_ATT" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_BW.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_BW", "INS_HNTCH_BW" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_OPTS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_OPTS", "INS_HNTCH_OPTS" }, MainV2.comPort.MAV.param);
-            INS_HNTCH_HMNCS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_HMNCS", "INS_HNTCH_HMNCS" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_ENABLE.setup(new[] { "INS_HNTCH_ENABLE" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_MODE.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_MODE" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_REF.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_REF" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_FREQ.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_FREQ" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_ATT.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_ATT" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_BW.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_BW" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_OPTS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_OPTS" }, MainV2.comPort.MAV.param);
+            INS_HNTCH_HMNCS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_HMNCS" }, MainV2.comPort.MAV.param);
 
             mavlinkNumericUpDownatc_accel_r_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_R_MAX", "Q_A_ACCEL_R_MAX"},
                 MainV2.comPort.MAV.param);

--- a/GCSViews/ConfigurationView/ConfigArducopter.resx
+++ b/GCSViews/ConfigurationView/ConfigArducopter.resx
@@ -118,106 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="TUNE_LOW.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="TUNE_LOW.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 360</value>
-  </data>
-  <data name="TUNE_LOW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 20</value>
-  </data>
-  <data name="TUNE_LOW.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;TUNE_LOW.Name" xml:space="preserve">
-    <value>TUNE_LOW</value>
-  </data>
-  <data name="&gt;&gt;TUNE_LOW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;TUNE_LOW.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TUNE_LOW.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="TUNE_HIGH.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="TUNE_HIGH.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 360</value>
-  </data>
-  <data name="TUNE_HIGH.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 20</value>
-  </data>
-  <data name="TUNE_HIGH.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;TUNE_HIGH.Name" xml:space="preserve">
-    <value>TUNE_HIGH</value>
-  </data>
-  <data name="&gt;&gt;TUNE_HIGH.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;TUNE_HIGH.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TUNE_HIGH.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="TUNE.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="TUNE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>242, 332</value>
-  </data>
-  <data name="TUNE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
-  </data>
-  <data name="TUNE.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;TUNE.Name" xml:space="preserve">
-    <value>TUNE</value>
-  </data>
-  <data name="&gt;&gt;TUNE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;TUNE.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TUNE.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="CH7_OPTION.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CH7_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 361</value>
-  </data>
-  <data name="CH7_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
-  </data>
-  <data name="CH7_OPTION.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;CH7_OPTION.Name" xml:space="preserve">
-    <value>CH7_OPTION</value>
-  </data>
-  <data name="&gt;&gt;CH7_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CH7_OPTION.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CH7_OPTION.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
   <data name="THR_RATE_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="THR_RATE_P.Location" type="System.Drawing.Point, System.Drawing">
     <value>80, 13</value>
   </data>
@@ -231,7 +135,7 @@
     <value>THR_RATE_P</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -337,7 +241,7 @@
     <value>WPNAV_SPEED_UP</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -388,7 +292,7 @@
     <value>WPNAV_LOIT_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -439,7 +343,7 @@
     <value>WPNAV_SPEED_DN</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -490,7 +394,7 @@
     <value>WPNAV_RADIUS</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -541,7 +445,7 @@
     <value>WPNAV_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -616,7 +520,7 @@
     <value>THR_ALT_P</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Parent" xml:space="preserve">
     <value>groupBox7</value>
@@ -691,7 +595,7 @@
     <value>mavlinkNumericUpDownatc_input_tc</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -742,7 +646,7 @@
     <value>HLD_LAT_P</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -817,7 +721,7 @@
     <value>mavlinkNumericUpDownatc_accel_y_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -868,7 +772,7 @@
     <value>STB_YAW_P</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -943,7 +847,7 @@
     <value>mavlinkNumericUpDownatc_accel_p_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -994,7 +898,7 @@
     <value>STB_PIT_P</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -1069,7 +973,7 @@
     <value>mavlinkNumericUpDownatc_accel_r_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1120,7 +1024,7 @@
     <value>STB_RLL_P</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1195,7 +1099,7 @@
     <value>ATC_RAT_YAW_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1249,7 +1153,7 @@
     <value>ATC_RAT_YAW_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1303,7 +1207,7 @@
     <value>RATE_YAW_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1354,7 +1258,7 @@
     <value>RATE_YAW_D</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1405,7 +1309,7 @@
     <value>RATE_YAW_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1456,7 +1360,7 @@
     <value>RATE_YAW_I</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1507,7 +1411,7 @@
     <value>RATE_YAW_P</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1582,7 +1486,7 @@
     <value>ATC_RAT_RLL_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1636,7 +1540,7 @@
     <value>ATC_RAT_RLL_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1690,7 +1594,7 @@
     <value>RATE_PIT_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1741,7 +1645,7 @@
     <value>RATE_PIT_D</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1792,7 +1696,7 @@
     <value>RATE_PIT_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1843,7 +1747,7 @@
     <value>RATE_PIT_I</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1894,7 +1798,7 @@
     <value>RATE_PIT_P</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1969,7 +1873,7 @@
     <value>ATC_RAT_PIT_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2023,7 +1927,7 @@
     <value>ATC_RAT_PIT_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2077,7 +1981,7 @@
     <value>RATE_RLL_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2128,7 +2032,7 @@
     <value>RATE_RLL_D</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2179,7 +2083,7 @@
     <value>RATE_RLL_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2230,7 +2134,7 @@
     <value>RATE_RLL_I</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2281,7 +2185,7 @@
     <value>RATE_RLL_P</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2359,7 +2263,7 @@
     <value>LOITER_LAT_D</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2410,7 +2314,7 @@
     <value>LOITER_LAT_IMAX</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2461,7 +2365,7 @@
     <value>LOITER_LAT_I</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2512,7 +2416,7 @@
     <value>LOITER_LAT_P</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2634,6 +2538,9 @@
   <data name="myLabel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="myLabel3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="myLabel3.Location" type="System.Drawing.Point, System.Drawing">
     <value>183, 357</value>
   </data>
@@ -2661,6 +2568,9 @@
   <data name="myLabel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="myLabel2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="myLabel2.Location" type="System.Drawing.Point, System.Drawing">
     <value>183, 332</value>
   </data>
@@ -2687,6 +2597,9 @@
   </data>
   <data name="myLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="myLabel1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="myLabel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>357, 361</value>
@@ -2728,7 +2641,7 @@
     <value>THR_ACCEL_D</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2806,7 +2719,7 @@
     <value>THR_ACCEL_IMAX</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2830,7 +2743,7 @@
     <value>THR_ACCEL_I</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2881,7 +2794,7 @@
     <value>THR_ACCEL_P</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2973,6 +2886,9 @@
   <data name="myLabel4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="myLabel4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="myLabel4.Location" type="System.Drawing.Point, System.Drawing">
     <value>357, 388</value>
   </data>
@@ -2997,32 +2913,11 @@
   <data name="&gt;&gt;myLabel4.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
-  <data name="CH8_OPTION.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CH8_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 388</value>
-  </data>
-  <data name="CH8_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
-  </data>
-  <data name="CH8_OPTION.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;CH8_OPTION.Name" xml:space="preserve">
-    <value>CH8_OPTION</value>
-  </data>
-  <data name="&gt;&gt;CH8_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CH8_OPTION.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CH8_OPTION.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="myLabel5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="myLabel5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="myLabel5.Location" type="System.Drawing.Point, System.Drawing">
     <value>357, 415</value>
@@ -3048,32 +2943,11 @@
   <data name="&gt;&gt;myLabel5.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="CH9_OPTION.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CH9_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 415</value>
-  </data>
-  <data name="CH9_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
-  </data>
-  <data name="CH9_OPTION.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="&gt;&gt;CH9_OPTION.Name" xml:space="preserve">
-    <value>CH9_OPTION</value>
-  </data>
-  <data name="&gt;&gt;CH9_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CH9_OPTION.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CH9_OPTION.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="myLabel6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="myLabel6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="myLabel6.Location" type="System.Drawing.Point, System.Drawing">
     <value>357, 442</value>
@@ -3099,30 +2973,6 @@
   <data name="&gt;&gt;myLabel6.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="CH10_OPTION.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CH10_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 442</value>
-  </data>
-  <data name="CH10_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
-  </data>
-  <data name="CH10_OPTION.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
-  </data>
-  <data name="&gt;&gt;CH10_OPTION.Name" xml:space="preserve">
-    <value>CH10_OPTION</value>
-  </data>
-  <data name="&gt;&gt;CH10_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CH10_OPTION.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CH10_OPTION.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="INS_ACCEL_FILTER.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -3139,7 +2989,7 @@
     <value>INS_ACCEL_FILTER</value>
   </data>
   <data name="&gt;&gt;INS_ACCEL_FILTER.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_ACCEL_FILTER.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -3193,7 +3043,7 @@
     <value>INS_GYRO_FILTER</value>
   </data>
   <data name="&gt;&gt;INS_GYRO_FILTER.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_GYRO_FILTER.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -3203,6 +3053,9 @@
   </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="label24.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 16</value>
@@ -3252,6 +3105,30 @@
   <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="INS_HNTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>64, 26</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 21</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
+    <value>69</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.Name" xml:space="preserve">
+    <value>INS_HNTCH_ENABLE</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="INS_HNTCH_HMNCS.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -3268,13 +3145,13 @@
     <value>INS_HNTCH_HMNCS</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="label51.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3304,7 +3181,7 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label51.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="INS_HNTCH_OPTS.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3322,13 +3199,13 @@
     <value>INS_HNTCH_OPTS</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label50.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3358,7 +3235,7 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label50.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="INS_HNTCH_BW.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3376,13 +3253,13 @@
     <value>INS_HNTCH_BW</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label49.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3412,7 +3289,7 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label49.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="INS_HNTCH_ATT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3430,13 +3307,13 @@
     <value>INS_HNTCH_ATT</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="label48.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3466,7 +3343,7 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label48.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="INS_HNTCH_FREQ.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3484,13 +3361,13 @@
     <value>INS_HNTCH_FREQ</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="label41.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3520,7 +3397,7 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="INS_HNTCH_REF.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3538,13 +3415,13 @@
     <value>INS_HNTCH_REF</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="label43.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3574,7 +3451,7 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="INS_HNTCH_MODE.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3592,13 +3469,13 @@
     <value>INS_HNTCH_MODE</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.Parent" xml:space="preserve">
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="label44.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3628,30 +3505,6 @@
     <value>groupBox9</value>
   </data>
   <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="INS_HNTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="INS_HNTCH_ENABLE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>64, 27</value>
-  </data>
-  <data name="INS_HNTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
-  </data>
-  <data name="INS_HNTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
-    <value>54</value>
-  </data>
-  <data name="&gt;&gt;INS_HNTCH_ENABLE.Name" xml:space="preserve">
-    <value>INS_HNTCH_ENABLE</value>
-  </data>
-  <data name="&gt;&gt;INS_HNTCH_ENABLE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;INS_HNTCH_ENABLE.Parent" xml:space="preserve">
-    <value>groupBox9</value>
-  </data>
-  <data name="&gt;&gt;INS_HNTCH_ENABLE.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
   <data name="label45.AutoSize" type="System.Boolean, mscorlib">
@@ -3708,6 +3561,30 @@
   <data name="&gt;&gt;groupBox9.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="INS_NOTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 26</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 21</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
+    <value>53</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.Name" xml:space="preserve">
+    <value>INS_NOTCH_ENABLE</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="INS_NOTCH_ATT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -3724,13 +3601,13 @@
     <value>INS_NOTCH_ATT</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.Parent" xml:space="preserve">
     <value>groupBox8</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="label40.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3760,7 +3637,7 @@
     <value>groupBox8</value>
   </data>
   <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="INS_NOTCH_BW.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3778,13 +3655,13 @@
     <value>INS_NOTCH_BW</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.Parent" xml:space="preserve">
     <value>groupBox8</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label39.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3814,7 +3691,7 @@
     <value>groupBox8</value>
   </data>
   <data name="&gt;&gt;label39.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="INS_NOTCH_FREQ.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3832,13 +3709,13 @@
     <value>INS_NOTCH_FREQ</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.Parent" xml:space="preserve">
     <value>groupBox8</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label38.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3868,30 +3745,6 @@
     <value>groupBox8</value>
   </data>
   <data name="&gt;&gt;label38.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="INS_NOTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="INS_NOTCH_ENABLE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 27</value>
-  </data>
-  <data name="INS_NOTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
-  </data>
-  <data name="INS_NOTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
-    <value>46</value>
-  </data>
-  <data name="&gt;&gt;INS_NOTCH_ENABLE.Name" xml:space="preserve">
-    <value>INS_NOTCH_ENABLE</value>
-  </data>
-  <data name="&gt;&gt;INS_NOTCH_ENABLE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;INS_NOTCH_ENABLE.Parent" xml:space="preserve">
-    <value>groupBox8</value>
-  </data>
-  <data name="&gt;&gt;INS_NOTCH_ENABLE.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
   <data name="label37.AutoSize" type="System.Boolean, mscorlib">
@@ -3952,25 +3805,49 @@
     <value>False</value>
   </data>
   <data name="INS_LOG_BAT_OPT.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 14</value>
+    <value>256, 14</value>
   </data>
   <data name="INS_LOG_BAT_OPT.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 20</value>
   </data>
   <data name="INS_LOG_BAT_OPT.TabIndex" type="System.Int32, mscorlib">
-    <value>46</value>
+    <value>55</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Name" xml:space="preserve">
     <value>INS_LOG_BAT_OPT</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Parent" xml:space="preserve">
     <value>groupBox6</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 13</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 21</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.TabIndex" type="System.Int32, mscorlib">
+    <value>47</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.Name" xml:space="preserve">
+    <value>INS_LOG_BAT_MASK</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.Parent" xml:space="preserve">
+    <value>groupBox6</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="label36.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3979,7 +3856,7 @@
     <value>NoControl</value>
   </data>
   <data name="label36.Location" type="System.Drawing.Point, System.Drawing">
-    <value>149, 16</value>
+    <value>182, 16</value>
   </data>
   <data name="label36.Size" type="System.Drawing.Size, System.Drawing">
     <value>43, 13</value>
@@ -4000,30 +3877,6 @@
     <value>groupBox6</value>
   </data>
   <data name="&gt;&gt;label36.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="INS_LOG_BAT_MASK.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="INS_LOG_BAT_MASK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>45, 14</value>
-  </data>
-  <data name="INS_LOG_BAT_MASK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
-  </data>
-  <data name="INS_LOG_BAT_MASK.TabIndex" type="System.Int32, mscorlib">
-    <value>44</value>
-  </data>
-  <data name="&gt;&gt;INS_LOG_BAT_MASK.Name" xml:space="preserve">
-    <value>INS_LOG_BAT_MASK</value>
-  </data>
-  <data name="&gt;&gt;INS_LOG_BAT_MASK.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;INS_LOG_BAT_MASK.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;INS_LOG_BAT_MASK.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="label34.AutoSize" type="System.Boolean, mscorlib">
@@ -4126,13 +3979,181 @@
     <value>CH6_OPTION</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="CH10_OPTION.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CH10_OPTION.Location" type="System.Drawing.Point, System.Drawing">
+    <value>416, 442</value>
+  </data>
+  <data name="CH10_OPTION.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 21</value>
+  </data>
+  <data name="CH10_OPTION.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="&gt;&gt;CH10_OPTION.Name" xml:space="preserve">
+    <value>CH10_OPTION</value>
+  </data>
+  <data name="&gt;&gt;CH10_OPTION.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CH10_OPTION.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CH10_OPTION.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="CH9_OPTION.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CH9_OPTION.Location" type="System.Drawing.Point, System.Drawing">
+    <value>416, 415</value>
+  </data>
+  <data name="CH9_OPTION.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 21</value>
+  </data>
+  <data name="CH9_OPTION.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="&gt;&gt;CH9_OPTION.Name" xml:space="preserve">
+    <value>CH9_OPTION</value>
+  </data>
+  <data name="&gt;&gt;CH9_OPTION.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CH9_OPTION.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CH9_OPTION.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="CH8_OPTION.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CH8_OPTION.Location" type="System.Drawing.Point, System.Drawing">
+    <value>416, 388</value>
+  </data>
+  <data name="CH8_OPTION.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 21</value>
+  </data>
+  <data name="CH8_OPTION.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;CH8_OPTION.Name" xml:space="preserve">
+    <value>CH8_OPTION</value>
+  </data>
+  <data name="&gt;&gt;CH8_OPTION.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CH8_OPTION.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CH8_OPTION.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="TUNE_LOW.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="TUNE_LOW.Location" type="System.Drawing.Point, System.Drawing">
+    <value>218, 360</value>
+  </data>
+  <data name="TUNE_LOW.Size" type="System.Drawing.Size, System.Drawing">
+    <value>51, 20</value>
+  </data>
+  <data name="TUNE_LOW.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;TUNE_LOW.Name" xml:space="preserve">
+    <value>TUNE_LOW</value>
+  </data>
+  <data name="&gt;&gt;TUNE_LOW.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;TUNE_LOW.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TUNE_LOW.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="TUNE_HIGH.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="TUNE_HIGH.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 360</value>
+  </data>
+  <data name="TUNE_HIGH.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 20</value>
+  </data>
+  <data name="TUNE_HIGH.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;TUNE_HIGH.Name" xml:space="preserve">
+    <value>TUNE_HIGH</value>
+  </data>
+  <data name="&gt;&gt;TUNE_HIGH.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;TUNE_HIGH.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TUNE_HIGH.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="TUNE.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="TUNE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>242, 332</value>
+  </data>
+  <data name="TUNE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 21</value>
+  </data>
+  <data name="TUNE.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;TUNE.Name" xml:space="preserve">
+    <value>TUNE</value>
+  </data>
+  <data name="&gt;&gt;TUNE.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;TUNE.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TUNE.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="CH7_OPTION.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CH7_OPTION.Location" type="System.Drawing.Point, System.Drawing">
+    <value>416, 361</value>
+  </data>
+  <data name="CH7_OPTION.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 21</value>
+  </data>
+  <data name="CH7_OPTION.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;CH7_OPTION.Name" xml:space="preserve">
+    <value>CH7_OPTION</value>
+  </data>
+  <data name="&gt;&gt;CH7_OPTION.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CH7_OPTION.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CH7_OPTION.ZOrder" xml:space="preserve">
+    <value>23</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/GCSViews/ConfigurationView/ConfigArducopter.resx
+++ b/GCSViews/ConfigurationView/ConfigArducopter.resx
@@ -123,10 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="TUNE_LOW.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 315</value>
+    <value>218, 369</value>
   </data>
   <data name="TUNE_LOW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 20</value>
+    <value>51, 31</value>
   </data>
   <data name="TUNE_LOW.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -135,22 +135,22 @@
     <value>TUNE_LOW</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>18</value>
   </data>
   <data name="TUNE_HIGH.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="TUNE_HIGH.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 315</value>
+    <value>308, 369</value>
   </data>
   <data name="TUNE_HIGH.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 20</value>
+    <value>46, 31</value>
   </data>
   <data name="TUNE_HIGH.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -159,22 +159,22 @@
     <value>TUNE_HIGH</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>19</value>
   </data>
   <data name="TUNE.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="TUNE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>242, 287</value>
+    <value>242, 341</value>
   </data>
   <data name="TUNE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
+    <value>112, 33</value>
   </data>
   <data name="TUNE.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -183,22 +183,22 @@
     <value>TUNE</value>
   </data>
   <data name="&gt;&gt;TUNE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;TUNE.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>21</value>
   </data>
   <data name="CH7_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="CH7_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>417, 288</value>
+    <value>416, 370</value>
   </data>
   <data name="CH7_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
+    <value>112, 33</value>
   </data>
   <data name="CH7_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -207,61 +207,13 @@
     <value>CH7_OPTION</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;THR_RATE_P.Name" xml:space="preserve">
-    <value>THR_RATE_P</value>
-  </data>
-  <data name="&gt;&gt;THR_RATE_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;THR_RATE_P.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;THR_RATE_P.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label25.Name" xml:space="preserve">
-    <value>label25</value>
-  </data>
-  <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label25.Parent" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;label25.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="groupBox5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 242</value>
-  </data>
-  <data name="groupBox5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 43</value>
-  </data>
-  <data name="groupBox5.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="groupBox5.Text" xml:space="preserve">
-    <value>Throttle Rate (VSpd to accel)</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Name" xml:space="preserve">
-    <value>groupBox5</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>23</value>
   </data>
   <data name="THR_RATE_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -270,7 +222,7 @@
     <value>80, 13</value>
   </data>
   <data name="THR_RATE_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="THR_RATE_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -279,7 +231,7 @@
     <value>THR_RATE_P</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -315,6 +267,30 @@
   <data name="&gt;&gt;label25.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="groupBox5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>183, 296</value>
+  </data>
+  <data name="groupBox5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 50</value>
+  </data>
+  <data name="groupBox5.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="groupBox5.Text" xml:space="preserve">
+    <value>Throttle Rate (VSpd to accel)</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.Name" xml:space="preserve">
+    <value>groupBox5</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
   <data name="CHK_lockrollpitch.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -325,7 +301,7 @@
     <value>7, 79</value>
   </data>
   <data name="CHK_lockrollpitch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 17</value>
+    <value>301, 29</value>
   </data>
   <data name="CHK_lockrollpitch.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -343,151 +319,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_lockrollpitch.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_UP.Name" xml:space="preserve">
-    <value>WPNAV_SPEED_UP</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_UP.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_UP.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_UP.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label27.Name" xml:space="preserve">
-    <value>label27</value>
-  </data>
-  <data name="&gt;&gt;label27.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label27.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label27.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_LOIT_SPEED.Name" xml:space="preserve">
-    <value>WPNAV_LOIT_SPEED</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_LOIT_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_LOIT_SPEED.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_LOIT_SPEED.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_DN.Name" xml:space="preserve">
-    <value>WPNAV_SPEED_DN</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_DN.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_DN.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED_DN.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label13.Name" xml:space="preserve">
-    <value>label13</value>
-  </data>
-  <data name="&gt;&gt;label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label13.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_RADIUS.Name" xml:space="preserve">
-    <value>WPNAV_RADIUS</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_RADIUS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_RADIUS.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_RADIUS.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;label15.Name" xml:space="preserve">
-    <value>label15</value>
-  </data>
-  <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label15.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED.Name" xml:space="preserve">
-    <value>WPNAV_SPEED</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;WPNAV_SPEED.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label16.Name" xml:space="preserve">
-    <value>label16</value>
-  </data>
-  <data name="&gt;&gt;label16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label16.Parent" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>532, 236</value>
-  </data>
-  <data name="groupBox4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 131</value>
-  </data>
-  <data name="groupBox4.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="groupBox4.Text" xml:space="preserve">
-    <value>WPNav (cm's)</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Name" xml:space="preserve">
-    <value>groupBox4</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>25</value>
   </data>
   <data name="WPNAV_SPEED_UP.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -496,7 +328,7 @@
     <value>80, 60</value>
   </data>
   <data name="WPNAV_SPEED_UP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="WPNAV_SPEED_UP.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -505,7 +337,7 @@
     <value>WPNAV_SPEED_UP</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -547,7 +379,7 @@
     <value>80, 107</value>
   </data>
   <data name="WPNAV_LOIT_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="WPNAV_LOIT_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -556,7 +388,7 @@
     <value>WPNAV_LOIT_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -598,7 +430,7 @@
     <value>80, 84</value>
   </data>
   <data name="WPNAV_SPEED_DN.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="WPNAV_SPEED_DN.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -607,7 +439,7 @@
     <value>WPNAV_SPEED_DN</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -649,7 +481,7 @@
     <value>80, 37</value>
   </data>
   <data name="WPNAV_RADIUS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="WPNAV_RADIUS.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -658,7 +490,7 @@
     <value>WPNAV_RADIUS</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -700,7 +532,7 @@
     <value>80, 13</value>
   </data>
   <data name="WPNAV_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="WPNAV_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -709,7 +541,7 @@
     <value>WPNAV_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -744,53 +576,29 @@
   <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;THR_ALT_P.Name" xml:space="preserve">
-    <value>THR_ALT_P</value>
+  <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>532, 296</value>
   </data>
-  <data name="&gt;&gt;THR_ALT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+  <data name="groupBox4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 138</value>
   </data>
-  <data name="&gt;&gt;THR_ALT_P.Parent" xml:space="preserve">
-    <value>groupBox7</value>
+  <data name="groupBox4.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
   </data>
-  <data name="&gt;&gt;THR_ALT_P.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="groupBox4.Text" xml:space="preserve">
+    <value>WPNav (cm's)</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
+  <data name="&gt;&gt;groupBox4.Name" xml:space="preserve">
+    <value>groupBox4</value>
   </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>groupBox7</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="groupBox7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>359, 242</value>
-  </data>
-  <data name="groupBox7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 43</value>
-  </data>
-  <data name="groupBox7.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="groupBox7.Text" xml:space="preserve">
-    <value>Altitude Hold (Alt to climbrate)</value>
-  </data>
-  <data name="&gt;&gt;groupBox7.Name" xml:space="preserve">
-    <value>groupBox7</value>
-  </data>
-  <data name="&gt;&gt;groupBox7.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox4.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox7.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox4.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox7.ZOrder" xml:space="preserve">
-    <value>21</value>
+  <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
+    <value>26</value>
   </data>
   <data name="THR_ALT_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -799,7 +607,7 @@
     <value>80, 13</value>
   </data>
   <data name="THR_ALT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="THR_ALT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -808,7 +616,7 @@
     <value>THR_ALT_P</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Parent" xml:space="preserve">
     <value>groupBox7</value>
@@ -843,77 +651,29 @@
   <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownatc_input_tc</value>
+  <data name="groupBox7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>359, 296</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+  <data name="groupBox7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 50</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Parent" xml:space="preserve">
-    <value>groupBox19</value>
+  <data name="groupBox7.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="groupBox7.Text" xml:space="preserve">
+    <value>Altitude Hold (Alt to climbrate)</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
+  <data name="&gt;&gt;groupBox7.Name" xml:space="preserve">
+    <value>groupBox7</value>
   </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>groupBox19</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;HLD_LAT_P.Name" xml:space="preserve">
-    <value>HLD_LAT_P</value>
-  </data>
-  <data name="&gt;&gt;HLD_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;HLD_LAT_P.Parent" xml:space="preserve">
-    <value>groupBox19</value>
-  </data>
-  <data name="&gt;&gt;HLD_LAT_P.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label31.Name" xml:space="preserve">
-    <value>label31</value>
-  </data>
-  <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
-    <value>groupBox19</value>
-  </data>
-  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="groupBox19.Location" type="System.Drawing.Point, System.Drawing">
-    <value>532, 5</value>
-  </data>
-  <data name="groupBox19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 68</value>
-  </data>
-  <data name="groupBox19.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="groupBox19.Text" xml:space="preserve">
-    <value>Position XY (Dist to Speed)</value>
-  </data>
-  <data name="&gt;&gt;groupBox19.Name" xml:space="preserve">
-    <value>groupBox19</value>
-  </data>
-  <data name="&gt;&gt;groupBox19.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox7.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox19.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox7.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox19.ZOrder" xml:space="preserve">
-    <value>22</value>
+  <data name="&gt;&gt;groupBox7.ZOrder" xml:space="preserve">
+    <value>27</value>
   </data>
   <data name="mavlinkNumericUpDownatc_input_tc.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -922,7 +682,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_input_tc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="mavlinkNumericUpDownatc_input_tc.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -931,7 +691,7 @@
     <value>mavlinkNumericUpDownatc_input_tc</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -973,7 +733,7 @@
     <value>80, 13</value>
   </data>
   <data name="HLD_LAT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="HLD_LAT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -982,7 +742,7 @@
     <value>HLD_LAT_P</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -1017,77 +777,29 @@
   <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownatc_accel_y_max</value>
+  <data name="groupBox19.Location" type="System.Drawing.Point, System.Drawing">
+    <value>532, 5</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Parent" xml:space="preserve">
-    <value>groupBox20</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label21.Name" xml:space="preserve">
-    <value>label21</value>
-  </data>
-  <data name="&gt;&gt;label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label21.Parent" xml:space="preserve">
-    <value>groupBox20</value>
-  </data>
-  <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;STB_YAW_P.Name" xml:space="preserve">
-    <value>STB_YAW_P</value>
-  </data>
-  <data name="&gt;&gt;STB_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;STB_YAW_P.Parent" xml:space="preserve">
-    <value>groupBox20</value>
-  </data>
-  <data name="&gt;&gt;STB_YAW_P.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label35.Name" xml:space="preserve">
-    <value>label35</value>
-  </data>
-  <data name="&gt;&gt;label35.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label35.Parent" xml:space="preserve">
-    <value>groupBox20</value>
-  </data>
-  <data name="&gt;&gt;label35.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="groupBox20.Location" type="System.Drawing.Point, System.Drawing">
-    <value>359, 5</value>
-  </data>
-  <data name="groupBox20.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="groupBox19.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 68</value>
   </data>
-  <data name="groupBox20.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="groupBox19.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="groupBox20.Text" xml:space="preserve">
-    <value>Stabilize Yaw (Error to Rate)</value>
+  <data name="groupBox19.Text" xml:space="preserve">
+    <value>Position XY (Dist to Speed)</value>
   </data>
-  <data name="&gt;&gt;groupBox20.Name" xml:space="preserve">
-    <value>groupBox20</value>
+  <data name="&gt;&gt;groupBox19.Name" xml:space="preserve">
+    <value>groupBox19</value>
   </data>
-  <data name="&gt;&gt;groupBox20.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox19.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox20.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox19.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox20.ZOrder" xml:space="preserve">
-    <value>23</value>
+  <data name="&gt;&gt;groupBox19.ZOrder" xml:space="preserve">
+    <value>28</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_y_max.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1096,7 +808,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_y_max.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_y_max.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1105,7 +817,7 @@
     <value>mavlinkNumericUpDownatc_accel_y_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -1147,7 +859,7 @@
     <value>80, 13</value>
   </data>
   <data name="STB_YAW_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="STB_YAW_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1156,7 +868,7 @@
     <value>STB_YAW_P</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -1191,77 +903,29 @@
   <data name="&gt;&gt;label35.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownatc_accel_p_max</value>
+  <data name="groupBox20.Location" type="System.Drawing.Point, System.Drawing">
+    <value>359, 5</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Parent" xml:space="preserve">
-    <value>groupBox21</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>groupBox21</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;STB_PIT_P.Name" xml:space="preserve">
-    <value>STB_PIT_P</value>
-  </data>
-  <data name="&gt;&gt;STB_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;STB_PIT_P.Parent" xml:space="preserve">
-    <value>groupBox21</value>
-  </data>
-  <data name="&gt;&gt;STB_PIT_P.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label42.Name" xml:space="preserve">
-    <value>label42</value>
-  </data>
-  <data name="&gt;&gt;label42.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label42.Parent" xml:space="preserve">
-    <value>groupBox21</value>
-  </data>
-  <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="groupBox21.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 5</value>
-  </data>
-  <data name="groupBox21.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="groupBox20.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 68</value>
   </data>
-  <data name="groupBox21.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="groupBox20.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="groupBox21.Text" xml:space="preserve">
-    <value>Stabilize Pitch (Error to Rate)</value>
+  <data name="groupBox20.Text" xml:space="preserve">
+    <value>Stabilize Yaw (Error to Rate)</value>
   </data>
-  <data name="&gt;&gt;groupBox21.Name" xml:space="preserve">
-    <value>groupBox21</value>
+  <data name="&gt;&gt;groupBox20.Name" xml:space="preserve">
+    <value>groupBox20</value>
   </data>
-  <data name="&gt;&gt;groupBox21.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox20.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox21.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox20.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox21.ZOrder" xml:space="preserve">
-    <value>24</value>
+  <data name="&gt;&gt;groupBox20.ZOrder" xml:space="preserve">
+    <value>29</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_p_max.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1270,7 +934,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_p_max.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_p_max.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1279,7 +943,7 @@
     <value>mavlinkNumericUpDownatc_accel_p_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -1321,7 +985,7 @@
     <value>80, 13</value>
   </data>
   <data name="STB_PIT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="STB_PIT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1330,7 +994,7 @@
     <value>STB_PIT_P</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -1365,77 +1029,29 @@
   <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownatc_accel_r_max</value>
+  <data name="groupBox21.Location" type="System.Drawing.Point, System.Drawing">
+    <value>183, 5</value>
   </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Parent" xml:space="preserve">
-    <value>groupBox22</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label19.Name" xml:space="preserve">
-    <value>label19</value>
-  </data>
-  <data name="&gt;&gt;label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label19.Parent" xml:space="preserve">
-    <value>groupBox22</value>
-  </data>
-  <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;STB_RLL_P.Name" xml:space="preserve">
-    <value>STB_RLL_P</value>
-  </data>
-  <data name="&gt;&gt;STB_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;STB_RLL_P.Parent" xml:space="preserve">
-    <value>groupBox22</value>
-  </data>
-  <data name="&gt;&gt;STB_RLL_P.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label46.Name" xml:space="preserve">
-    <value>label46</value>
-  </data>
-  <data name="&gt;&gt;label46.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label46.Parent" xml:space="preserve">
-    <value>groupBox22</value>
-  </data>
-  <data name="&gt;&gt;label46.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="groupBox22.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 5</value>
-  </data>
-  <data name="groupBox22.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="groupBox21.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 68</value>
   </data>
-  <data name="groupBox22.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="groupBox21.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="groupBox22.Text" xml:space="preserve">
-    <value>Stabilize Roll (Error to Rate)</value>
+  <data name="groupBox21.Text" xml:space="preserve">
+    <value>Stabilize Pitch (Error to Rate)</value>
   </data>
-  <data name="&gt;&gt;groupBox22.Name" xml:space="preserve">
-    <value>groupBox22</value>
+  <data name="&gt;&gt;groupBox21.Name" xml:space="preserve">
+    <value>groupBox21</value>
   </data>
-  <data name="&gt;&gt;groupBox22.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox21.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox22.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox21.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox22.ZOrder" xml:space="preserve">
-    <value>25</value>
+  <data name="&gt;&gt;groupBox21.ZOrder" xml:space="preserve">
+    <value>30</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_r_max.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1444,7 +1060,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_r_max.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_r_max.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1453,7 +1069,7 @@
     <value>mavlinkNumericUpDownatc_accel_r_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1495,7 +1111,7 @@
     <value>80, 13</value>
   </data>
   <data name="STB_RLL_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="STB_RLL_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1504,7 +1120,7 @@
     <value>STB_RLL_P</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1539,158 +1155,146 @@
   <data name="&gt;&gt;label46.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;RATE_YAW_FILT.Name" xml:space="preserve">
-    <value>RATE_YAW_FILT</value>
+  <data name="groupBox22.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 5</value>
   </data>
-  <data name="&gt;&gt;RATE_YAW_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+  <data name="groupBox22.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 68</value>
   </data>
-  <data name="&gt;&gt;RATE_YAW_FILT.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_FILT.ZOrder" xml:space="preserve">
+  <data name="groupBox22.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;label18.Name" xml:space="preserve">
-    <value>label18</value>
+  <data name="groupBox22.Text" xml:space="preserve">
+    <value>Stabilize Roll (Error to Rate)</value>
   </data>
-  <data name="&gt;&gt;label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;groupBox22.Name" xml:space="preserve">
+    <value>groupBox22</value>
   </data>
-  <data name="&gt;&gt;label18.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_D.Name" xml:space="preserve">
-    <value>RATE_YAW_D</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_D.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_D.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label10.Name" xml:space="preserve">
-    <value>label10</value>
-  </data>
-  <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_IMAX.Name" xml:space="preserve">
-    <value>RATE_YAW_IMAX</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_IMAX.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_IMAX.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label47.Name" xml:space="preserve">
-    <value>label47</value>
-  </data>
-  <data name="&gt;&gt;label47.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label47.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;label47.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_I.Name" xml:space="preserve">
-    <value>RATE_YAW_I</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_I.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_I.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;label77.Name" xml:space="preserve">
-    <value>label77</value>
-  </data>
-  <data name="&gt;&gt;label77.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label77.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;label77.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_P.Name" xml:space="preserve">
-    <value>RATE_YAW_P</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_P.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;RATE_YAW_P.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label82.Name" xml:space="preserve">
-    <value>label82</value>
-  </data>
-  <data name="&gt;&gt;label82.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label82.Parent" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;label82.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="groupBox23.Location" type="System.Drawing.Point, System.Drawing">
-    <value>359, 100</value>
-  </data>
-  <data name="groupBox23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 136</value>
-  </data>
-  <data name="groupBox23.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="groupBox23.Text" xml:space="preserve">
-    <value>Rate Yaw</value>
-  </data>
-  <data name="&gt;&gt;groupBox23.Name" xml:space="preserve">
-    <value>groupBox23</value>
-  </data>
-  <data name="&gt;&gt;groupBox23.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox22.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox23.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox22.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox23.ZOrder" xml:space="preserve">
-    <value>26</value>
+  <data name="&gt;&gt;groupBox22.ZOrder" xml:space="preserve">
+    <value>31</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTT.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>79, 152</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTT.TabIndex" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Name" xml:space="preserve">
+    <value>ATC_RAT_YAW_FLTT</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Parent" xml:space="preserve">
+    <value>groupBox23</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTT.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label33.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label33.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 154</value>
+  </data>
+  <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 25</value>
+  </data>
+  <data name="label33.TabIndex" type="System.Int32, mscorlib">
+    <value>44</value>
+  </data>
+  <data name="label33.Text" xml:space="preserve">
+    <value>FLTT</value>
+  </data>
+  <data name="&gt;&gt;label33.Name" xml:space="preserve">
+    <value>label33</value>
+  </data>
+  <data name="&gt;&gt;label33.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
+    <value>groupBox23</value>
+  </data>
+  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTD.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTD.Location" type="System.Drawing.Point, System.Drawing">
+    <value>79, 129</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTD.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="ATC_RAT_YAW_FLTD.TabIndex" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Name" xml:space="preserve">
+    <value>ATC_RAT_YAW_FLTD</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Parent" xml:space="preserve">
+    <value>groupBox23</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_YAW_FLTD.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label32.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label32.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label32.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 131</value>
+  </data>
+  <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="label32.TabIndex" type="System.Int32, mscorlib">
+    <value>42</value>
+  </data>
+  <data name="label32.Text" xml:space="preserve">
+    <value>FLTD</value>
+  </data>
+  <data name="&gt;&gt;label32.Name" xml:space="preserve">
+    <value>label32</value>
+  </data>
+  <data name="&gt;&gt;label32.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
+    <value>groupBox23</value>
+  </data>
+  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="RATE_YAW_FILT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="RATE_YAW_FILT.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 110</value>
+    <value>80, 106</value>
   </data>
   <data name="RATE_YAW_FILT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_YAW_FILT.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1699,19 +1303,19 @@
     <value>RATE_YAW_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Parent" xml:space="preserve">
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="label18.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="label18.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 113</value>
+    <value>6, 108</value>
   </data>
   <data name="label18.Size" type="System.Drawing.Size, System.Drawing">
     <value>68, 13</value>
@@ -1720,7 +1324,7 @@
     <value>8</value>
   </data>
   <data name="label18.Text" xml:space="preserve">
-    <value>FILT</value>
+    <value>FLTE</value>
   </data>
   <data name="&gt;&gt;label18.Name" xml:space="preserve">
     <value>label18</value>
@@ -1732,7 +1336,7 @@
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="RATE_YAW_D.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1741,7 +1345,7 @@
     <value>80, 60</value>
   </data>
   <data name="RATE_YAW_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_YAW_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1750,13 +1354,13 @@
     <value>RATE_YAW_D</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Parent" xml:space="preserve">
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1783,16 +1387,16 @@
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="RATE_YAW_IMAX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="RATE_YAW_IMAX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 84</value>
+    <value>80, 83</value>
   </data>
   <data name="RATE_YAW_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_YAW_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1801,19 +1405,19 @@
     <value>RATE_YAW_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Parent" xml:space="preserve">
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="label47.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="label47.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 87</value>
+    <value>6, 86</value>
   </data>
   <data name="label47.Size" type="System.Drawing.Size, System.Drawing">
     <value>65, 13</value>
@@ -1834,7 +1438,7 @@
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;label47.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="RATE_YAW_I.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1843,7 +1447,7 @@
     <value>80, 37</value>
   </data>
   <data name="RATE_YAW_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_YAW_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1852,13 +1456,13 @@
     <value>RATE_YAW_I</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Parent" xml:space="preserve">
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="label77.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1885,7 +1489,7 @@
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;label77.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="RATE_YAW_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1894,7 +1498,7 @@
     <value>80, 13</value>
   </data>
   <data name="RATE_YAW_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_YAW_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1903,13 +1507,13 @@
     <value>RATE_YAW_P</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Parent" xml:space="preserve">
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="label82.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1936,160 +1540,148 @@
     <value>groupBox23</value>
   </data>
   <data name="&gt;&gt;label82.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
-  <data name="&gt;&gt;RATE_PIT_FILT.Name" xml:space="preserve">
-    <value>RATE_PIT_FILT</value>
+  <data name="groupBox23.Location" type="System.Drawing.Point, System.Drawing">
+    <value>359, 100</value>
   </data>
-  <data name="&gt;&gt;RATE_PIT_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+  <data name="groupBox23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 180</value>
   </data>
-  <data name="&gt;&gt;RATE_PIT_FILT.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_FILT.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label14.Name" xml:space="preserve">
-    <value>label14</value>
-  </data>
-  <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label14.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_D.Name" xml:space="preserve">
-    <value>RATE_PIT_D</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_D.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_D.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_IMAX.Name" xml:space="preserve">
-    <value>RATE_PIT_IMAX</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_IMAX.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_IMAX.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label84.Name" xml:space="preserve">
-    <value>label84</value>
-  </data>
-  <data name="&gt;&gt;label84.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label84.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;label84.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_I.Name" xml:space="preserve">
-    <value>RATE_PIT_I</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_I.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_I.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;label86.Name" xml:space="preserve">
-    <value>label86</value>
-  </data>
-  <data name="&gt;&gt;label86.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label86.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;label86.ZOrder" xml:space="preserve">
+  <data name="groupBox23.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;RATE_PIT_P.Name" xml:space="preserve">
-    <value>RATE_PIT_P</value>
+  <data name="groupBox23.Text" xml:space="preserve">
+    <value>Rate Yaw</value>
   </data>
-  <data name="&gt;&gt;RATE_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;groupBox23.Name" xml:space="preserve">
+    <value>groupBox23</value>
   </data>
-  <data name="&gt;&gt;RATE_PIT_P.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;RATE_PIT_P.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label87.Name" xml:space="preserve">
-    <value>label87</value>
-  </data>
-  <data name="&gt;&gt;label87.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label87.Parent" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;label87.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="groupBox24.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 100</value>
-  </data>
-  <data name="groupBox24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 136</value>
-  </data>
-  <data name="groupBox24.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="groupBox24.Text" xml:space="preserve">
-    <value>Rate Pitch</value>
-  </data>
-  <data name="&gt;&gt;groupBox24.Name" xml:space="preserve">
-    <value>groupBox24</value>
-  </data>
-  <data name="&gt;&gt;groupBox24.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox23.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox24.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox23.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox24.ZOrder" xml:space="preserve">
-    <value>27</value>
+  <data name="&gt;&gt;groupBox23.ZOrder" xml:space="preserve">
+    <value>32</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTT.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 152</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTT.TabIndex" type="System.Int32, mscorlib">
+    <value>41</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Name" xml:space="preserve">
+    <value>ATC_RAT_RLL_FLTT</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Parent" xml:space="preserve">
+    <value>groupBox24</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label30.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label30.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label30.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 156</value>
+  </data>
+  <data name="label30.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 25</value>
+  </data>
+  <data name="label30.TabIndex" type="System.Int32, mscorlib">
+    <value>40</value>
+  </data>
+  <data name="label30.Text" xml:space="preserve">
+    <value>FLTT</value>
+  </data>
+  <data name="&gt;&gt;label30.Name" xml:space="preserve">
+    <value>label30</value>
+  </data>
+  <data name="&gt;&gt;label30.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label30.Parent" xml:space="preserve">
+    <value>groupBox24</value>
+  </data>
+  <data name="&gt;&gt;label30.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTD.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTD.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 129</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTD.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="ATC_RAT_RLL_FLTD.TabIndex" type="System.Int32, mscorlib">
+    <value>39</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Name" xml:space="preserve">
+    <value>ATC_RAT_RLL_FLTD</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Parent" xml:space="preserve">
+    <value>groupBox24</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label29.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label29.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label29.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 131</value>
+  </data>
+  <data name="label29.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="label29.TabIndex" type="System.Int32, mscorlib">
+    <value>38</value>
+  </data>
+  <data name="label29.Text" xml:space="preserve">
+    <value>FLTD</value>
+  </data>
+  <data name="&gt;&gt;label29.Name" xml:space="preserve">
+    <value>label29</value>
+  </data>
+  <data name="&gt;&gt;label29.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label29.Parent" xml:space="preserve">
+    <value>groupBox24</value>
+  </data>
+  <data name="&gt;&gt;label29.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="RATE_PIT_FILT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="RATE_PIT_FILT.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 109</value>
+    <value>80, 106</value>
   </data>
   <data name="RATE_PIT_FILT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_PIT_FILT.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -2098,19 +1690,19 @@
     <value>RATE_PIT_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="label14.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 112</value>
+    <value>6, 108</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
     <value>68, 13</value>
@@ -2119,7 +1711,7 @@
     <value>8</value>
   </data>
   <data name="label14.Text" xml:space="preserve">
-    <value>FILT</value>
+    <value>FLTE</value>
   </data>
   <data name="&gt;&gt;label14.Name" xml:space="preserve">
     <value>label14</value>
@@ -2131,7 +1723,7 @@
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="RATE_PIT_D.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2140,7 +1732,7 @@
     <value>80, 60</value>
   </data>
   <data name="RATE_PIT_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_PIT_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2149,13 +1741,13 @@
     <value>RATE_PIT_D</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2182,16 +1774,16 @@
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="RATE_PIT_IMAX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="RATE_PIT_IMAX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 83</value>
+    <value>80, 84</value>
   </data>
   <data name="RATE_PIT_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_PIT_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2200,13 +1792,13 @@
     <value>RATE_PIT_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="label84.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2233,7 +1825,7 @@
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;label84.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="RATE_PIT_I.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2242,7 +1834,7 @@
     <value>80, 37</value>
   </data>
   <data name="RATE_PIT_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_PIT_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2251,13 +1843,13 @@
     <value>RATE_PIT_I</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="label86.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2284,7 +1876,7 @@
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;label86.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="RATE_PIT_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2293,7 +1885,7 @@
     <value>80, 13</value>
   </data>
   <data name="RATE_PIT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_PIT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2302,13 +1894,13 @@
     <value>RATE_PIT_P</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="label87.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2335,160 +1927,148 @@
     <value>groupBox24</value>
   </data>
   <data name="&gt;&gt;label87.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
-  <data name="&gt;&gt;RATE_RLL_FILT.Name" xml:space="preserve">
-    <value>RATE_RLL_FILT</value>
+  <data name="groupBox24.Location" type="System.Drawing.Point, System.Drawing">
+    <value>183, 100</value>
   </data>
-  <data name="&gt;&gt;RATE_RLL_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+  <data name="groupBox24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 180</value>
   </data>
-  <data name="&gt;&gt;RATE_RLL_FILT.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_FILT.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label12.Name" xml:space="preserve">
-    <value>label12</value>
-  </data>
-  <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_D.Name" xml:space="preserve">
-    <value>RATE_RLL_D</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_D.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_D.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label17.Name" xml:space="preserve">
-    <value>label17</value>
-  </data>
-  <data name="&gt;&gt;label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label17.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_IMAX.Name" xml:space="preserve">
-    <value>RATE_RLL_IMAX</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_IMAX.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_IMAX.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label88.Name" xml:space="preserve">
-    <value>label88</value>
-  </data>
-  <data name="&gt;&gt;label88.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label88.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;label88.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_I.Name" xml:space="preserve">
-    <value>RATE_RLL_I</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_I.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_I.ZOrder" xml:space="preserve">
+  <data name="groupBox24.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;label90.Name" xml:space="preserve">
-    <value>label90</value>
+  <data name="groupBox24.Text" xml:space="preserve">
+    <value>Rate Pitch</value>
   </data>
-  <data name="&gt;&gt;label90.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;groupBox24.Name" xml:space="preserve">
+    <value>groupBox24</value>
   </data>
-  <data name="&gt;&gt;label90.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;label90.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_P.Name" xml:space="preserve">
-    <value>RATE_RLL_P</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_P.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;RATE_RLL_P.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label91.Name" xml:space="preserve">
-    <value>label91</value>
-  </data>
-  <data name="&gt;&gt;label91.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label91.Parent" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;label91.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="groupBox25.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 100</value>
-  </data>
-  <data name="groupBox25.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 136</value>
-  </data>
-  <data name="groupBox25.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="groupBox25.Text" xml:space="preserve">
-    <value>Rate Roll</value>
-  </data>
-  <data name="&gt;&gt;groupBox25.Name" xml:space="preserve">
-    <value>groupBox25</value>
-  </data>
-  <data name="&gt;&gt;groupBox25.Type" xml:space="preserve">
+  <data name="&gt;&gt;groupBox24.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox25.Parent" xml:space="preserve">
+  <data name="&gt;&gt;groupBox24.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox25.ZOrder" xml:space="preserve">
-    <value>28</value>
+  <data name="&gt;&gt;groupBox24.ZOrder" xml:space="preserve">
+    <value>33</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTT.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 152</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTT.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Name" xml:space="preserve">
+    <value>ATC_RAT_PIT_FLTT</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Parent" xml:space="preserve">
+    <value>groupBox25</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label28.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label28.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label28.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 154</value>
+  </data>
+  <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 25</value>
+  </data>
+  <data name="label28.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="label28.Text" xml:space="preserve">
+    <value>FLTT</value>
+  </data>
+  <data name="&gt;&gt;label28.Name" xml:space="preserve">
+    <value>label28</value>
+  </data>
+  <data name="&gt;&gt;label28.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label28.Parent" xml:space="preserve">
+    <value>groupBox25</value>
+  </data>
+  <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTD.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTD.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 129</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTD.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="ATC_RAT_PIT_FLTD.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Name" xml:space="preserve">
+    <value>ATC_RAT_PIT_FLTD</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Parent" xml:space="preserve">
+    <value>groupBox25</value>
+  </data>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="P_FLTD.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="P_FLTD.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="P_FLTD.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 131</value>
+  </data>
+  <data name="P_FLTD.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="P_FLTD.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="P_FLTD.Text" xml:space="preserve">
+    <value>FLTD</value>
+  </data>
+  <data name="&gt;&gt;P_FLTD.Name" xml:space="preserve">
+    <value>P_FLTD</value>
+  </data>
+  <data name="&gt;&gt;P_FLTD.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;P_FLTD.Parent" xml:space="preserve">
+    <value>groupBox25</value>
+  </data>
+  <data name="&gt;&gt;P_FLTD.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="RATE_RLL_FILT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="RATE_RLL_FILT.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 109</value>
+    <value>80, 106</value>
   </data>
   <data name="RATE_RLL_FILT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_RLL_FILT.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -2497,19 +2077,19 @@
     <value>RATE_RLL_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 112</value>
+    <value>6, 108</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
     <value>68, 13</value>
@@ -2518,7 +2098,7 @@
     <value>8</value>
   </data>
   <data name="label12.Text" xml:space="preserve">
-    <value>FILT</value>
+    <value>FLTE</value>
   </data>
   <data name="&gt;&gt;label12.Name" xml:space="preserve">
     <value>label12</value>
@@ -2530,7 +2110,7 @@
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="RATE_RLL_D.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2539,7 +2119,7 @@
     <value>80, 60</value>
   </data>
   <data name="RATE_RLL_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_RLL_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2548,13 +2128,13 @@
     <value>RATE_RLL_D</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="label17.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2581,7 +2161,7 @@
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="RATE_RLL_IMAX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2590,7 +2170,7 @@
     <value>80, 83</value>
   </data>
   <data name="RATE_RLL_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_RLL_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2599,13 +2179,13 @@
     <value>RATE_RLL_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="label88.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2632,7 +2212,7 @@
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;label88.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="RATE_RLL_I.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2641,7 +2221,7 @@
     <value>80, 37</value>
   </data>
   <data name="RATE_RLL_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_RLL_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2650,13 +2230,13 @@
     <value>RATE_RLL_I</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="label90.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2683,7 +2263,7 @@
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;label90.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="RATE_RLL_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2692,7 +2272,7 @@
     <value>80, 13</value>
   </data>
   <data name="RATE_RLL_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="RATE_RLL_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2701,13 +2281,13 @@
     <value>RATE_RLL_P</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="label91.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2734,131 +2314,35 @@
     <value>groupBox25</value>
   </data>
   <data name="&gt;&gt;label91.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
+  </data>
+  <data name="groupBox25.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 100</value>
+  </data>
+  <data name="groupBox25.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 180</value>
+  </data>
+  <data name="groupBox25.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="groupBox25.Text" xml:space="preserve">
+    <value>Rate Roll</value>
+  </data>
+  <data name="&gt;&gt;groupBox25.Name" xml:space="preserve">
+    <value>groupBox25</value>
+  </data>
+  <data name="&gt;&gt;groupBox25.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox25.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox25.ZOrder" xml:space="preserve">
+    <value>34</value>
   </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="&gt;&gt;LOITER_LAT_D.Name" xml:space="preserve">
-    <value>LOITER_LAT_D</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_D.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_D.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_IMAX.Name" xml:space="preserve">
-    <value>LOITER_LAT_IMAX</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_IMAX.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_IMAX.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_I.Name" xml:space="preserve">
-    <value>LOITER_LAT_I</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_I.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_I.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_P.Name" xml:space="preserve">
-    <value>LOITER_LAT_P</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_P.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;LOITER_LAT_P.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>532, 100</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 108</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>Velocity XY (Vel to Accel)</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="LOITER_LAT_D.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -2866,7 +2350,7 @@
     <value>80, 60</value>
   </data>
   <data name="LOITER_LAT_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="LOITER_LAT_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2875,7 +2359,7 @@
     <value>LOITER_LAT_D</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2917,7 +2401,7 @@
     <value>80, 84</value>
   </data>
   <data name="LOITER_LAT_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="LOITER_LAT_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2926,7 +2410,7 @@
     <value>LOITER_LAT_IMAX</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2968,7 +2452,7 @@
     <value>80, 37</value>
   </data>
   <data name="LOITER_LAT_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="LOITER_LAT_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2977,7 +2461,7 @@
     <value>LOITER_LAT_I</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -3019,7 +2503,7 @@
     <value>80, 13</value>
   </data>
   <data name="LOITER_LAT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="LOITER_LAT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3028,7 +2512,7 @@
     <value>LOITER_LAT_P</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -3063,17 +2547,41 @@
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>532, 100</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 108</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>Velocity XY (Vel to Accel)</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
   <data name="BUT_rerequestparams.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="BUT_rerequestparams.Location" type="System.Drawing.Point, System.Drawing">
-    <value>364, 395</value>
+    <value>317, 617</value>
   </data>
   <data name="BUT_rerequestparams.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 15, 0, 0</value>
   </data>
   <data name="BUT_rerequestparams.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 19</value>
+    <value>103, 25</value>
   </data>
   <data name="BUT_rerequestparams.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -3094,16 +2602,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_rerequestparams.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>15</value>
   </data>
   <data name="BUT_writePIDS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="BUT_writePIDS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 395</value>
+    <value>208, 617</value>
   </data>
   <data name="BUT_writePIDS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 19</value>
+    <value>103, 25</value>
   </data>
   <data name="BUT_writePIDS.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -3121,16 +2629,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_writePIDS.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>16</value>
   </data>
   <data name="myLabel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="myLabel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 312</value>
+    <value>183, 366</value>
   </data>
   <data name="myLabel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 13</value>
+    <value>47, 25</value>
   </data>
   <data name="myLabel3.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -3148,16 +2656,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel3.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>17</value>
   </data>
   <data name="myLabel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="myLabel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 287</value>
+    <value>183, 341</value>
   </data>
   <data name="myLabel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>61, 25</value>
   </data>
   <data name="myLabel2.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -3175,16 +2683,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel2.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>20</value>
   </data>
   <data name="myLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="myLabel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>358, 288</value>
+    <value>357, 370</value>
   </data>
   <data name="myLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>94, 25</value>
   </data>
   <data name="myLabel1.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -3202,127 +2710,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel1.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_D.Name" xml:space="preserve">
-    <value>THR_ACCEL_D</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_D.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_D.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_IMAX.Name" xml:space="preserve">
-    <value>THR_ACCEL_IMAX</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_IMAX.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_IMAX.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_I.Name" xml:space="preserve">
-    <value>THR_ACCEL_I</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_I.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_I.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_P.Name" xml:space="preserve">
-    <value>THR_ACCEL_P</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_P.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;THR_ACCEL_P.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 242</value>
-  </data>
-  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>170, 115</value>
-  </data>
-  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="groupBox2.Text" xml:space="preserve">
-    <value>Throttle Accel (Accel to motor)</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>22</value>
   </data>
   <data name="THR_ACCEL_D.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3331,7 +2719,7 @@
     <value>80, 66</value>
   </data>
   <data name="THR_ACCEL_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="THR_ACCEL_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -3340,7 +2728,7 @@
     <value>THR_ACCEL_D</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -3409,7 +2797,7 @@
     <value>80, 89</value>
   </data>
   <data name="THR_ACCEL_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="THR_ACCEL_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -3418,7 +2806,7 @@
     <value>THR_ACCEL_IMAX</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -3433,7 +2821,7 @@
     <value>80, 43</value>
   </data>
   <data name="THR_ACCEL_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="THR_ACCEL_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3442,7 +2830,7 @@
     <value>THR_ACCEL_I</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -3484,7 +2872,7 @@
     <value>80, 19</value>
   </data>
   <data name="THR_ACCEL_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 20</value>
+    <value>78, 31</value>
   </data>
   <data name="THR_ACCEL_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3493,7 +2881,7 @@
     <value>THR_ACCEL_P</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -3528,17 +2916,41 @@
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 296</value>
+  </data>
+  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 122</value>
+  </data>
+  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="groupBox2.Text" xml:space="preserve">
+    <value>Throttle Accel (Accel to motor)</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
   <data name="BUT_refreshpart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="BUT_refreshpart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>473, 395</value>
+    <value>426, 617</value>
   </data>
   <data name="BUT_refreshpart.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 15, 0, 0</value>
   </data>
   <data name="BUT_refreshpart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 19</value>
+    <value>103, 25</value>
   </data>
   <data name="BUT_refreshpart.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -3556,16 +2968,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_refreshpart.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>12</value>
   </data>
   <data name="myLabel4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="myLabel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>358, 315</value>
+    <value>357, 397</value>
   </data>
   <data name="myLabel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>94, 25</value>
   </data>
   <data name="myLabel4.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -3583,16 +2995,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel4.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>10</value>
   </data>
   <data name="CH8_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="CH8_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>417, 315</value>
+    <value>416, 397</value>
   </data>
   <data name="CH8_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
+    <value>112, 33</value>
   </data>
   <data name="CH8_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -3601,22 +3013,22 @@
     <value>CH8_OPTION</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>11</value>
   </data>
   <data name="myLabel5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="myLabel5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>358, 342</value>
+    <value>357, 424</value>
   </data>
   <data name="myLabel5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>94, 25</value>
   </data>
   <data name="myLabel5.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -3634,16 +3046,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel5.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>8</value>
   </data>
   <data name="CH9_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="CH9_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>417, 342</value>
+    <value>416, 424</value>
   </data>
   <data name="CH9_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
+    <value>112, 33</value>
   </data>
   <data name="CH9_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -3652,22 +3064,22 @@
     <value>CH9_OPTION</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>9</value>
   </data>
   <data name="myLabel6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="myLabel6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>358, 369</value>
+    <value>357, 451</value>
   </data>
   <data name="myLabel6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 13</value>
+    <value>106, 25</value>
   </data>
   <data name="myLabel6.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -3685,16 +3097,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel6.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>6</value>
   </data>
   <data name="CH10_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="CH10_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>417, 369</value>
+    <value>416, 451</value>
   </data>
   <data name="CH10_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 21</value>
+    <value>112, 33</value>
   </data>
   <data name="CH10_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -3703,13 +3115,1024 @@
     <value>CH10_OPTION</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7352.19376, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="INS_ACCEL_FILTER.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_ACCEL_FILTER.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 37</value>
+  </data>
+  <data name="INS_ACCEL_FILTER.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_ACCEL_FILTER.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;INS_ACCEL_FILTER.Name" xml:space="preserve">
+    <value>INS_ACCEL_FILTER</value>
+  </data>
+  <data name="&gt;&gt;INS_ACCEL_FILTER.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_ACCEL_FILTER.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;INS_ACCEL_FILTER.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label26.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label26.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label26.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 39</value>
+  </data>
+  <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="label26.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="label26.Text" xml:space="preserve">
+    <value>Accel</value>
+  </data>
+  <data name="&gt;&gt;label26.Name" xml:space="preserve">
+    <value>label26</value>
+  </data>
+  <data name="&gt;&gt;label26.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="INS_GYRO_FILTER.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_GYRO_FILTER.Location" type="System.Drawing.Point, System.Drawing">
+    <value>79, 14</value>
+  </data>
+  <data name="INS_GYRO_FILTER.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 31</value>
+  </data>
+  <data name="INS_GYRO_FILTER.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;INS_GYRO_FILTER.Name" xml:space="preserve">
+    <value>INS_GYRO_FILTER</value>
+  </data>
+  <data name="&gt;&gt;INS_GYRO_FILTER.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_GYRO_FILTER.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;INS_GYRO_FILTER.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label24.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 16</value>
+  </data>
+  <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 25</value>
+  </data>
+  <data name="label24.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label24.Text" xml:space="preserve">
+    <value>Gyro</value>
+  </data>
+  <data name="&gt;&gt;label24.Name" xml:space="preserve">
+    <value>label24</value>
+  </data>
+  <data name="&gt;&gt;label24.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label24.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>532, 210</value>
+  </data>
+  <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 70</value>
+  </data>
+  <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="groupBox3.Text" xml:space="preserve">
+    <value>Basic Filters</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Name" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="INS_HNTCH_HMNCS.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_HMNCS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>230, 102</value>
+  </data>
+  <data name="INS_HNTCH_HMNCS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_HMNCS.TabIndex" type="System.Int32, mscorlib">
+    <value>68</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_HMNCS.Name" xml:space="preserve">
+    <value>INS_HNTCH_HMNCS</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_HMNCS.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_HMNCS.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_HMNCS.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label51.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label51.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label51.Location" type="System.Drawing.Point, System.Drawing">
+    <value>158, 104</value>
+  </data>
+  <data name="label51.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 25</value>
+  </data>
+  <data name="label51.TabIndex" type="System.Int32, mscorlib">
+    <value>67</value>
+  </data>
+  <data name="label51.Text" xml:space="preserve">
+    <value>Harmonics</value>
+  </data>
+  <data name="&gt;&gt;label51.Name" xml:space="preserve">
+    <value>label51</value>
+  </data>
+  <data name="&gt;&gt;label51.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label51.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label51.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="INS_HNTCH_OPTS.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_OPTS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>230, 77</value>
+  </data>
+  <data name="INS_HNTCH_OPTS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_OPTS.TabIndex" type="System.Int32, mscorlib">
+    <value>66</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_OPTS.Name" xml:space="preserve">
+    <value>INS_HNTCH_OPTS</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_OPTS.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_OPTS.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_OPTS.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label50.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label50.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label50.Location" type="System.Drawing.Point, System.Drawing">
+    <value>158, 79</value>
+  </data>
+  <data name="label50.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 25</value>
+  </data>
+  <data name="label50.TabIndex" type="System.Int32, mscorlib">
+    <value>65</value>
+  </data>
+  <data name="label50.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;label50.Name" xml:space="preserve">
+    <value>label50</value>
+  </data>
+  <data name="&gt;&gt;label50.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label50.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label50.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="INS_HNTCH_BW.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_BW.Location" type="System.Drawing.Point, System.Drawing">
+    <value>229, 52</value>
+  </data>
+  <data name="INS_HNTCH_BW.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_BW.TabIndex" type="System.Int32, mscorlib">
+    <value>64</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_BW.Name" xml:space="preserve">
+    <value>INS_HNTCH_BW</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_BW.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_BW.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_BW.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label49.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label49.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label49.Location" type="System.Drawing.Point, System.Drawing">
+    <value>158, 54</value>
+  </data>
+  <data name="label49.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 25</value>
+  </data>
+  <data name="label49.TabIndex" type="System.Int32, mscorlib">
+    <value>63</value>
+  </data>
+  <data name="label49.Text" xml:space="preserve">
+    <value>Bandwidth</value>
+  </data>
+  <data name="&gt;&gt;label49.Name" xml:space="preserve">
+    <value>label49</value>
+  </data>
+  <data name="&gt;&gt;label49.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label49.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label49.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="INS_HNTCH_ATT.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_ATT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>229, 27</value>
+  </data>
+  <data name="INS_HNTCH_ATT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_ATT.TabIndex" type="System.Int32, mscorlib">
+    <value>62</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ATT.Name" xml:space="preserve">
+    <value>INS_HNTCH_ATT</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ATT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ATT.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ATT.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="label48.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label48.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label48.Location" type="System.Drawing.Point, System.Drawing">
+    <value>158, 29</value>
+  </data>
+  <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 25</value>
+  </data>
+  <data name="label48.TabIndex" type="System.Int32, mscorlib">
+    <value>61</value>
+  </data>
+  <data name="label48.Text" xml:space="preserve">
+    <value>Attenuation</value>
+  </data>
+  <data name="&gt;&gt;label48.Name" xml:space="preserve">
+    <value>label48</value>
+  </data>
+  <data name="&gt;&gt;label48.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label48.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label48.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="INS_HNTCH_FREQ.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_FREQ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>64, 102</value>
+  </data>
+  <data name="INS_HNTCH_FREQ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_FREQ.TabIndex" type="System.Int32, mscorlib">
+    <value>60</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_FREQ.Name" xml:space="preserve">
+    <value>INS_HNTCH_FREQ</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_FREQ.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_FREQ.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_FREQ.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="label41.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label41.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label41.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 104</value>
+  </data>
+  <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 25</value>
+  </data>
+  <data name="label41.TabIndex" type="System.Int32, mscorlib">
+    <value>59</value>
+  </data>
+  <data name="label41.Text" xml:space="preserve">
+    <value>Frequency</value>
+  </data>
+  <data name="&gt;&gt;label41.Name" xml:space="preserve">
+    <value>label41</value>
+  </data>
+  <data name="&gt;&gt;label41.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label41.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="INS_HNTCH_REF.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_REF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>64, 77</value>
+  </data>
+  <data name="INS_HNTCH_REF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_REF.TabIndex" type="System.Int32, mscorlib">
+    <value>58</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_REF.Name" xml:space="preserve">
+    <value>INS_HNTCH_REF</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_REF.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_REF.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_REF.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="label43.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label43.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label43.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 79</value>
+  </data>
+  <data name="label43.Size" type="System.Drawing.Size, System.Drawing">
+    <value>111, 25</value>
+  </data>
+  <data name="label43.TabIndex" type="System.Int32, mscorlib">
+    <value>57</value>
+  </data>
+  <data name="label43.Text" xml:space="preserve">
+    <value>Reference</value>
+  </data>
+  <data name="&gt;&gt;label43.Name" xml:space="preserve">
+    <value>label43</value>
+  </data>
+  <data name="&gt;&gt;label43.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label43.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="INS_HNTCH_MODE.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_MODE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>64, 52</value>
+  </data>
+  <data name="INS_HNTCH_MODE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_MODE.TabIndex" type="System.Int32, mscorlib">
+    <value>56</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_MODE.Name" xml:space="preserve">
+    <value>INS_HNTCH_MODE</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_MODE.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_MODE.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_MODE.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="label44.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label44.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label44.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 54</value>
+  </data>
+  <data name="label44.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 25</value>
+  </data>
+  <data name="label44.TabIndex" type="System.Int32, mscorlib">
+    <value>55</value>
+  </data>
+  <data name="label44.Text" xml:space="preserve">
+    <value>Mode</value>
+  </data>
+  <data name="&gt;&gt;label44.Name" xml:space="preserve">
+    <value>label44</value>
+  </data>
+  <data name="&gt;&gt;label44.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label44.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>64, 27</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_HNTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
+    <value>54</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.Name" xml:space="preserve">
+    <value>INS_HNTCH_ENABLE</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;INS_HNTCH_ENABLE.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="label45.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label45.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label45.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 29</value>
+  </data>
+  <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 25</value>
+  </data>
+  <data name="label45.TabIndex" type="System.Int32, mscorlib">
+    <value>53</value>
+  </data>
+  <data name="label45.Text" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="&gt;&gt;label45.Name" xml:space="preserve">
+    <value>label45</value>
+  </data>
+  <data name="&gt;&gt;label45.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label45.Parent" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;label45.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="groupBox9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>186, 478</value>
+  </data>
+  <data name="groupBox9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>342, 133</value>
+  </data>
+  <data name="groupBox9.TabIndex" type="System.Int32, mscorlib">
+    <value>44</value>
+  </data>
+  <data name="groupBox9.Text" xml:space="preserve">
+    <value>Harmonic Notch Filter</value>
+  </data>
+  <data name="&gt;&gt;groupBox9.Name" xml:space="preserve">
+    <value>groupBox9</value>
+  </data>
+  <data name="&gt;&gt;groupBox9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox9.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox9.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="INS_NOTCH_ATT.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_NOTCH_ATT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 102</value>
+  </data>
+  <data name="INS_NOTCH_ATT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_NOTCH_ATT.TabIndex" type="System.Int32, mscorlib">
+    <value>52</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ATT.Name" xml:space="preserve">
+    <value>INS_NOTCH_ATT</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ATT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ATT.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ATT.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label40.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label40.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label40.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 104</value>
+  </data>
+  <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 25</value>
+  </data>
+  <data name="label40.TabIndex" type="System.Int32, mscorlib">
+    <value>51</value>
+  </data>
+  <data name="label40.Text" xml:space="preserve">
+    <value>Attenuation</value>
+  </data>
+  <data name="&gt;&gt;label40.Name" xml:space="preserve">
+    <value>label40</value>
+  </data>
+  <data name="&gt;&gt;label40.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label40.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="INS_NOTCH_BW.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_NOTCH_BW.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 77</value>
+  </data>
+  <data name="INS_NOTCH_BW.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_NOTCH_BW.TabIndex" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_BW.Name" xml:space="preserve">
+    <value>INS_NOTCH_BW</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_BW.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_BW.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_BW.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label39.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label39.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label39.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 79</value>
+  </data>
+  <data name="label39.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 25</value>
+  </data>
+  <data name="label39.TabIndex" type="System.Int32, mscorlib">
+    <value>49</value>
+  </data>
+  <data name="label39.Text" xml:space="preserve">
+    <value>BandWidth</value>
+  </data>
+  <data name="&gt;&gt;label39.Name" xml:space="preserve">
+    <value>label39</value>
+  </data>
+  <data name="&gt;&gt;label39.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label39.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;label39.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="INS_NOTCH_FREQ.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_NOTCH_FREQ.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 52</value>
+  </data>
+  <data name="INS_NOTCH_FREQ.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_NOTCH_FREQ.TabIndex" type="System.Int32, mscorlib">
+    <value>48</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_FREQ.Name" xml:space="preserve">
+    <value>INS_NOTCH_FREQ</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_FREQ.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_FREQ.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_FREQ.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label38.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label38.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label38.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 54</value>
+  </data>
+  <data name="label38.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 25</value>
+  </data>
+  <data name="label38.TabIndex" type="System.Int32, mscorlib">
+    <value>47</value>
+  </data>
+  <data name="label38.Text" xml:space="preserve">
+    <value>Frequency</value>
+  </data>
+  <data name="&gt;&gt;label38.Name" xml:space="preserve">
+    <value>label38</value>
+  </data>
+  <data name="&gt;&gt;label38.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label38.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;label38.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>80, 27</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_NOTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
+    <value>46</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.Name" xml:space="preserve">
+    <value>INS_NOTCH_ENABLE</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;INS_NOTCH_ENABLE.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="label37.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label37.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label37.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 29</value>
+  </data>
+  <data name="label37.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 25</value>
+  </data>
+  <data name="label37.TabIndex" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="label37.Text" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="&gt;&gt;label37.Name" xml:space="preserve">
+    <value>label37</value>
+  </data>
+  <data name="&gt;&gt;label37.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label37.Parent" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;label37.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="groupBox8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 478</value>
+  </data>
+  <data name="groupBox8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 133</value>
+  </data>
+  <data name="groupBox8.TabIndex" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <data name="groupBox8.Text" xml:space="preserve">
+    <value>Static Notch Filter</value>
+  </data>
+  <data name="&gt;&gt;groupBox8.Name" xml:space="preserve">
+    <value>groupBox8</value>
+  </data>
+  <data name="&gt;&gt;groupBox8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox8.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox8.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="INS_LOG_BAT_OPT.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_LOG_BAT_OPT.Location" type="System.Drawing.Point, System.Drawing">
+    <value>211, 14</value>
+  </data>
+  <data name="INS_LOG_BAT_OPT.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_LOG_BAT_OPT.TabIndex" type="System.Int32, mscorlib">
+    <value>46</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_OPT.Name" xml:space="preserve">
+    <value>INS_LOG_BAT_OPT</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_OPT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_OPT.Parent" xml:space="preserve">
+    <value>groupBox6</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_OPT.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label36.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label36.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label36.Location" type="System.Drawing.Point, System.Drawing">
+    <value>149, 16</value>
+  </data>
+  <data name="label36.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 25</value>
+  </data>
+  <data name="label36.TabIndex" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="label36.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;label36.Name" xml:space="preserve">
+    <value>label36</value>
+  </data>
+  <data name="&gt;&gt;label36.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label36.Parent" xml:space="preserve">
+    <value>groupBox6</value>
+  </data>
+  <data name="&gt;&gt;label36.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.Location" type="System.Drawing.Point, System.Drawing">
+    <value>45, 14</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 31</value>
+  </data>
+  <data name="INS_LOG_BAT_MASK.TabIndex" type="System.Int32, mscorlib">
+    <value>44</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.Name" xml:space="preserve">
+    <value>INS_LOG_BAT_MASK</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.Parent" xml:space="preserve">
+    <value>groupBox6</value>
+  </data>
+  <data name="&gt;&gt;INS_LOG_BAT_MASK.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label34.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label34.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label34.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 16</value>
+  </data>
+  <data name="label34.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 25</value>
+  </data>
+  <data name="label34.TabIndex" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <data name="label34.Text" xml:space="preserve">
+    <value>Mask</value>
+  </data>
+  <data name="&gt;&gt;label34.Name" xml:space="preserve">
+    <value>label34</value>
+  </data>
+  <data name="&gt;&gt;label34.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label34.Parent" xml:space="preserve">
+    <value>groupBox6</value>
+  </data>
+  <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="groupBox6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 424</value>
+  </data>
+  <data name="groupBox6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>344, 48</value>
+  </data>
+  <data name="groupBox6.TabIndex" type="System.Int32, mscorlib">
+    <value>42</value>
+  </data>
+  <data name="groupBox6.Text" xml:space="preserve">
+    <value>Filter Logs</value>
+  </data>
+  <data name="&gt;&gt;groupBox6.Name" xml:space="preserve">
+    <value>groupBox6</value>
+  </data>
+  <data name="&gt;&gt;groupBox6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox6.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox6.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label52.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label52.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label52.Location" type="System.Drawing.Point, System.Drawing">
+    <value>357, 343</value>
+  </data>
+  <data name="label52.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 25</value>
+  </data>
+  <data name="label52.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="label52.Text" xml:space="preserve">
+    <value>RC6 Opt</value>
+  </data>
+  <data name="&gt;&gt;label52.Name" xml:space="preserve">
+    <value>label52</value>
+  </data>
+  <data name="&gt;&gt;label52.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label52.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label52.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="CH6_OPTION.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CH6_OPTION.Location" type="System.Drawing.Point, System.Drawing">
+    <value>416, 343</value>
+  </data>
+  <data name="CH6_OPTION.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 33</value>
+  </data>
+  <data name="CH6_OPTION.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="&gt;&gt;CH6_OPTION.Name" xml:space="preserve">
+    <value>CH6_OPTION</value>
+  </data>
+  <data name="&gt;&gt;CH6_OPTION.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CH6_OPTION.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CH6_OPTION.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -3721,7 +4144,7 @@
     <value>True</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>707, 421</value>
+    <value>729, 651</value>
   </data>
   <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
     <value>toolTip1</value>

--- a/GCSViews/ConfigurationView/ConfigArducopter.resx
+++ b/GCSViews/ConfigurationView/ConfigArducopter.resx
@@ -123,10 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="TUNE_LOW.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 369</value>
+    <value>218, 360</value>
   </data>
   <data name="TUNE_LOW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 31</value>
+    <value>51, 20</value>
   </data>
   <data name="TUNE_LOW.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -135,7 +135,7 @@
     <value>TUNE_LOW</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.Parent" xml:space="preserve">
     <value>$this</value>
@@ -147,10 +147,10 @@
     <value>False</value>
   </data>
   <data name="TUNE_HIGH.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 369</value>
+    <value>308, 360</value>
   </data>
   <data name="TUNE_HIGH.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 31</value>
+    <value>46, 20</value>
   </data>
   <data name="TUNE_HIGH.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -159,7 +159,7 @@
     <value>TUNE_HIGH</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.Parent" xml:space="preserve">
     <value>$this</value>
@@ -171,10 +171,10 @@
     <value>False</value>
   </data>
   <data name="TUNE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>242, 341</value>
+    <value>242, 332</value>
   </data>
   <data name="TUNE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 33</value>
+    <value>112, 21</value>
   </data>
   <data name="TUNE.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -183,7 +183,7 @@
     <value>TUNE</value>
   </data>
   <data name="&gt;&gt;TUNE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE.Parent" xml:space="preserve">
     <value>$this</value>
@@ -195,10 +195,10 @@
     <value>False</value>
   </data>
   <data name="CH7_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 370</value>
+    <value>416, 361</value>
   </data>
   <data name="CH7_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 33</value>
+    <value>112, 21</value>
   </data>
   <data name="CH7_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -207,7 +207,7 @@
     <value>CH7_OPTION</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
@@ -222,7 +222,7 @@
     <value>80, 13</value>
   </data>
   <data name="THR_RATE_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="THR_RATE_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -231,7 +231,7 @@
     <value>THR_RATE_P</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -268,7 +268,7 @@
     <value>1</value>
   </data>
   <data name="groupBox5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 296</value>
+    <value>183, 287</value>
   </data>
   <data name="groupBox5.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 50</value>
@@ -301,7 +301,7 @@
     <value>7, 79</value>
   </data>
   <data name="CHK_lockrollpitch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>301, 29</value>
+    <value>154, 17</value>
   </data>
   <data name="CHK_lockrollpitch.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -328,7 +328,7 @@
     <value>80, 60</value>
   </data>
   <data name="WPNAV_SPEED_UP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="WPNAV_SPEED_UP.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -337,7 +337,7 @@
     <value>WPNAV_SPEED_UP</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -379,7 +379,7 @@
     <value>80, 107</value>
   </data>
   <data name="WPNAV_LOIT_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="WPNAV_LOIT_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -388,7 +388,7 @@
     <value>WPNAV_LOIT_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -430,7 +430,7 @@
     <value>80, 84</value>
   </data>
   <data name="WPNAV_SPEED_DN.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="WPNAV_SPEED_DN.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -439,7 +439,7 @@
     <value>WPNAV_SPEED_DN</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -481,7 +481,7 @@
     <value>80, 37</value>
   </data>
   <data name="WPNAV_RADIUS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="WPNAV_RADIUS.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -490,7 +490,7 @@
     <value>WPNAV_RADIUS</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -532,7 +532,7 @@
     <value>80, 13</value>
   </data>
   <data name="WPNAV_SPEED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="WPNAV_SPEED.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -541,7 +541,7 @@
     <value>WPNAV_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -577,7 +577,7 @@
     <value>9</value>
   </data>
   <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>532, 296</value>
+    <value>532, 287</value>
   </data>
   <data name="groupBox4.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 138</value>
@@ -607,7 +607,7 @@
     <value>80, 13</value>
   </data>
   <data name="THR_ALT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="THR_ALT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -616,7 +616,7 @@
     <value>THR_ALT_P</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Parent" xml:space="preserve">
     <value>groupBox7</value>
@@ -652,7 +652,7 @@
     <value>1</value>
   </data>
   <data name="groupBox7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>359, 296</value>
+    <value>359, 287</value>
   </data>
   <data name="groupBox7.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 50</value>
@@ -682,7 +682,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_input_tc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="mavlinkNumericUpDownatc_input_tc.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -691,7 +691,7 @@
     <value>mavlinkNumericUpDownatc_input_tc</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -733,7 +733,7 @@
     <value>80, 13</value>
   </data>
   <data name="HLD_LAT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="HLD_LAT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -742,7 +742,7 @@
     <value>HLD_LAT_P</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -808,7 +808,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_y_max.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_y_max.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -817,7 +817,7 @@
     <value>mavlinkNumericUpDownatc_accel_y_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -859,7 +859,7 @@
     <value>80, 13</value>
   </data>
   <data name="STB_YAW_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="STB_YAW_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -868,7 +868,7 @@
     <value>STB_YAW_P</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -934,7 +934,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_p_max.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_p_max.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -943,7 +943,7 @@
     <value>mavlinkNumericUpDownatc_accel_p_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -985,7 +985,7 @@
     <value>80, 13</value>
   </data>
   <data name="STB_PIT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="STB_PIT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -994,7 +994,7 @@
     <value>STB_PIT_P</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -1060,7 +1060,7 @@
     <value>80, 39</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_r_max.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_r_max.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1069,7 +1069,7 @@
     <value>mavlinkNumericUpDownatc_accel_r_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1111,7 +1111,7 @@
     <value>80, 13</value>
   </data>
   <data name="STB_RLL_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="STB_RLL_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1120,7 +1120,7 @@
     <value>STB_RLL_P</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1186,7 +1186,7 @@
     <value>79, 152</value>
   </data>
   <data name="ATC_RAT_YAW_FLTT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="ATC_RAT_YAW_FLTT.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -1195,7 +1195,7 @@
     <value>ATC_RAT_YAW_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1213,7 +1213,7 @@
     <value>6, 154</value>
   </data>
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 25</value>
+    <value>33, 13</value>
   </data>
   <data name="label33.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -1240,7 +1240,7 @@
     <value>79, 129</value>
   </data>
   <data name="ATC_RAT_YAW_FLTD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="ATC_RAT_YAW_FLTD.TabIndex" type="System.Int32, mscorlib">
     <value>43</value>
@@ -1249,7 +1249,7 @@
     <value>ATC_RAT_YAW_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1267,7 +1267,7 @@
     <value>6, 131</value>
   </data>
   <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 25</value>
+    <value>34, 13</value>
   </data>
   <data name="label32.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1294,7 +1294,7 @@
     <value>80, 106</value>
   </data>
   <data name="RATE_YAW_FILT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_YAW_FILT.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1303,7 +1303,7 @@
     <value>RATE_YAW_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1345,7 +1345,7 @@
     <value>80, 60</value>
   </data>
   <data name="RATE_YAW_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_YAW_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1354,7 +1354,7 @@
     <value>RATE_YAW_D</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1396,7 +1396,7 @@
     <value>80, 83</value>
   </data>
   <data name="RATE_YAW_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_YAW_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1405,7 +1405,7 @@
     <value>RATE_YAW_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1447,7 +1447,7 @@
     <value>80, 37</value>
   </data>
   <data name="RATE_YAW_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_YAW_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1456,7 +1456,7 @@
     <value>RATE_YAW_I</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1498,7 +1498,7 @@
     <value>80, 13</value>
   </data>
   <data name="RATE_YAW_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_YAW_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1507,7 +1507,7 @@
     <value>RATE_YAW_P</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1573,7 +1573,7 @@
     <value>80, 152</value>
   </data>
   <data name="ATC_RAT_RLL_FLTT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="ATC_RAT_RLL_FLTT.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -1582,7 +1582,7 @@
     <value>ATC_RAT_RLL_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1600,7 +1600,7 @@
     <value>5, 156</value>
   </data>
   <data name="label30.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 25</value>
+    <value>33, 13</value>
   </data>
   <data name="label30.TabIndex" type="System.Int32, mscorlib">
     <value>40</value>
@@ -1627,7 +1627,7 @@
     <value>80, 129</value>
   </data>
   <data name="ATC_RAT_RLL_FLTD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="ATC_RAT_RLL_FLTD.TabIndex" type="System.Int32, mscorlib">
     <value>39</value>
@@ -1636,7 +1636,7 @@
     <value>ATC_RAT_RLL_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1654,7 +1654,7 @@
     <value>6, 131</value>
   </data>
   <data name="label29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 25</value>
+    <value>34, 13</value>
   </data>
   <data name="label29.TabIndex" type="System.Int32, mscorlib">
     <value>38</value>
@@ -1681,7 +1681,7 @@
     <value>80, 106</value>
   </data>
   <data name="RATE_PIT_FILT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_PIT_FILT.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1690,7 +1690,7 @@
     <value>RATE_PIT_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1732,7 +1732,7 @@
     <value>80, 60</value>
   </data>
   <data name="RATE_PIT_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_PIT_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1741,7 +1741,7 @@
     <value>RATE_PIT_D</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1783,7 +1783,7 @@
     <value>80, 84</value>
   </data>
   <data name="RATE_PIT_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_PIT_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1792,7 +1792,7 @@
     <value>RATE_PIT_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1834,7 +1834,7 @@
     <value>80, 37</value>
   </data>
   <data name="RATE_PIT_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_PIT_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1843,7 +1843,7 @@
     <value>RATE_PIT_I</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1885,7 +1885,7 @@
     <value>80, 13</value>
   </data>
   <data name="RATE_PIT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_PIT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1894,7 +1894,7 @@
     <value>RATE_PIT_P</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1960,7 +1960,7 @@
     <value>80, 152</value>
   </data>
   <data name="ATC_RAT_PIT_FLTT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="ATC_RAT_PIT_FLTT.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -1969,7 +1969,7 @@
     <value>ATC_RAT_PIT_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -1987,7 +1987,7 @@
     <value>7, 154</value>
   </data>
   <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 25</value>
+    <value>33, 13</value>
   </data>
   <data name="label28.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
@@ -2014,7 +2014,7 @@
     <value>80, 129</value>
   </data>
   <data name="ATC_RAT_PIT_FLTD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="ATC_RAT_PIT_FLTD.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -2023,7 +2023,7 @@
     <value>ATC_RAT_PIT_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2041,7 +2041,7 @@
     <value>6, 131</value>
   </data>
   <data name="P_FLTD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 25</value>
+    <value>34, 13</value>
   </data>
   <data name="P_FLTD.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -2068,7 +2068,7 @@
     <value>80, 106</value>
   </data>
   <data name="RATE_RLL_FILT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_RLL_FILT.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -2077,7 +2077,7 @@
     <value>RATE_RLL_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2119,7 +2119,7 @@
     <value>80, 60</value>
   </data>
   <data name="RATE_RLL_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_RLL_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2128,7 +2128,7 @@
     <value>RATE_RLL_D</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2170,7 +2170,7 @@
     <value>80, 83</value>
   </data>
   <data name="RATE_RLL_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_RLL_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2179,7 +2179,7 @@
     <value>RATE_RLL_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2221,7 +2221,7 @@
     <value>80, 37</value>
   </data>
   <data name="RATE_RLL_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_RLL_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2230,7 +2230,7 @@
     <value>RATE_RLL_I</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2272,7 +2272,7 @@
     <value>80, 13</value>
   </data>
   <data name="RATE_RLL_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="RATE_RLL_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2281,7 +2281,7 @@
     <value>RATE_RLL_P</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2350,7 +2350,7 @@
     <value>80, 60</value>
   </data>
   <data name="LOITER_LAT_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="LOITER_LAT_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2359,7 +2359,7 @@
     <value>LOITER_LAT_D</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2401,7 +2401,7 @@
     <value>80, 84</value>
   </data>
   <data name="LOITER_LAT_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="LOITER_LAT_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2410,7 +2410,7 @@
     <value>LOITER_LAT_IMAX</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2452,7 +2452,7 @@
     <value>80, 37</value>
   </data>
   <data name="LOITER_LAT_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="LOITER_LAT_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2461,7 +2461,7 @@
     <value>LOITER_LAT_I</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2503,7 +2503,7 @@
     <value>80, 13</value>
   </data>
   <data name="LOITER_LAT_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="LOITER_LAT_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2512,7 +2512,7 @@
     <value>LOITER_LAT_P</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2575,7 +2575,7 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_rerequestparams.Location" type="System.Drawing.Point, System.Drawing">
-    <value>317, 617</value>
+    <value>317, 608</value>
   </data>
   <data name="BUT_rerequestparams.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 15, 0, 0</value>
@@ -2608,7 +2608,7 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_writePIDS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>208, 617</value>
+    <value>208, 608</value>
   </data>
   <data name="BUT_writePIDS.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 25</value>
@@ -2635,10 +2635,10 @@
     <value>True</value>
   </data>
   <data name="myLabel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 366</value>
+    <value>183, 357</value>
   </data>
   <data name="myLabel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 25</value>
+    <value>24, 13</value>
   </data>
   <data name="myLabel3.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -2662,10 +2662,10 @@
     <value>True</value>
   </data>
   <data name="myLabel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>183, 341</value>
+    <value>183, 332</value>
   </data>
   <data name="myLabel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 25</value>
+    <value>32, 13</value>
   </data>
   <data name="myLabel2.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -2689,10 +2689,10 @@
     <value>True</value>
   </data>
   <data name="myLabel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 370</value>
+    <value>357, 361</value>
   </data>
   <data name="myLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 25</value>
+    <value>48, 13</value>
   </data>
   <data name="myLabel1.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2719,7 +2719,7 @@
     <value>80, 66</value>
   </data>
   <data name="THR_ACCEL_D.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="THR_ACCEL_D.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2728,7 +2728,7 @@
     <value>THR_ACCEL_D</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2797,7 +2797,7 @@
     <value>80, 89</value>
   </data>
   <data name="THR_ACCEL_IMAX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="THR_ACCEL_IMAX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2806,7 +2806,7 @@
     <value>THR_ACCEL_IMAX</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2821,7 +2821,7 @@
     <value>80, 43</value>
   </data>
   <data name="THR_ACCEL_I.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="THR_ACCEL_I.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2830,7 +2830,7 @@
     <value>THR_ACCEL_I</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2872,7 +2872,7 @@
     <value>80, 19</value>
   </data>
   <data name="THR_ACCEL_P.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="THR_ACCEL_P.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2881,7 +2881,7 @@
     <value>THR_ACCEL_P</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2917,7 +2917,7 @@
     <value>7</value>
   </data>
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 296</value>
+    <value>7, 287</value>
   </data>
   <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 122</value>
@@ -2944,7 +2944,7 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_refreshpart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>426, 617</value>
+    <value>426, 608</value>
   </data>
   <data name="BUT_refreshpart.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 15, 0, 0</value>
@@ -2974,10 +2974,10 @@
     <value>True</value>
   </data>
   <data name="myLabel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 397</value>
+    <value>357, 388</value>
   </data>
   <data name="myLabel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 25</value>
+    <value>48, 13</value>
   </data>
   <data name="myLabel4.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -3001,10 +3001,10 @@
     <value>False</value>
   </data>
   <data name="CH8_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 397</value>
+    <value>416, 388</value>
   </data>
   <data name="CH8_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 33</value>
+    <value>112, 21</value>
   </data>
   <data name="CH8_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -3013,7 +3013,7 @@
     <value>CH8_OPTION</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3025,10 +3025,10 @@
     <value>True</value>
   </data>
   <data name="myLabel5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 424</value>
+    <value>357, 415</value>
   </data>
   <data name="myLabel5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 25</value>
+    <value>48, 13</value>
   </data>
   <data name="myLabel5.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -3052,10 +3052,10 @@
     <value>False</value>
   </data>
   <data name="CH9_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 424</value>
+    <value>416, 415</value>
   </data>
   <data name="CH9_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 33</value>
+    <value>112, 21</value>
   </data>
   <data name="CH9_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -3064,7 +3064,7 @@
     <value>CH9_OPTION</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3076,10 +3076,10 @@
     <value>True</value>
   </data>
   <data name="myLabel6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 451</value>
+    <value>357, 442</value>
   </data>
   <data name="myLabel6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 25</value>
+    <value>54, 13</value>
   </data>
   <data name="myLabel6.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -3103,10 +3103,10 @@
     <value>False</value>
   </data>
   <data name="CH10_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 451</value>
+    <value>416, 442</value>
   </data>
   <data name="CH10_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 33</value>
+    <value>112, 21</value>
   </data>
   <data name="CH10_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -3115,7 +3115,7 @@
     <value>CH10_OPTION</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
@@ -3130,7 +3130,7 @@
     <value>80, 37</value>
   </data>
   <data name="INS_ACCEL_FILTER.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_ACCEL_FILTER.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -3139,7 +3139,7 @@
     <value>INS_ACCEL_FILTER</value>
   </data>
   <data name="&gt;&gt;INS_ACCEL_FILTER.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_ACCEL_FILTER.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -3157,7 +3157,7 @@
     <value>8, 39</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 25</value>
+    <value>34, 13</value>
   </data>
   <data name="label26.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -3184,7 +3184,7 @@
     <value>79, 14</value>
   </data>
   <data name="INS_GYRO_FILTER.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 31</value>
+    <value>79, 20</value>
   </data>
   <data name="INS_GYRO_FILTER.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -3193,7 +3193,7 @@
     <value>INS_GYRO_FILTER</value>
   </data>
   <data name="&gt;&gt;INS_GYRO_FILTER.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_GYRO_FILTER.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -3208,7 +3208,7 @@
     <value>8, 16</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 25</value>
+    <value>29, 13</value>
   </data>
   <data name="label24.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3259,7 +3259,7 @@
     <value>230, 102</value>
   </data>
   <data name="INS_HNTCH_HMNCS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_HMNCS.TabIndex" type="System.Int32, mscorlib">
     <value>68</value>
@@ -3268,7 +3268,7 @@
     <value>INS_HNTCH_HMNCS</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3286,7 +3286,7 @@
     <value>158, 104</value>
   </data>
   <data name="label51.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 25</value>
+    <value>57, 13</value>
   </data>
   <data name="label51.TabIndex" type="System.Int32, mscorlib">
     <value>67</value>
@@ -3313,7 +3313,7 @@
     <value>230, 77</value>
   </data>
   <data name="INS_HNTCH_OPTS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_OPTS.TabIndex" type="System.Int32, mscorlib">
     <value>66</value>
@@ -3322,7 +3322,7 @@
     <value>INS_HNTCH_OPTS</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3340,7 +3340,7 @@
     <value>158, 79</value>
   </data>
   <data name="label50.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 25</value>
+    <value>43, 13</value>
   </data>
   <data name="label50.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -3367,7 +3367,7 @@
     <value>229, 52</value>
   </data>
   <data name="INS_HNTCH_BW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_BW.TabIndex" type="System.Int32, mscorlib">
     <value>64</value>
@@ -3376,7 +3376,7 @@
     <value>INS_HNTCH_BW</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3394,7 +3394,7 @@
     <value>158, 54</value>
   </data>
   <data name="label49.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 25</value>
+    <value>57, 13</value>
   </data>
   <data name="label49.TabIndex" type="System.Int32, mscorlib">
     <value>63</value>
@@ -3421,7 +3421,7 @@
     <value>229, 27</value>
   </data>
   <data name="INS_HNTCH_ATT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_ATT.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -3430,7 +3430,7 @@
     <value>INS_HNTCH_ATT</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3448,7 +3448,7 @@
     <value>158, 29</value>
   </data>
   <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 25</value>
+    <value>61, 13</value>
   </data>
   <data name="label48.TabIndex" type="System.Int32, mscorlib">
     <value>61</value>
@@ -3475,7 +3475,7 @@
     <value>64, 102</value>
   </data>
   <data name="INS_HNTCH_FREQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_FREQ.TabIndex" type="System.Int32, mscorlib">
     <value>60</value>
@@ -3484,7 +3484,7 @@
     <value>INS_HNTCH_FREQ</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3502,7 +3502,7 @@
     <value>6, 104</value>
   </data>
   <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 25</value>
+    <value>57, 13</value>
   </data>
   <data name="label41.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
@@ -3529,7 +3529,7 @@
     <value>64, 77</value>
   </data>
   <data name="INS_HNTCH_REF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_REF.TabIndex" type="System.Int32, mscorlib">
     <value>58</value>
@@ -3538,7 +3538,7 @@
     <value>INS_HNTCH_REF</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3556,7 +3556,7 @@
     <value>6, 79</value>
   </data>
   <data name="label43.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 25</value>
+    <value>57, 13</value>
   </data>
   <data name="label43.TabIndex" type="System.Int32, mscorlib">
     <value>57</value>
@@ -3583,7 +3583,7 @@
     <value>64, 52</value>
   </data>
   <data name="INS_HNTCH_MODE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_MODE.TabIndex" type="System.Int32, mscorlib">
     <value>56</value>
@@ -3592,7 +3592,7 @@
     <value>INS_HNTCH_MODE</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3610,7 +3610,7 @@
     <value>6, 54</value>
   </data>
   <data name="label44.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 25</value>
+    <value>34, 13</value>
   </data>
   <data name="label44.TabIndex" type="System.Int32, mscorlib">
     <value>55</value>
@@ -3637,7 +3637,7 @@
     <value>64, 27</value>
   </data>
   <data name="INS_HNTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_HNTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
@@ -3646,7 +3646,7 @@
     <value>INS_HNTCH_ENABLE</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ENABLE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ENABLE.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3664,7 +3664,7 @@
     <value>6, 29</value>
   </data>
   <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 25</value>
+    <value>46, 13</value>
   </data>
   <data name="label45.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -3685,7 +3685,7 @@
     <value>15</value>
   </data>
   <data name="groupBox9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>186, 478</value>
+    <value>186, 469</value>
   </data>
   <data name="groupBox9.Size" type="System.Drawing.Size, System.Drawing">
     <value>342, 133</value>
@@ -3715,7 +3715,7 @@
     <value>80, 102</value>
   </data>
   <data name="INS_NOTCH_ATT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_NOTCH_ATT.TabIndex" type="System.Int32, mscorlib">
     <value>52</value>
@@ -3724,7 +3724,7 @@
     <value>INS_NOTCH_ATT</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3742,7 +3742,7 @@
     <value>8, 104</value>
   </data>
   <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 25</value>
+    <value>61, 13</value>
   </data>
   <data name="label40.TabIndex" type="System.Int32, mscorlib">
     <value>51</value>
@@ -3769,7 +3769,7 @@
     <value>80, 77</value>
   </data>
   <data name="INS_NOTCH_BW.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_NOTCH_BW.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -3778,7 +3778,7 @@
     <value>INS_NOTCH_BW</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3796,7 +3796,7 @@
     <value>8, 79</value>
   </data>
   <data name="label39.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 25</value>
+    <value>60, 13</value>
   </data>
   <data name="label39.TabIndex" type="System.Int32, mscorlib">
     <value>49</value>
@@ -3823,7 +3823,7 @@
     <value>80, 52</value>
   </data>
   <data name="INS_NOTCH_FREQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_NOTCH_FREQ.TabIndex" type="System.Int32, mscorlib">
     <value>48</value>
@@ -3832,7 +3832,7 @@
     <value>INS_NOTCH_FREQ</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3850,7 +3850,7 @@
     <value>6, 54</value>
   </data>
   <data name="label38.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 25</value>
+    <value>57, 13</value>
   </data>
   <data name="label38.TabIndex" type="System.Int32, mscorlib">
     <value>47</value>
@@ -3877,7 +3877,7 @@
     <value>80, 27</value>
   </data>
   <data name="INS_NOTCH_ENABLE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_NOTCH_ENABLE.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -3886,7 +3886,7 @@
     <value>INS_NOTCH_ENABLE</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ENABLE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ENABLE.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3904,7 +3904,7 @@
     <value>8, 29</value>
   </data>
   <data name="label37.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 25</value>
+    <value>46, 13</value>
   </data>
   <data name="label37.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -3925,7 +3925,7 @@
     <value>7</value>
   </data>
   <data name="groupBox8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 478</value>
+    <value>7, 469</value>
   </data>
   <data name="groupBox8.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 133</value>
@@ -3955,7 +3955,7 @@
     <value>211, 14</value>
   </data>
   <data name="INS_LOG_BAT_OPT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_LOG_BAT_OPT.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -3964,7 +3964,7 @@
     <value>INS_LOG_BAT_OPT</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Parent" xml:space="preserve">
     <value>groupBox6</value>
@@ -3982,7 +3982,7 @@
     <value>149, 16</value>
   </data>
   <data name="label36.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 25</value>
+    <value>43, 13</value>
   </data>
   <data name="label36.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -4009,7 +4009,7 @@
     <value>45, 14</value>
   </data>
   <data name="INS_LOG_BAT_MASK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 31</value>
+    <value>78, 20</value>
   </data>
   <data name="INS_LOG_BAT_MASK.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -4018,7 +4018,7 @@
     <value>INS_LOG_BAT_MASK</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_MASK.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_MASK.Parent" xml:space="preserve">
     <value>groupBox6</value>
@@ -4036,7 +4036,7 @@
     <value>6, 16</value>
   </data>
   <data name="label34.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 25</value>
+    <value>33, 13</value>
   </data>
   <data name="label34.TabIndex" type="System.Int32, mscorlib">
     <value>43</value>
@@ -4057,7 +4057,7 @@
     <value>3</value>
   </data>
   <data name="groupBox6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 424</value>
+    <value>7, 415</value>
   </data>
   <data name="groupBox6.Size" type="System.Drawing.Size, System.Drawing">
     <value>344, 48</value>
@@ -4087,10 +4087,10 @@
     <value>NoControl</value>
   </data>
   <data name="label52.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 343</value>
+    <value>357, 334</value>
   </data>
   <data name="label52.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 25</value>
+    <value>48, 13</value>
   </data>
   <data name="label52.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -4114,10 +4114,10 @@
     <value>False</value>
   </data>
   <data name="CH6_OPTION.Location" type="System.Drawing.Point, System.Drawing">
-    <value>416, 343</value>
+    <value>416, 334</value>
   </data>
   <data name="CH6_OPTION.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 33</value>
+    <value>112, 21</value>
   </data>
   <data name="CH6_OPTION.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -4126,7 +4126,7 @@
     <value>CH6_OPTION</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2132, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7828.2600, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.Parent" xml:space="preserve">
     <value>$this</value>


### PR DESCRIPTION
In the last few releases, several new filter values have been added, including notch and harmonic filters and FLT* filters. I have updated the UI to include fields for all those filters so that they don't need to be modified from the the parameter list or tree views.