### PR TITLE
remove redundant processBuffer call

### DIFF
--- a/ExtLibs/Mavlink/MAVLinkMessage.cs
+++ b/ExtLibs/Mavlink/MAVLinkMessage.cs
@@ -151,8 +151,6 @@ public partial class MAVLink
         {
             this.buffer = buffer;
             this.rxtime = rxTime;
-
-            processBuffer(buffer);
         }
 
         internal void processBuffer(byte[] buffer)


### PR DESCRIPTION
`processBuffer()` is called twice during  MAVLinkMessage construction

In
https://github.com/ArduPilot/MissionPlanner/blob/dc9f3fb4836f585ecbb35f12fa41dd1fa1ecccd3/ExtLibs/Mavlink/MAVLinkMessage.cs#L152
The setter already call `processBuffer()`
https://github.com/ArduPilot/MissionPlanner/blob/dc9f3fb4836f585ecbb35f12fa41dd1fa1ecccd3/ExtLibs/Mavlink/MAVLinkMessage.cs#L19