### PR TITLE
setPositionTargetGlobalInt: fix TYPE_MASK_FORCE handling

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4220,6 +4220,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             };
 
             target.type_mask = ushort.MaxValue;
+            target.type_mask -= MAVLINK_SET_POS_TYPE_MASK_FORCE;
 
             if (pos && lat != 0 && lng != 0)
                 target.type_mask -= MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;


### PR DESCRIPTION
This fixes the handling of setPositionTargetGlobalInt messages due to a recent change in ArduPilot master  [here ](https://github.com/ArduPilot/ardupilot/pull/18720) to reject commands with FORCE set.

Tested by building MissionPlanner and moving around in SITL.

See Discuss post [here](https://discuss.ardupilot.org/t/sitl-no-longer-responds-to-setguidedmodewp-command/77224?u=hendjosh)

@rmackay9 Thoughts on changing this behavior in ArduPilot master to only reject commands where FORCE set is true and we are not ignoring acceleration commands?

With the behavior as we have it we could get more support requests for where people are setting the bit even though they weren't using it. Unfortunately, for the field the MAVLINK spec was a bit wonky. 