### PR TITLE
Correct the table headers for do_change_speed params

### DIFF
--- a/ExtLibs/Xamarin/Xamarin/Resources/mavcmd.xml
+++ b/ExtLibs/Xamarin/Xamarin/Resources/mavcmd.xml
@@ -175,8 +175,8 @@
       <Z></Z>
     </DO_JUMP>
     <DO_CHANGE_SPEED>
-      <P1>speed m/s</P1>
-      <P2>speed m/s</P2>
+      <P1>Type</P1>
+      <P2>Speed m/s</P2>
       <P3></P3>
       <P4></P4>
       <X></X>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -175,8 +175,8 @@
       <Z></Z>
     </DO_JUMP>
     <DO_CHANGE_SPEED>
-      <P1>speed m/s</P1>
-      <P2>speed m/s</P2>
+      <P1>Type</P1>
+      <P2>Speed m/s</P2>
       <P3></P3>
       <P4></P4>
       <X></X>


### PR DESCRIPTION
Trivial change to the DO_CHANGE_SPEED command table headers.

This resolves issue: #454

The table headers are now better aligned to both Mavlink Common descriptions and AP Stable and later.