### PR TITLE
Grid: Use PlannedHomeLocation altitude

### DIFF
--- a/Grid/GridUI.cs
+++ b/Grid/GridUI.cs
@@ -652,7 +652,7 @@ namespace MissionPlanner.Grid
             List<PointLatLng> segment = new List<PointLatLng>();
             double maxgroundelevation = double.MinValue;
             double mingroundelevation = double.MaxValue;
-            double startalt = plugin.Host.cs.HomeAlt;
+            double startalt = plugin.Host.cs.PlannedHomeLocation.Alt;
 
             foreach (var item in grid)
             {


### PR DESCRIPTION
Camera footprints are not displayed if we don't have valid home altitude. This patch change startalt to PlannedHomeLocation.Alt.
Now footprints are shown again :)