### PR TITLE
Fix application local data path in *nix based OS

### DIFF
--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -289,6 +289,8 @@ namespace MissionPlanner.Utilities
             return (t != null);
         }
 
+        public static bool isUnix = Environment.OSVersion.Platform == PlatformID.Unix;
+
         /// <summary>
         /// Shared data directory
         /// </summary>
@@ -318,9 +320,19 @@ namespace MissionPlanner.Utilities
                 return CustomUserDataDirectory + Path.DirectorySeparatorChar + AppConfigName +
                        Path.DirectorySeparatorChar;
 
-            var path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + Path.DirectorySeparatorChar + AppConfigName +
-                          Path.DirectorySeparatorChar;
+            var oldApproachPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) +
+                Path.DirectorySeparatorChar + AppConfigName + Path.DirectorySeparatorChar;
+            var path = "";
+            if (isUnix && !Directory.Exists(oldApproachPath)) // Do not use new AppData path if old path already exists
+            {                                                 // E.g. do not migrate to new aproach if directory exists
+                path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            }
+            else
+            {
+                path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            }
 
+            path += Path.DirectorySeparatorChar + AppConfigName + Path.DirectorySeparatorChar;
             return path;
         }
 


### PR DESCRIPTION
In Linux/Unix like operating systems 'MyDocuments' dir does not exists.
However, the mono framework for compatibility purposes points it to the root of the user directory instead(/home/username). That is incorrect from the point of view of the Linux/Unit standards (see [1] for more detail). The Local Application
Data directory should be used instead(/home/username/.local/share). Fix that for operating systems where platform ID is Unix.

 * [1] https://www.freedesktop.org/wiki/Specifications/basedir-spec/

Please be aware for existing users it might be required to execute a command
```bash
mv "~/Mission Planner" ~/.local/share/
```