### PR TITLE
remove first (home) cmd when loading saved fence or rally from file.

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -973,7 +973,11 @@ namespace MissionPlanner.GCSViews
             try
             {
                 var cmds = WaypointFile.ReadWaypointFile(file);
-
+                if ((MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.FENCE ||
+                    (MAVLink.MAV_MISSION_TYPE)cmb_missiontype.SelectedValue == MAVLink.MAV_MISSION_TYPE.RALLY)
+                {
+                    cmds.RemoveAt(0);
+                }
                 processToScreen(cmds, append);
 
                 writeKML();


### PR DESCRIPTION
Prevent creating an UNKNOWN first entry when a rally or a fence waypoints file is loaded.
discussed at https://discuss.ardupilot.org/t/geofence-file-cannot-be-saved/78871/13
