### PR TITLE
fix coax and single copter firmware type setting

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -65,6 +65,12 @@ namespace MissionPlanner
                 return (new GMapMarkerAntennaTracker(portlocation, MAV.cs.yaw,
                     MAV.cs.target_bearing){ Tag = MAV});
             }
+            else if (MAV.aptype == MAVLink.MAV_TYPE.COAXIAL)
+            {
+                return (new GMapMarkerSingle(portlocation, MAV.cs.yaw,
+                   MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.sysid)
+                { Tag = MAV });
+            }
             else if (MAV.cs.firmware == Firmwares.ArduCopter2 || MAV.aptype == MAVLink.MAV_TYPE.QUADROTOR)
             {
                 if (MAV.param.ContainsKey("AVD_W_DIST_XY") && MAV.param.ContainsKey("AVD_F_DIST_XY"))
@@ -87,11 +93,6 @@ namespace MissionPlanner
                     ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ? MarkerTooltipMode.Never : MarkerTooltipMode.Always,
                     Tag = MAV
                 });
-            }
-            else if (MAV.aptype == MAVLink.MAV_TYPE.COAXIAL)
-            {
-                return (new GMapMarkerSingle(portlocation, MAV.cs.yaw,
-                   MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.sysid){ Tag = MAV});
             }
             else
             {

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -6297,7 +6297,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                         case MAV_TYPE.ANTENNA_TRACKER:
                             MAVlist[sysid, compid].cs.firmware = Firmwares.ArduTracker;
                             break;
-
+                        case MAV_TYPE.COAXIAL:
+                            MAVlist[sysid, compid].cs.firmware = Firmwares.ArduCopter2;
+                            break;
                         default:
                             MAVlist[sysid, compid].cs.firmware = Firmwares.Other;
                             log.Error(MAVlist[sysid, compid].aptype + " not registered as valid type");


### PR DESCRIPTION
MAV_TYPE.COAXIAL was not handled in MavlinkInterface.cs, therefore not mode names were displayed.
GMapMarker type selection order also needed to change to keep the coax copter icon.