### PR TITLE
Fix for ISSUE #2749, OSD Color not changeable

### DIFF
--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -373,14 +373,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             if (startup)
                 return;
-/*
+
             if (CMB_osdcolor.Text != "")
             {
                 Settings.Instance["hudcolor"] = CMB_osdcolor.Text;
                 FlightData.myhud.hudcolor =
                     Color.FromKnownColor((KnownColor)Enum.Parse(typeof(KnownColor), CMB_osdcolor.Text));
             }
-            */
+
         }
 
         private void CHK_speechwaypoint_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Fix for ISSUE #2749.
Under Configuration View, The OSD Color parameter changes are now reflected on the OSD. 

![after](https://user-images.githubusercontent.com/33371507/147822517-6f094812-157b-4f03-8eda-0c7f80a48479.PNG)
![after2](https://user-images.githubusercontent.com/33371507/147822504-b23ae52d-d135-4745-bdc4-e119da1737b0.PNG)

