### PR TITLE
CTRL-F screen, add editor to add/delete mavlink commands to Planner grid dropdown

### DIFF
--- a/Controls/MavCommandSelection.Designer.cs
+++ b/Controls/MavCommandSelection.Designer.cs
@@ -1,0 +1,196 @@
+﻿
+namespace MissionPlanner.Controls
+{
+    partial class MavCommandSelection
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MavCommandSelection));
+            this.btn_AddLine = new MissionPlanner.Controls.MyButton();
+            this.btn_Save = new MissionPlanner.Controls.MyButton();
+            this.label1 = new System.Windows.Forms.Label();
+            this.myDataGridView1 = new MissionPlanner.Controls.MyDataGridView();
+            this.msgid = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.msgname = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.param7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ((System.ComponentModel.ISupportInitialize)(this.myDataGridView1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // btn_AddLine
+            // 
+            this.btn_AddLine.Cursor = System.Windows.Forms.Cursors.Default;
+            this.btn_AddLine.Location = new System.Drawing.Point(12, 438);
+            this.btn_AddLine.Name = "btn_AddLine";
+            this.btn_AddLine.Size = new System.Drawing.Size(75, 23);
+            this.btn_AddLine.TabIndex = 1;
+            this.btn_AddLine.Text = "ADD";
+            this.btn_AddLine.UseVisualStyleBackColor = true;
+            this.btn_AddLine.Click += new System.EventHandler(this.btn_AddLine_Click);
+            // 
+            // btn_Save
+            // 
+            this.btn_Save.Location = new System.Drawing.Point(133, 438);
+            this.btn_Save.Name = "btn_Save";
+            this.btn_Save.Size = new System.Drawing.Size(75, 23);
+            this.btn_Save.TabIndex = 2;
+            this.btn_Save.Text = "Save && Exit";
+            this.btn_Save.UseVisualStyleBackColor = true;
+            this.btn_Save.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(432, 419);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(461, 65);
+            this.label1.TabIndex = 3;
+            this.label1.Text = resources.GetString("label1.Text");
+            // 
+            // myDataGridView1
+            // 
+            this.myDataGridView1.AllowUserToAddRows = false;
+            this.myDataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.myDataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.msgid,
+            this.msgname,
+            this.param1,
+            this.param2,
+            this.param3,
+            this.param4,
+            this.param5,
+            this.param6,
+            this.param7});
+            this.myDataGridView1.Location = new System.Drawing.Point(12, 12);
+            this.myDataGridView1.Name = "myDataGridView1";
+            this.myDataGridView1.Size = new System.Drawing.Size(925, 393);
+            this.myDataGridView1.TabIndex = 0;
+            // 
+            // msgid
+            // 
+            this.msgid.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.msgid.HeaderText = "MSG ID";
+            this.msgid.Name = "msgid";
+            this.msgid.ReadOnly = true;
+            this.msgid.Width = 70;
+            // 
+            // msgname
+            // 
+            this.msgname.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.msgname.HeaderText = "NAME";
+            this.msgname.Name = "msgname";
+            this.msgname.ReadOnly = true;
+            this.msgname.Width = 63;
+            // 
+            // param1
+            // 
+            this.param1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param1.HeaderText = "Param1 Name";
+            this.param1.Name = "param1";
+            this.param1.Width = 99;
+            // 
+            // param2
+            // 
+            this.param2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param2.HeaderText = "Param2 Name";
+            this.param2.Name = "param2";
+            this.param2.Width = 99;
+            // 
+            // param3
+            // 
+            this.param3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param3.HeaderText = "Param3 Name";
+            this.param3.Name = "param3";
+            this.param3.Width = 99;
+            // 
+            // param4
+            // 
+            this.param4.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param4.HeaderText = "Param4 Name";
+            this.param4.Name = "param4";
+            this.param4.Width = 99;
+            // 
+            // param5
+            // 
+            this.param5.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param5.HeaderText = "Param5 Name";
+            this.param5.Name = "param5";
+            this.param5.Width = 99;
+            // 
+            // param6
+            // 
+            this.param6.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param6.HeaderText = "Param6 Name";
+            this.param6.Name = "param6";
+            this.param6.Width = 99;
+            // 
+            // param7
+            // 
+            this.param7.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.param7.HeaderText = "Param7 Name";
+            this.param7.Name = "param7";
+            this.param7.Width = 99;
+            // 
+            // MavCommandSelection
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(950, 493);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.btn_Save);
+            this.Controls.Add(this.btn_AddLine);
+            this.Controls.Add(this.myDataGridView1);
+            this.Name = "MavCommandSelection";
+            this.Text = "MavCommandSelection";
+            ((System.ComponentModel.ISupportInitialize)(this.myDataGridView1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private MyDataGridView myDataGridView1;
+        private System.Windows.Forms.DataGridViewTextBoxColumn msgid;
+        private System.Windows.Forms.DataGridViewTextBoxColumn msgname;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param1;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param2;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param3;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param4;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param5;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param6;
+        private System.Windows.Forms.DataGridViewTextBoxColumn param7;
+        private MyButton btn_AddLine;
+        private MyButton btn_Save;
+        private System.Windows.Forms.Label label1;
+    }
+}

--- a/Controls/MavCommandSelection.cs
+++ b/Controls/MavCommandSelection.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using MissionPlanner.Controls;
+using MissionPlanner.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using MissionPlanner.GCSViews;
+
+namespace MissionPlanner.Controls
+{
+    public partial class MavCommandSelection : Form
+    {
+        public MavCommandSelection()
+        {
+            InitializeComponent();
+            loadFromSettings();
+        }
+
+        //All commands that added (not including ID)
+        public Dictionary<string, string[]> commands = new Dictionary<string, string[]>();
+        //ID of addedd commands that are not in MAV_CMD enum
+        public Dictionary<string, ushort> extraCommands = new Dictionary<string, ushort>();
+
+
+        private void loadFromSettings()
+        {
+
+            commands.Clear();
+            extraCommands.Clear();
+
+            try
+            {
+                commands = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(Settings.Instance["PlannerExtraCommand"]);
+                extraCommands = JsonConvert.DeserializeObject<Dictionary<string, ushort>>(Settings.Instance["PlannerExtraCommandIDs"]);
+            }
+            catch { }
+
+            foreach (var cmd in commands)
+            {
+                //Is it a cmd already in the Mavlink Library ?
+                if (Enum.IsDefined(typeof(MAVLink.MAV_CMD), cmd.Key))
+                {
+                    //Yes no need to look up extraCommands
+                    var selectedrow = myDataGridView1.Rows.Add();
+                    myDataGridView1.Rows[selectedrow].Cells[msgid.Index].Value = ((ushort)Enum.Parse(typeof(MAVLink.MAV_CMD),cmd.Key)).ToString();
+                    myDataGridView1.Rows[selectedrow].Cells[msgname.Index].Value = cmd.Key;
+                    myDataGridView1.Rows[selectedrow].Cells[param1.Index].Value = cmd.Value[0];
+                    myDataGridView1.Rows[selectedrow].Cells[param2.Index].Value = cmd.Value[1];
+                    myDataGridView1.Rows[selectedrow].Cells[param3.Index].Value = cmd.Value[2];
+                    myDataGridView1.Rows[selectedrow].Cells[param4.Index].Value = cmd.Value[3];
+                    myDataGridView1.Rows[selectedrow].Cells[param5.Index].Value = cmd.Value[4];
+                    myDataGridView1.Rows[selectedrow].Cells[param6.Index].Value = cmd.Value[5];
+                    myDataGridView1.Rows[selectedrow].Cells[param7.Index].Value = cmd.Value[6];
+                }
+                else
+                {
+                    var selectedrow = myDataGridView1.Rows.Add();
+                    myDataGridView1.Rows[selectedrow].Cells[msgid.Index].Value = extraCommands[cmd.Key];
+                    myDataGridView1.Rows[selectedrow].Cells[msgname.Index].Value = cmd.Key;
+                    myDataGridView1.Rows[selectedrow].Cells[param1.Index].Value = cmd.Value[0];
+                    myDataGridView1.Rows[selectedrow].Cells[param2.Index].Value = cmd.Value[1];
+                    myDataGridView1.Rows[selectedrow].Cells[param3.Index].Value = cmd.Value[2];
+                    myDataGridView1.Rows[selectedrow].Cells[param4.Index].Value = cmd.Value[3];
+                    myDataGridView1.Rows[selectedrow].Cells[param5.Index].Value = cmd.Value[4];
+                    myDataGridView1.Rows[selectedrow].Cells[param6.Index].Value = cmd.Value[5];
+                    myDataGridView1.Rows[selectedrow].Cells[param7.Index].Value = cmd.Value[6];
+                }
+            }
+
+
+        }
+
+
+        //Check if the given id or name is already in the table
+        private bool checkIDandName(ushort cmdId, string cmdName)
+        {
+
+            bool retval = false;
+
+            for (int i = 0; i < myDataGridView1.RowCount; i++)
+            {
+                string cmdNameRow = myDataGridView1.Rows[i].Cells[msgname.Index].Value.ToString();
+                if (cmdNameRow == cmdName)
+                {
+                    retval = true;
+                    break;
+                }
+                ushort cmdIdRow = ushort.Parse(myDataGridView1.Rows[i].Cells[msgid.Index].Value.ToString());
+                if (cmdIdRow == cmdId)
+                {
+                    retval = true;
+                    break;
+                }
+            }
+            return retval;
+        }
+
+        private void btn_AddLine_Click(object sender, EventArgs e)
+        {
+            var cmdid = "-1";
+            InputBox.Show("Enter command ID","ID number of the command", ref cmdid);
+
+            try
+            {
+
+                if (cmdid != "-1")
+                {
+                    ushort i = ushort.Parse(cmdid);
+                    string a = ((MAVLink.MAV_CMD)i).ToString();
+
+                    if (checkIDandName(i, a))
+                    {
+                        CustomMessageBox.Show("Name or ID exists");
+                        return;
+                    }
+
+                    if (a == i.ToString())
+                    {
+                        string cmdName = "NEW_COMMAND";
+                        InputBox.Show("What is the name", "Name", ref cmdName);
+                        if (cmdName.Length > 0)
+                        {
+                            if (checkIDandName(i, cmdName))
+                            {
+                                MessageBox.Show("Name or ID exists");
+                                return;
+                            }
+                            var selectedrow = myDataGridView1.Rows.Add();
+                            myDataGridView1.Rows[selectedrow].Cells[msgid.Index].Value = i.ToString();
+                            myDataGridView1.Rows[selectedrow].Cells[msgname.Index].Value = cmdName;
+                            myDataGridView1.Rows[selectedrow].Cells[param5.Index].Value = "Lat";
+                            myDataGridView1.Rows[selectedrow].Cells[param6.Index].Value = "Long";
+                            myDataGridView1.Rows[selectedrow].Cells[param7.Index].Value = "Alt";
+                        }
+                    }
+                    else
+                    {
+                        var selectedrow = myDataGridView1.Rows.Add();
+                        myDataGridView1.Rows[selectedrow].Cells[msgid.Index].Value = i.ToString();
+                        myDataGridView1.Rows[selectedrow].Cells[msgname.Index].Value = a;
+                        myDataGridView1.Rows[selectedrow].Cells[param5.Index].Value = "Lat";
+                        myDataGridView1.Rows[selectedrow].Cells[param6.Index].Value = "Long";
+                        myDataGridView1.Rows[selectedrow].Cells[param7.Index].Value = "Alt";
+
+                    }
+
+                }
+            }
+            catch { }
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            //Go through the rows and fill up data table
+            commands.Clear();
+            extraCommands.Clear();
+            for (int i = 0; i < myDataGridView1.RowCount; i++)
+            {
+                try
+                {
+
+                    string cmdName = myDataGridView1.Rows[i].Cells[msgname.Index].Value.ToString();
+                    ushort cmdId = ushort.Parse(myDataGridView1.Rows[i].Cells[msgid.Index].Value.ToString());
+
+                    string[] p = new string[7];
+
+                    p[0] = myDataGridView1.Rows[i].Cells[param1.Index].Value?.ToString();
+                    p[1] = myDataGridView1.Rows[i].Cells[param2.Index].Value?.ToString();
+                    p[2] = myDataGridView1.Rows[i].Cells[param3.Index].Value?.ToString();
+                    p[3] = myDataGridView1.Rows[i].Cells[param4.Index].Value?.ToString();
+                    p[4] = myDataGridView1.Rows[i].Cells[param5.Index].Value?.ToString();
+                    p[5] = myDataGridView1.Rows[i].Cells[param6.Index].Value?.ToString();
+                    p[6] = myDataGridView1.Rows[i].Cells[param7.Index].Value?.ToString();
+
+
+                    commands.Add(cmdName, p);
+                    if (!Enum.IsDefined(typeof(MAVLink.MAV_CMD), cmdId))
+                    {
+                        extraCommands.Add(cmdName, cmdId);
+                    }
+                }
+                catch { }
+            }
+
+            Settings.Instance["PlannerExtraCommand"] = JsonConvert.SerializeObject(commands);
+            Settings.Instance["PlannerExtraCommandIDs"] =  JsonConvert.SerializeObject(extraCommands);
+
+            //This needed in case the user already have a mission in the planner tab with added items.
+            MainV2.instance.FlightPlanner.updateCMDParams();
+
+            this.Close();
+
+        }
+
+    }
+}

--- a/Controls/MavCommandSelection.resx
+++ b/Controls/MavCommandSelection.resx
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="label1.Text" xml:space="preserve">
+    <value>You can add MAVLink commands to the command selection of Planner View's Mission Grid. 
+To add a command, you have to know the ID. The name will automatically be filled out if the
+ID is already defined in the MAVLink libraries. You can also add an ID that is not yet defined.
+In this case, you have to give the name as well. Adding a command here does not mean that the
+autopilot will accept or execute it. So you have to know what you are doing.</value>
+  </data>
+  <metadata name="msgid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="msgname.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param1.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param2.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param3.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param4.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param5.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param6.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="param7.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -441,6 +441,12 @@
     <Compile Include="Controls\DigitalSkyUI.Designer.cs">
       <DependentUpon>DigitalSkyUI.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\MavCommandSelection.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Controls\MavCommandSelection.Designer.cs">
+      <DependentUpon>MavCommandSelection.cs</DependentUpon>
+    </Compile>
     <Compile Include="Controls\SerialOutputCoT.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -819,6 +825,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\EKFStatus.ko-KR.resx">
       <DependentUpon>EKFStatus.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Controls\MavCommandSelection.resx">
+      <DependentUpon>MavCommandSelection.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\PropagationSettings.ko-KR.resx">
       <DependentUpon>PropagationSettings.cs</DependentUpon>

--- a/temp.Designer.cs
+++ b/temp.Designer.cs
@@ -143,6 +143,8 @@
             this.but_remotedflogger = new MissionPlanner.Controls.MyButton();
             this.label12 = new System.Windows.Forms.Label();
             this.controlSensorsStatus1 = new MissionPlanner.Controls.ControlSensorsStatus();
+            this.but_ManageCMDList = new MissionPlanner.Controls.MyButton();
+            this.label28 = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -262,6 +264,8 @@
             this.tableLayoutPanel1.Controls.Add(this.label55, 3, 28);
             this.tableLayoutPanel1.Controls.Add(this.but_remotedflogger, 0, 15);
             this.tableLayoutPanel1.Controls.Add(this.label12, 1, 29);
+            this.tableLayoutPanel1.Controls.Add(this.but_ManageCMDList, 2, 29);
+            this.tableLayoutPanel1.Controls.Add(this.label28, 3, 29);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // BUT_CoT
@@ -943,6 +947,18 @@
             resources.ApplyResources(this.controlSensorsStatus1, "controlSensorsStatus1");
             this.controlSensorsStatus1.Name = "controlSensorsStatus1";
             // 
+            // but_ManageCMDList
+            // 
+            resources.ApplyResources(this.but_ManageCMDList, "but_ManageCMDList");
+            this.but_ManageCMDList.Name = "but_ManageCMDList";
+            this.but_ManageCMDList.UseVisualStyleBackColor = true;
+            this.but_ManageCMDList.Click += new System.EventHandler(this.but_ManageCMDList_Click);
+            // 
+            // label28
+            // 
+            resources.ApplyResources(this.label28, "label28");
+            this.label28.Name = "label28";
+            // 
             // temp
             // 
             resources.ApplyResources(this, "$this");
@@ -1075,5 +1091,7 @@
         private Controls.MyButton but_remotedflogger;
         private Controls.MyButton BUT_CoT;
         private System.Windows.Forms.Label label12;
+        private Controls.MyButton but_ManageCMDList;
+        private System.Windows.Forms.Label label28;
     }
 }

--- a/temp.cs
+++ b/temp.cs
@@ -1398,5 +1398,11 @@ namespace MissionPlanner
         {
             new SerialOutputCoT().Show();
         }
+
+        private void but_ManageCMDList_Click(object sender, EventArgs e)
+        {
+            var CMDList = new MavCommandSelection();
+            CMDList.Show();
+        }
     }
 }

--- a/temp.resx
+++ b/temp.resx
@@ -130,10 +130,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="BUT_CoT.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 525</value>
+    <value>3, 554</value>
   </data>
   <data name="BUT_CoT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 15</value>
+    <value>125, 18</value>
   </data>
   <data name="BUT_CoT.TabIndex" type="System.Int32, mscorlib">
     <value>136</value>
@@ -160,10 +160,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_proximity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 489</value>
+    <value>403, 516</value>
   </data>
   <data name="but_proximity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_proximity.TabIndex" type="System.Int32, mscorlib">
     <value>91</value>
@@ -190,10 +190,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_followswarm.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 507</value>
+    <value>403, 535</value>
   </data>
   <data name="but_followswarm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_followswarm.TabIndex" type="System.Int32, mscorlib">
     <value>83</value>
@@ -220,7 +220,7 @@
     <value>NoControl</value>
   </data>
   <data name="label16.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 450</value>
+    <value>557, 475</value>
   </data>
   <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 13</value>
@@ -250,10 +250,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_lockup.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 183</value>
+    <value>403, 193</value>
   </data>
   <data name="but_lockup.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_lockup.TabIndex" type="System.Int32, mscorlib">
     <value>104</value>
@@ -280,10 +280,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_td.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 327</value>
+    <value>403, 345</value>
   </data>
   <data name="but_td.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_td.TabIndex" type="System.Int32, mscorlib">
     <value>88</value>
@@ -310,10 +310,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_gpsinj.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 471</value>
+    <value>403, 497</value>
   </data>
   <data name="but_gpsinj.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_gpsinj.TabIndex" type="System.Int32, mscorlib">
     <value>81</value>
@@ -340,10 +340,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_dem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 201</value>
+    <value>403, 212</value>
   </data>
   <data name="but_dem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_dem.TabIndex" type="System.Int32, mscorlib">
     <value>89</value>
@@ -370,10 +370,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_magfit2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 507</value>
+    <value>3, 535</value>
   </data>
   <data name="BUT_magfit2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_magfit2.TabIndex" type="System.Int32, mscorlib">
     <value>79</value>
@@ -400,10 +400,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_GDAL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 255</value>
+    <value>403, 269</value>
   </data>
   <data name="but_GDAL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_GDAL.TabIndex" type="System.Int32, mscorlib">
     <value>85</value>
@@ -430,10 +430,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_sortlogs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 237</value>
+    <value>403, 250</value>
   </data>
   <data name="but_sortlogs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_sortlogs.TabIndex" type="System.Int32, mscorlib">
     <value>86</value>
@@ -460,10 +460,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_optflowcalib.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 471</value>
+    <value>3, 497</value>
   </data>
   <data name="but_optflowcalib.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_optflowcalib.TabIndex" type="System.Int32, mscorlib">
     <value>77</value>
@@ -490,10 +490,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_logdlscp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 219</value>
+    <value>403, 231</value>
   </data>
   <data name="but_logdlscp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_logdlscp.TabIndex" type="System.Int32, mscorlib">
     <value>87</value>
@@ -520,10 +520,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_signkey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 453</value>
+    <value>403, 478</value>
   </data>
   <data name="but_signkey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_signkey.TabIndex" type="System.Int32, mscorlib">
     <value>76</value>
@@ -550,10 +550,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_acbarohight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 165</value>
+    <value>403, 174</value>
   </data>
   <data name="but_acbarohight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_acbarohight.TabIndex" type="System.Int32, mscorlib">
     <value>101</value>
@@ -580,10 +580,10 @@
     <value>NoControl</value>
   </data>
   <data name="myButton1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 435</value>
+    <value>403, 459</value>
   </data>
   <data name="myButton1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="myButton1.TabIndex" type="System.Int32, mscorlib">
     <value>73</value>
@@ -610,10 +610,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_driverclean.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 21</value>
+    <value>403, 22</value>
   </data>
   <data name="but_driverclean.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_driverclean.TabIndex" type="System.Int32, mscorlib">
     <value>103</value>
@@ -640,10 +640,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_agemapdata.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 417</value>
+    <value>403, 440</value>
   </data>
   <data name="but_agemapdata.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_agemapdata.TabIndex" type="System.Int32, mscorlib">
     <value>75</value>
@@ -670,10 +670,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_packetbytes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 147</value>
+    <value>403, 155</value>
   </data>
   <data name="but_packetbytes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_packetbytes.TabIndex" type="System.Int32, mscorlib">
     <value>100</value>
@@ -700,10 +700,10 @@
     <value>NoControl</value>
   </data>
   <data name="myButton_vlc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 399</value>
+    <value>403, 421</value>
   </data>
   <data name="myButton_vlc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="myButton_vlc.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -730,7 +730,7 @@
     <value>NoControl</value>
   </data>
   <data name="label22.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 378</value>
+    <value>134, 399</value>
   </data>
   <data name="label22.Size" type="System.Drawing.Size, System.Drawing">
     <value>153, 13</value>
@@ -760,10 +760,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_trimble.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 381</value>
+    <value>403, 402</value>
   </data>
   <data name="but_trimble.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_trimble.TabIndex" type="System.Int32, mscorlib">
     <value>64</value>
@@ -790,10 +790,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_hwids.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 129</value>
+    <value>403, 136</value>
   </data>
   <data name="but_hwids.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_hwids.TabIndex" type="System.Int32, mscorlib">
     <value>99</value>
@@ -820,10 +820,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_QNH.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 363</value>
+    <value>403, 383</value>
   </data>
   <data name="BUT_QNH.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="BUT_QNH.TabIndex" type="System.Int32, mscorlib">
     <value>63</value>
@@ -850,10 +850,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_reboot.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 345</value>
+    <value>403, 364</value>
   </data>
   <data name="but_reboot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_reboot.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -880,10 +880,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_3dmap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 111</value>
+    <value>403, 117</value>
   </data>
   <data name="but_3dmap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_3dmap.TabIndex" type="System.Int32, mscorlib">
     <value>94</value>
@@ -910,10 +910,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_messageinterval.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 57</value>
+    <value>403, 60</value>
   </data>
   <data name="but_messageinterval.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_messageinterval.TabIndex" type="System.Int32, mscorlib">
     <value>97</value>
@@ -940,10 +940,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_blupdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 93</value>
+    <value>403, 98</value>
   </data>
   <data name="but_blupdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_blupdate.TabIndex" type="System.Int32, mscorlib">
     <value>93</value>
@@ -970,10 +970,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_fft.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 309</value>
+    <value>403, 326</value>
   </data>
   <data name="BUT_fft.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="BUT_fft.TabIndex" type="System.Int32, mscorlib">
     <value>60</value>
@@ -1000,10 +1000,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_disablearmswitch.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 39</value>
+    <value>403, 41</value>
   </data>
   <data name="but_disablearmswitch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_disablearmswitch.TabIndex" type="System.Int32, mscorlib">
     <value>98</value>
@@ -1030,10 +1030,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_paramrestore.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 291</value>
+    <value>403, 307</value>
   </data>
   <data name="but_paramrestore.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_paramrestore.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
@@ -1060,10 +1060,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_mavinspector.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 75</value>
+    <value>403, 79</value>
   </data>
   <data name="but_mavinspector.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_mavinspector.TabIndex" type="System.Int32, mscorlib">
     <value>92</value>
@@ -1090,10 +1090,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_sitl_comb.Location" type="System.Drawing.Point, System.Drawing">
-    <value>403, 273</value>
+    <value>403, 288</value>
   </data>
   <data name="but_sitl_comb.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_sitl_comb.TabIndex" type="System.Int32, mscorlib">
     <value>58</value>
@@ -1120,10 +1120,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_anonlog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 201</value>
+    <value>3, 212</value>
   </data>
   <data name="but_anonlog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_anonlog.TabIndex" type="System.Int32, mscorlib">
     <value>95</value>
@@ -1150,10 +1150,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_dashware.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 381</value>
+    <value>3, 402</value>
   </data>
   <data name="but_dashware.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_dashware.TabIndex" type="System.Int32, mscorlib">
     <value>92</value>
@@ -1180,7 +1180,7 @@
     <value>NoControl</value>
   </data>
   <data name="label26.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 450</value>
+    <value>134, 475</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 13</value>
@@ -1210,7 +1210,7 @@
     <value>NoControl</value>
   </data>
   <data name="label25.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 432</value>
+    <value>134, 456</value>
   </data>
   <data name="label25.Size" type="System.Drawing.Size, System.Drawing">
     <value>171, 13</value>
@@ -1240,7 +1240,7 @@
     <value>NoControl</value>
   </data>
   <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 414</value>
+    <value>134, 437</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
     <value>136, 13</value>
@@ -1270,7 +1270,7 @@
     <value>NoControl</value>
   </data>
   <data name="label23.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 396</value>
+    <value>134, 418</value>
   </data>
   <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 13</value>
@@ -1300,7 +1300,7 @@
     <value>NoControl</value>
   </data>
   <data name="label21.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 360</value>
+    <value>134, 380</value>
   </data>
   <data name="label21.Size" type="System.Drawing.Size, System.Drawing">
     <value>140, 13</value>
@@ -1330,7 +1330,7 @@
     <value>NoControl</value>
   </data>
   <data name="label20.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 342</value>
+    <value>134, 361</value>
   </data>
   <data name="label20.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 13</value>
@@ -1360,7 +1360,7 @@
     <value>NoControl</value>
   </data>
   <data name="label19.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 324</value>
+    <value>134, 342</value>
   </data>
   <data name="label19.Size" type="System.Drawing.Size, System.Drawing">
     <value>130, 13</value>
@@ -1390,7 +1390,7 @@
     <value>NoControl</value>
   </data>
   <data name="label18.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 306</value>
+    <value>134, 323</value>
   </data>
   <data name="label18.Size" type="System.Drawing.Size, System.Drawing">
     <value>123, 13</value>
@@ -1420,10 +1420,10 @@
     <value>NoControl</value>
   </data>
   <data name="butlogindex.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 453</value>
+    <value>3, 478</value>
   </data>
   <data name="butlogindex.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="butlogindex.TabIndex" type="System.Int32, mscorlib">
     <value>51</value>
@@ -1450,10 +1450,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_armandtakeoff.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 399</value>
+    <value>3, 421</value>
   </data>
   <data name="but_armandtakeoff.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_armandtakeoff.TabIndex" type="System.Int32, mscorlib">
     <value>56</value>
@@ -1480,10 +1480,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_maplogs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 435</value>
+    <value>3, 459</value>
   </data>
   <data name="but_maplogs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_maplogs.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -1510,7 +1510,7 @@
     <value>NoControl</value>
   </data>
   <data name="label17.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 288</value>
+    <value>134, 304</value>
   </data>
   <data name="label17.Size" type="System.Drawing.Size, System.Drawing">
     <value>214, 13</value>
@@ -1540,10 +1540,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_gimbaltest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 417</value>
+    <value>3, 440</value>
   </data>
   <data name="but_gimbaltest.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_gimbaltest.TabIndex" type="System.Int32, mscorlib">
     <value>48</value>
@@ -1570,10 +1570,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_structtest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 363</value>
+    <value>3, 383</value>
   </data>
   <data name="but_structtest.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_structtest.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
@@ -1600,7 +1600,7 @@
     <value>NoControl</value>
   </data>
   <data name="label15.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 252</value>
+    <value>134, 266</value>
   </data>
   <data name="label15.Size" type="System.Drawing.Size, System.Drawing">
     <value>252, 13</value>
@@ -1630,7 +1630,7 @@
     <value>NoControl</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 234</value>
+    <value>134, 247</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
     <value>117, 13</value>
@@ -1660,7 +1660,7 @@
     <value>NoControl</value>
   </data>
   <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 216</value>
+    <value>134, 228</value>
   </data>
   <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
     <value>128, 13</value>
@@ -1690,7 +1690,7 @@
     <value>NoControl</value>
   </data>
   <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 180</value>
+    <value>134, 190</value>
   </data>
   <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
     <value>156, 13</value>
@@ -1720,10 +1720,10 @@
     <value>NoControl</value>
   </data>
   <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 162</value>
+    <value>134, 171</value>
   </data>
   <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>226, 18</value>
+    <value>226, 19</value>
   </data>
   <data name="label10.TabIndex" type="System.Int32, mscorlib">
     <value>56</value>
@@ -1750,7 +1750,7 @@
     <value>NoControl</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 144</value>
+    <value>134, 152</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
     <value>202, 13</value>
@@ -1780,10 +1780,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_clearcustommaps.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 345</value>
+    <value>3, 364</value>
   </data>
   <data name="BUT_clearcustommaps.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_clearcustommaps.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -1810,10 +1810,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_getfw.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 309</value>
+    <value>3, 326</value>
   </data>
   <data name="but_getfw.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_getfw.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -1840,10 +1840,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_geinjection.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 327</value>
+    <value>3, 345</value>
   </data>
   <data name="BUT_geinjection.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_geinjection.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1870,7 +1870,7 @@
     <value>NoControl</value>
   </data>
   <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 126</value>
+    <value>134, 133</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
     <value>131, 13</value>
@@ -1900,7 +1900,7 @@
     <value>NoControl</value>
   </data>
   <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 108</value>
+    <value>134, 114</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
     <value>204, 13</value>
@@ -1930,10 +1930,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_sorttlogs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 291</value>
+    <value>3, 307</value>
   </data>
   <data name="BUT_sorttlogs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_sorttlogs.TabIndex" type="System.Int32, mscorlib">
     <value>38</value>
@@ -1960,7 +1960,7 @@
     <value>NoControl</value>
   </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 90</value>
+    <value>134, 95</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
     <value>203, 13</value>
@@ -1990,7 +1990,7 @@
     <value>NoControl</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 72</value>
+    <value>134, 76</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
     <value>221, 13</value>
@@ -2020,7 +2020,7 @@
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 54</value>
+    <value>134, 57</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
     <value>163, 13</value>
@@ -2050,7 +2050,7 @@
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 36</value>
+    <value>134, 38</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>141, 13</value>
@@ -2080,7 +2080,7 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 18</value>
+    <value>134, 19</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 13</value>
@@ -2110,10 +2110,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_outputMavlink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 93</value>
+    <value>3, 98</value>
   </data>
   <data name="BUT_outputMavlink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_outputMavlink.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -2140,10 +2140,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_outputMD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 75</value>
+    <value>3, 79</value>
   </data>
   <data name="BUT_outputMD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_outputMD.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -2170,10 +2170,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_outputnmea.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 57</value>
+    <value>3, 60</value>
   </data>
   <data name="BUT_outputnmea.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_outputnmea.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -2203,7 +2203,7 @@
     <value>3, 3</value>
   </data>
   <data name="BUT_georefimage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_georefimage.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2230,10 +2230,10 @@
     <value>NoControl</value>
   </data>
   <data name="button3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 21</value>
+    <value>3, 22</value>
   </data>
   <data name="button3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="button3.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -2260,10 +2260,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_lang_edit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 129</value>
+    <value>3, 136</value>
   </data>
   <data name="BUT_lang_edit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_lang_edit.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -2290,10 +2290,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_follow_me.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 39</value>
+    <value>3, 41</value>
   </data>
   <data name="BUT_follow_me.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_follow_me.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2320,10 +2320,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_paramgen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 111</value>
+    <value>3, 117</value>
   </data>
   <data name="BUT_paramgen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_paramgen.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -2350,10 +2350,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_osdvideo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 147</value>
+    <value>3, 155</value>
   </data>
   <data name="but_osdvideo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_osdvideo.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -2380,10 +2380,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_movingbase.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 165</value>
+    <value>3, 174</value>
   </data>
   <data name="BUT_movingbase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_movingbase.TabIndex" type="System.Int32, mscorlib">
     <value>40</value>
@@ -2410,10 +2410,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_shptopoly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 183</value>
+    <value>3, 193</value>
   </data>
   <data name="BUT_shptopoly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_shptopoly.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -2440,10 +2440,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_swarm.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 219</value>
+    <value>3, 231</value>
   </data>
   <data name="BUT_swarm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_swarm.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -2470,10 +2470,10 @@
     <value>NoControl</value>
   </data>
   <data name="BUT_followleader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 237</value>
+    <value>3, 250</value>
   </data>
   <data name="BUT_followleader.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="BUT_followleader.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -2530,10 +2530,10 @@
     <value>NoControl</value>
   </data>
   <data name="but_mavserialport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 255</value>
+    <value>3, 269</value>
   </data>
   <data name="but_mavserialport.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
+    <value>125, 13</value>
   </data>
   <data name="but_mavserialport.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -2563,7 +2563,7 @@
     <value>403, 3</value>
   </data>
   <data name="but_hexmavlink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 12</value>
+    <value>148, 13</value>
   </data>
   <data name="but_hexmavlink.TabIndex" type="System.Int32, mscorlib">
     <value>105</value>
@@ -2590,7 +2590,7 @@
     <value>NoControl</value>
   </data>
   <data name="label27.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 504</value>
+    <value>134, 532</value>
   </data>
   <data name="label27.Size" type="System.Drawing.Size, System.Drawing">
     <value>128, 13</value>
@@ -2620,7 +2620,7 @@
     <value>NoControl</value>
   </data>
   <data name="label29.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 468</value>
+    <value>134, 494</value>
   </data>
   <data name="label29.Size" type="System.Drawing.Size, System.Drawing">
     <value>263, 13</value>
@@ -2650,7 +2650,7 @@
     <value>NoControl</value>
   </data>
   <data name="label30.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 18</value>
+    <value>557, 19</value>
   </data>
   <data name="label30.Size" type="System.Drawing.Size, System.Drawing">
     <value>117, 13</value>
@@ -2680,7 +2680,7 @@
     <value>NoControl</value>
   </data>
   <data name="label31.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 36</value>
+    <value>557, 38</value>
   </data>
   <data name="label31.Size" type="System.Drawing.Size, System.Drawing">
     <value>142, 13</value>
@@ -2710,7 +2710,7 @@
     <value>NoControl</value>
   </data>
   <data name="label32.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 54</value>
+    <value>557, 57</value>
   </data>
   <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
     <value>212, 13</value>
@@ -2740,7 +2740,7 @@
     <value>NoControl</value>
   </data>
   <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 72</value>
+    <value>557, 76</value>
   </data>
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
     <value>218, 13</value>
@@ -2770,7 +2770,7 @@
     <value>NoControl</value>
   </data>
   <data name="label34.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 90</value>
+    <value>557, 95</value>
   </data>
   <data name="label34.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 13</value>
@@ -2800,7 +2800,7 @@
     <value>NoControl</value>
   </data>
   <data name="label35.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 108</value>
+    <value>557, 114</value>
   </data>
   <data name="label35.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 13</value>
@@ -2830,7 +2830,7 @@
     <value>NoControl</value>
   </data>
   <data name="label36.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 126</value>
+    <value>557, 133</value>
   </data>
   <data name="label36.Size" type="System.Drawing.Size, System.Drawing">
     <value>196, 13</value>
@@ -2860,7 +2860,7 @@
     <value>NoControl</value>
   </data>
   <data name="label37.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 144</value>
+    <value>557, 152</value>
   </data>
   <data name="label37.Size" type="System.Drawing.Size, System.Drawing">
     <value>169, 13</value>
@@ -2890,7 +2890,7 @@
     <value>NoControl</value>
   </data>
   <data name="label38.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 162</value>
+    <value>557, 171</value>
   </data>
   <data name="label38.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 13</value>
@@ -2920,7 +2920,7 @@
     <value>NoControl</value>
   </data>
   <data name="label39.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 180</value>
+    <value>557, 190</value>
   </data>
   <data name="label39.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 13</value>
@@ -2950,10 +2950,10 @@
     <value>NoControl</value>
   </data>
   <data name="label40.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 198</value>
+    <value>557, 209</value>
   </data>
   <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 18</value>
+    <value>222, 19</value>
   </data>
   <data name="label40.TabIndex" type="System.Int32, mscorlib">
     <value>119</value>
@@ -2980,7 +2980,7 @@
     <value>NoControl</value>
   </data>
   <data name="label41.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 216</value>
+    <value>557, 228</value>
   </data>
   <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
     <value>172, 13</value>
@@ -3010,7 +3010,7 @@
     <value>NoControl</value>
   </data>
   <data name="label42.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 234</value>
+    <value>557, 247</value>
   </data>
   <data name="label42.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 13</value>
@@ -3040,7 +3040,7 @@
     <value>NoControl</value>
   </data>
   <data name="label43.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 252</value>
+    <value>557, 266</value>
   </data>
   <data name="label43.Size" type="System.Drawing.Size, System.Drawing">
     <value>196, 13</value>
@@ -3070,7 +3070,7 @@
     <value>NoControl</value>
   </data>
   <data name="label44.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 288</value>
+    <value>557, 304</value>
   </data>
   <data name="label44.Size" type="System.Drawing.Size, System.Drawing">
     <value>19, 13</value>
@@ -3100,7 +3100,7 @@
     <value>NoControl</value>
   </data>
   <data name="label45.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 306</value>
+    <value>557, 323</value>
   </data>
   <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
     <value>19, 13</value>
@@ -3130,7 +3130,7 @@
     <value>NoControl</value>
   </data>
   <data name="label46.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 324</value>
+    <value>557, 342</value>
   </data>
   <data name="label46.Size" type="System.Drawing.Size, System.Drawing">
     <value>16, 13</value>
@@ -3160,7 +3160,7 @@
     <value>NoControl</value>
   </data>
   <data name="label47.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 342</value>
+    <value>557, 361</value>
   </data>
   <data name="label47.Size" type="System.Drawing.Size, System.Drawing">
     <value>98, 13</value>
@@ -3190,7 +3190,7 @@
     <value>NoControl</value>
   </data>
   <data name="label48.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 360</value>
+    <value>557, 380</value>
   </data>
   <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
     <value>74, 13</value>
@@ -3220,7 +3220,7 @@
     <value>NoControl</value>
   </data>
   <data name="label49.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 378</value>
+    <value>557, 399</value>
   </data>
   <data name="label49.Size" type="System.Drawing.Size, System.Drawing">
     <value>41, 13</value>
@@ -3250,10 +3250,10 @@
     <value>NoControl</value>
   </data>
   <data name="label50.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 396</value>
+    <value>557, 418</value>
   </data>
   <data name="label50.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 18</value>
+    <value>212, 19</value>
   </data>
   <data name="label50.TabIndex" type="System.Int32, mscorlib">
     <value>129</value>
@@ -3280,7 +3280,7 @@
     <value>NoControl</value>
   </data>
   <data name="label51.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 414</value>
+    <value>557, 437</value>
   </data>
   <data name="label51.Size" type="System.Drawing.Size, System.Drawing">
     <value>184, 13</value>
@@ -3310,7 +3310,7 @@
     <value>NoControl</value>
   </data>
   <data name="label52.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 432</value>
+    <value>557, 456</value>
   </data>
   <data name="label52.Size" type="System.Drawing.Size, System.Drawing">
     <value>132, 13</value>
@@ -3340,7 +3340,7 @@
     <value>NoControl</value>
   </data>
   <data name="label53.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 468</value>
+    <value>557, 494</value>
   </data>
   <data name="label53.Size" type="System.Drawing.Size, System.Drawing">
     <value>129, 13</value>
@@ -3370,7 +3370,7 @@
     <value>NoControl</value>
   </data>
   <data name="label54.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 486</value>
+    <value>557, 513</value>
   </data>
   <data name="label54.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 13</value>
@@ -3400,7 +3400,7 @@
     <value>NoControl</value>
   </data>
   <data name="label55.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 504</value>
+    <value>557, 532</value>
   </data>
   <data name="label55.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>
@@ -3424,7 +3424,7 @@
     <value>109</value>
   </data>
   <data name="but_remotedflogger.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 273</value>
+    <value>3, 288</value>
   </data>
   <data name="but_remotedflogger.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 12</value>
@@ -3454,7 +3454,7 @@
     <value>NoControl</value>
   </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 522</value>
+    <value>134, 551</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
     <value>126, 13</value>
@@ -3477,6 +3477,60 @@
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
     <value>111</value>
   </data>
+  <data name="but_ManageCMDList.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="but_ManageCMDList.Location" type="System.Drawing.Point, System.Drawing">
+    <value>403, 554</value>
+  </data>
+  <data name="but_ManageCMDList.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 18</value>
+  </data>
+  <data name="but_ManageCMDList.TabIndex" type="System.Int32, mscorlib">
+    <value>138</value>
+  </data>
+  <data name="but_ManageCMDList.Text" xml:space="preserve">
+    <value>Manage Command List</value>
+  </data>
+  <data name="&gt;&gt;but_ManageCMDList.Name" xml:space="preserve">
+    <value>but_ManageCMDList</value>
+  </data>
+  <data name="&gt;&gt;but_ManageCMDList.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;but_ManageCMDList.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;but_ManageCMDList.ZOrder" xml:space="preserve">
+    <value>112</value>
+  </data>
+  <data name="label28.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label28.Location" type="System.Drawing.Point, System.Drawing">
+    <value>557, 551</value>
+  </data>
+  <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
+    <value>161, 13</value>
+  </data>
+  <data name="label28.TabIndex" type="System.Int32, mscorlib">
+    <value>139</value>
+  </data>
+  <data name="label28.Text" xml:space="preserve">
+    <value>Manage Planner's Command List</value>
+  </data>
+  <data name="&gt;&gt;label28.Name" xml:space="preserve">
+    <value>label28</value>
+  </data>
+  <data name="&gt;&gt;label28.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label28.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
+    <value>113</value>
+  </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 12</value>
   </data>
@@ -3484,7 +3538,7 @@
     <value>30</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>800, 543</value>
+    <value>800, 575</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>57</value>
@@ -3502,7 +3556,7 @@
     <value>1</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="BUT_CoT" Row="29" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_proximity" Row="27" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_followswarm" Row="28" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label16" Row="25" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="but_lockup" Row="10" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_td" Row="18" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_gpsinj" Row="26" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_dem" Row="11" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="BUT_magfit2" Row="28" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_GDAL" Row="14" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_sortlogs" Row="13" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_optflowcalib" Row="26" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_logdlscp" Row="12" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_signkey" Row="25" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_acbarohight" Row="9" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="myButton1" Row="24" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_driverclean" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_agemapdata" Row="23" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_packetbytes" Row="8" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="myButton_vlc" Row="22" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label22" Row="21" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_trimble" Row="21" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_hwids" Row="7" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="BUT_QNH" Row="20" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_reboot" Row="19" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_3dmap" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_messageinterval" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_blupdate" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="BUT_fft" Row="17" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_disablearmswitch" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_paramrestore" Row="16" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_mavinspector" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_sitl_comb" Row="15" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_anonlog" Row="11" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_dashware" Row="21" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label26" Row="25" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label25" Row="24" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label24" Row="23" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label23" Row="22" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label21" Row="20" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label20" Row="19" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label19" Row="18" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label18" Row="17" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="butlogindex" Row="25" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_armandtakeoff" Row="22" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_maplogs" Row="24" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label17" Row="16" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_gimbaltest" Row="23" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_structtest" Row="20" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label15" Row="14" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label14" Row="13" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label13" Row="12" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label11" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label10" Row="9" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label9" Row="8" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_clearcustommaps" Row="19" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_getfw" Row="17" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_geinjection" Row="18" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label8" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label7" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_sorttlogs" Row="16" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_outputMavlink" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_outputMD" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_outputnmea" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_georefimage" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button3" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_lang_edit" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_follow_me" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_paramgen" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_osdvideo" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_movingbase" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_shptopoly" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_swarm" Row="12" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_followleader" Row="13" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_mavserialport" Row="14" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_hexmavlink" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label27" Row="28" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label29" Row="26" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label30" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label31" Row="2" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label32" Row="3" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label33" Row="4" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label34" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label35" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label36" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label37" Row="8" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label38" Row="9" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label39" Row="10" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label40" Row="11" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label41" Row="12" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label42" Row="13" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label43" Row="14" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label44" Row="16" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label45" Row="17" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label46" Row="18" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label47" Row="19" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label48" Row="20" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label49" Row="21" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label50" Row="22" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label51" Row="23" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label52" Row="24" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label53" Row="26" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label54" Row="27" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label55" Row="28" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="but_remotedflogger" Row="15" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label12" Row="29" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,16.375,Percent,33.625,Percent,19.25,Percent,30.75" /&gt;&lt;Rows Styles="Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="BUT_CoT" Row="29" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_proximity" Row="27" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_followswarm" Row="28" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label16" Row="25" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="but_lockup" Row="10" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_td" Row="18" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_gpsinj" Row="26" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_dem" Row="11" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="BUT_magfit2" Row="28" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_GDAL" Row="14" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_sortlogs" Row="13" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_optflowcalib" Row="26" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_logdlscp" Row="12" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_signkey" Row="25" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_acbarohight" Row="9" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="myButton1" Row="24" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_driverclean" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_agemapdata" Row="23" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_packetbytes" Row="8" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="myButton_vlc" Row="22" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label22" Row="21" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_trimble" Row="21" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_hwids" Row="7" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="BUT_QNH" Row="20" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_reboot" Row="19" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_3dmap" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_messageinterval" Row="3" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_blupdate" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="BUT_fft" Row="17" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_disablearmswitch" Row="2" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_paramrestore" Row="16" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_mavinspector" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_sitl_comb" Row="15" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_anonlog" Row="11" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_dashware" Row="21" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label26" Row="25" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label25" Row="24" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label24" Row="23" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label23" Row="22" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label21" Row="20" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label20" Row="19" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label19" Row="18" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label18" Row="17" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="butlogindex" Row="25" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_armandtakeoff" Row="22" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_maplogs" Row="24" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label17" Row="16" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_gimbaltest" Row="23" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_structtest" Row="20" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label15" Row="14" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label14" Row="13" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label13" Row="12" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label11" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label10" Row="9" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label9" Row="8" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_clearcustommaps" Row="19" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_getfw" Row="17" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_geinjection" Row="18" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label8" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label7" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_sorttlogs" Row="16" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label6" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label5" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label4" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label3" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label2" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_outputMavlink" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_outputMD" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_outputnmea" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_georefimage" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="button3" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_lang_edit" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_follow_me" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_paramgen" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_osdvideo" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_movingbase" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_shptopoly" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_swarm" Row="12" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_followleader" Row="13" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_mavserialport" Row="14" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="but_hexmavlink" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label27" Row="28" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label29" Row="26" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="label30" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label31" Row="2" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label32" Row="3" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label33" Row="4" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label34" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label35" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label36" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label37" Row="8" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label38" Row="9" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label39" Row="10" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label40" Row="11" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label41" Row="12" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label42" Row="13" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label43" Row="14" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label44" Row="16" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label45" Row="17" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label46" Row="18" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label47" Row="19" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label48" Row="20" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label49" Row="21" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label50" Row="22" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label51" Row="23" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label52" Row="24" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label53" Row="26" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label54" Row="27" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="label55" Row="28" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="but_remotedflogger" Row="15" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label12" Row="29" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_ManageCMDList" Row="29" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="label28" Row="29" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,16.375,Percent,33.625,Percent,19.25,Percent,30.75" /&gt;&lt;Rows Styles="Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Percent,3.448275,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="controlSensorsStatus1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3520,7 +3574,7 @@
     <value>controlSensorsStatus1</value>
   </data>
   <data name="&gt;&gt;controlSensorsStatus1.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ControlSensorsStatus, MissionPlanner, Version=1.3.7941.38182, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ControlSensorsStatus, MissionPlanner, Version=1.3.8037.313, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;controlSensorsStatus1.Parent" xml:space="preserve">
     <value>$this</value>


### PR DESCRIPTION
This one is for the Devs. A quick editor enables users to add mavlink commands to the dropdown list of the Planner grid. You can add commands that are already defined in MAV_CMD enum and new ones as well. Also, you can edit the param names that are displayed In the header.
The commands are stored in config.xml.
 Adding a command here does not mean that the autopilot will accept or execute it. So the user has to know what is he/her doing.