### PR TITLE
FlightPlanner: Clear selected marker on ContextMenu open

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2564,6 +2564,7 @@ namespace MissionPlanner.GCSViews
             }
 
             isMouseClickOffMenu = false; // Just incase
+            CurentRectMarker = null;     // Clear selected marker, otherwise it will stuck in drag mode 
         }
 
         public void ContextMenuStripPoly_Opening(object sender, CancelEventArgs e)


### PR DESCRIPTION
It fixes, shen a context menu is opened over a marker, it remains selected and after closing the menu (or called dialog) next click on the map moves the marker.