### PR TITLE
GCSViews: If the delay of WAYPOINT is set to less than 0, set it to 0

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2979,7 +2979,16 @@ namespace MissionPlanner.GCSViews
                             false);
                 }
 
-                temp.p1 = float.Parse(Commands.Rows[a].Cells[Param1.Index].Value.ToString());
+                if (Commands.Rows[a].Cells[Command.Index].Value.Equals("WAYPOINT"))
+                {
+                    temp.p1 = float.Parse(Commands.Rows[a].Cells[Param1.Index].Value.ToString());
+                    if (temp.p1 < 0)
+                    {
+                        temp.p1 = 0;
+                        DataGridViewTextBoxCell cell = Commands.Rows[a].Cells[Param1.Index] as DataGridViewTextBoxCell;
+                        cell.Value = temp.p1;
+                    }
+                }
 
                 temp.alt =
                     (float)


### PR DESCRIPTION
I set it to 0 if the WAYPOINT delay is set to a value less than 0.
I set the PR to return an error response if the WAYPOINT delay is set to a value less than 0 on the ArduPilot side.
I hoped that the ArduPilot members would check the input value on the GCS side.
I was unable to set a value less than 0 for the WAYPOINT delay in APM PLANNER2.
I decided to change the MP side.

https://github.com/ArduPilot/ardupilot/pull/17704