### PR TITLE
update the map immediately once click 'Grid' check-box in FlightPlanner pannel

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2011,6 +2011,7 @@ namespace MissionPlanner.GCSViews
         public void chk_grid_CheckedChanged(object sender, EventArgs e)
         {
             grid = chk_grid.Checked;
+            this.MainMap.Refresh();
         }
 
         public void CHK_splinedefault_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
## update the map immediately once click 'Grid' check-box in FlightPlanner pannel

User needs to drag and move the map to see its change about grid after the 'Grid' check-box is clicked except for the first click, which may bother users with mild obsessive-compulsive disorder like me.