### PR TITLE
Fix for ISSUE #2714, Radio Calibration Screen reverse CB does not honor  RCMAP setting.

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRadioInput.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigRadioInput.Designer.cs
@@ -57,10 +57,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.BAR12 = new MissionPlanner.Controls.HorizontalProgressBar2();
             this.BAR11 = new MissionPlanner.Controls.HorizontalProgressBar2();
             this.BAR10 = new MissionPlanner.Controls.HorizontalProgressBar2();
-            this.CHK_revch3 = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CHK_revch4 = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CHK_revch2 = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CHK_revch1 = new MissionPlanner.Controls.MavlinkCheckBox();
+            this.CHK_revthr = new MissionPlanner.Controls.MavlinkCheckBox();
+            this.CHK_revyaw = new MissionPlanner.Controls.MavlinkCheckBox();
+            this.CHK_revpitch = new MissionPlanner.Controls.MavlinkCheckBox();
+            this.CHK_revroll = new MissionPlanner.Controls.MavlinkCheckBox();
             this.currentStateBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.groupBoxElevons.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -401,43 +401,43 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // CHK_revch3
             // 
-            resources.ApplyResources(this.CHK_revch3, "CHK_revch3");
-            this.CHK_revch3.Name = "CHK_revch3";
-            this.CHK_revch3.OffValue = 0D;
-            this.CHK_revch3.OnValue = 1D;
-            this.CHK_revch3.ParamName = null;
-            this.CHK_revch3.UseVisualStyleBackColor = true;
-            this.CHK_revch3.CheckedChanged += new System.EventHandler(this.CHK_revch3_CheckedChanged);
+            resources.ApplyResources(this.CHK_revthr, "CHK_revch3");
+            this.CHK_revthr.Name = "CHK_revch3";
+            this.CHK_revthr.OffValue = 0D;
+            this.CHK_revthr.OnValue = 1D;
+            this.CHK_revthr.ParamName = null;
+            this.CHK_revthr.UseVisualStyleBackColor = true;
+            this.CHK_revthr.CheckedChanged += new System.EventHandler(this.CHK_revch3_CheckedChanged);
             // 
             // CHK_revch4
             // 
-            resources.ApplyResources(this.CHK_revch4, "CHK_revch4");
-            this.CHK_revch4.Name = "CHK_revch4";
-            this.CHK_revch4.OffValue = 0D;
-            this.CHK_revch4.OnValue = 1D;
-            this.CHK_revch4.ParamName = null;
-            this.CHK_revch4.UseVisualStyleBackColor = true;
-            this.CHK_revch4.CheckedChanged += new System.EventHandler(this.CHK_revch4_CheckedChanged);
+            resources.ApplyResources(this.CHK_revyaw, "CHK_revch4");
+            this.CHK_revyaw.Name = "CHK_revch4";
+            this.CHK_revyaw.OffValue = 0D;
+            this.CHK_revyaw.OnValue = 1D;
+            this.CHK_revyaw.ParamName = null;
+            this.CHK_revyaw.UseVisualStyleBackColor = true;
+            this.CHK_revyaw.CheckedChanged += new System.EventHandler(this.CHK_revch4_CheckedChanged);
             // 
             // CHK_revch2
             // 
-            resources.ApplyResources(this.CHK_revch2, "CHK_revch2");
-            this.CHK_revch2.Name = "CHK_revch2";
-            this.CHK_revch2.OffValue = 0D;
-            this.CHK_revch2.OnValue = 1D;
-            this.CHK_revch2.ParamName = null;
-            this.CHK_revch2.UseVisualStyleBackColor = true;
-            this.CHK_revch2.CheckedChanged += new System.EventHandler(this.CHK_revch2_CheckedChanged);
+            resources.ApplyResources(this.CHK_revpitch, "CHK_revch2");
+            this.CHK_revpitch.Name = "CHK_revch2";
+            this.CHK_revpitch.OffValue = 0D;
+            this.CHK_revpitch.OnValue = 1D;
+            this.CHK_revpitch.ParamName = null;
+            this.CHK_revpitch.UseVisualStyleBackColor = true;
+            this.CHK_revpitch.CheckedChanged += new System.EventHandler(this.CHK_revch2_CheckedChanged);
             // 
             // CHK_revch1
             // 
-            resources.ApplyResources(this.CHK_revch1, "CHK_revch1");
-            this.CHK_revch1.Name = "CHK_revch1";
-            this.CHK_revch1.OffValue = 0D;
-            this.CHK_revch1.OnValue = 1D;
-            this.CHK_revch1.ParamName = null;
-            this.CHK_revch1.UseVisualStyleBackColor = true;
-            this.CHK_revch1.CheckedChanged += new System.EventHandler(this.CHK_revch1_CheckedChanged);
+            resources.ApplyResources(this.CHK_revroll, "CHK_revch1");
+            this.CHK_revroll.Name = "CHK_revch1";
+            this.CHK_revroll.OffValue = 0D;
+            this.CHK_revroll.OnValue = 1D;
+            this.CHK_revroll.ParamName = null;
+            this.CHK_revroll.UseVisualStyleBackColor = true;
+            this.CHK_revroll.CheckedChanged += new System.EventHandler(this.CHK_revch1_CheckedChanged);
             // 
             // currentStateBindingSource
             // 
@@ -456,10 +456,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Controls.Add(this.BAR9);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.groupBoxElevons);
-            this.Controls.Add(this.CHK_revch3);
-            this.Controls.Add(this.CHK_revch4);
-            this.Controls.Add(this.CHK_revch2);
-            this.Controls.Add(this.CHK_revch1);
+            this.Controls.Add(this.CHK_revthr);
+            this.Controls.Add(this.CHK_revyaw);
+            this.Controls.Add(this.CHK_revpitch);
+            this.Controls.Add(this.CHK_revroll);
             this.Controls.Add(this.BUT_Calibrateradio);
             this.Controls.Add(this.BAR8);
             this.Controls.Add(this.BAR7);
@@ -487,10 +487,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private MavlinkCheckBox CHK_elevonch2rev;
         private MavlinkCheckBox CHK_elevonrev;
         private MavlinkCheckBox CHK_elevonch1rev;
-        private MavlinkCheckBox CHK_revch3;
-        private MavlinkCheckBox CHK_revch4;
-        private MavlinkCheckBox CHK_revch2;
-        private MavlinkCheckBox CHK_revch1;
+        private MavlinkCheckBox CHK_revthr;
+        private MavlinkCheckBox CHK_revyaw;
+        private MavlinkCheckBox CHK_revpitch;
+        private MavlinkCheckBox CHK_revroll;
         private Controls.MyButton BUT_Calibrateradio;
         private HorizontalProgressBar2 BAR8;
         private HorizontalProgressBar2 BAR7;

--- a/GCSViews/ConfigurationView/ConfigRadioInput.cs
+++ b/GCSViews/ConfigurationView/ConfigRadioInput.cs
@@ -106,6 +106,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             BAR15.DataBindings.Add(new Binding("Value", currentStateBindingSource, "ch15in", true));
             BAR16.DataBindings.Add(new Binding("Value", currentStateBindingSource, "ch16in", true));
 
+            //Add channel to pitch/roll/throttle/yaw bars labels
+            BARroll.Label = BARroll.Label + " (ch" + chroll.ToString() + ")";
+            BARpitch.Label = BARpitch.Label + " (ch" + chpitch.ToString() + ")";
+            BARthrottle.Label = BARthrottle.Label + " (ch" + chthro.ToString() + ")";
+            BARyaw.Label = BARyaw.Label + " (ch" + chyaw.ToString() + ")";
+
             try
             {
                 // force this screen to work
@@ -131,16 +137,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
 
             // this controls the direction of the output, not the input.
-            CHK_revch1.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC1_REV", "RC1_REVERSED" },
+            CHK_revroll.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC" + chroll + "_REV", "RC" + chroll + "_REVERSED" },
                 MainV2.comPort.MAV.param);
-            CHK_revch2.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC2_REV", "RC2_REVERSED" },
+            CHK_revpitch.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC" + chpitch + "_REV", "RC" + chpitch + "_REVERSED" },
                 MainV2.comPort.MAV.param);
-            CHK_revch3.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC3_REV", "RC3_REVERSED" },
+            CHK_revthr.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC" + chthro + "_REV", "RC" + chthro + "_REVERSED" },
                 MainV2.comPort.MAV.param);
-            CHK_revch4.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC4_REV", "RC4_REVERSED" },
+            CHK_revyaw.setup(new double[] { -1, 1 }, new double[] { 1, 0 }, new string[] { "RC" + chyaw + "_REV", "RC" + chyaw + "_REVERSED" },
                 MainV2.comPort.MAV.param);
 
-            if(MainV2.comPort.MAV.param["RC"+ chroll + "_REVERSED"]?.Value == 1)
+            if (MainV2.comPort.MAV.param["RC"+ chroll + "_REVERSED"]?.Value == 1)
             {
                 reverseChannel(true, BARroll);
             }
@@ -161,10 +167,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // run after to ensure they are disabled on copter
             if (MainV2.comPort.MAV.cs.firmware == Firmwares.ArduCopter2)
             {
-                CHK_revch1.Visible = false;
-                CHK_revch2.Visible = false;
-                CHK_revch3.Visible = false;
-                CHK_revch4.Visible = false;
+                CHK_revroll.Visible = false;
+                CHK_revpitch.Visible = false;
+                CHK_revthr.Visible = false;
+                CHK_revyaw.Visible = false;
             }
 
             startup = false;


### PR DESCRIPTION
Fix for ISSUE #2714.
On Radio Calibration Screen, the reverse checkboxes now honor RCMAP setting.
Also channel number is displayed in roll/pitch/yaw/thr bars.
![image](https://user-images.githubusercontent.com/11500559/145695971-52cd6b48-26a1-4093-ac51-b40aea46089b.png)
