### PR TITLE
LogBrowser: fix issue #2758, changed param values now shown in ParamView

### DIFF
--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -3593,9 +3593,29 @@ main()
             var parmdata = logdata.GetEnumeratorType("PARM").Select(a =>
                 new MAVLink.MAVLinkParam(a["Name"], double.Parse(a["Value"], CultureInfo.InvariantCulture),
                     MAVLink.MAV_PARAM_TYPE.REAL32));
-            
+
+            //Check the list for duplicates and use the latest occurence for value
+            MAVLink.MAVLinkParamList newparamdata = new MAVLink.MAVLinkParamList();
+            foreach (MAVLink.MAVLinkParam sourceItem in parmdata)
+            {
+                //Lookup the next item in the target list
+                for (var idx_target = 0; idx_target < newparamdata.Count(); idx_target++)
+                {
+                    if (sourceItem.Name == newparamdata[idx_target].Name)
+                    {
+                        //This item is already in the parameters, since source is in time order, it means the value changed
+                        //We can replace the item in the output with this new value
+                        Console.WriteLine("Duplicated item Name:{0} Prev:{1} New:{2}", sourceItem.Name, newparamdata[idx_target].Value, sourceItem.Value);
+                        newparamdata[idx_target] = sourceItem;
+                        break;
+                    }
+                }
+                //item is not in target list, we can add it
+                newparamdata.Add(sourceItem);
+            }
+
             MainV2.comPort.MAV.param.Clear();
-            MainV2.comPort.MAV.param.AddRange(parmdata);
+            MainV2.comPort.MAV.param.AddRange(newparamdata);
 
             var frm = new ConfigRawParamsTree().ShowUserControl();
         }

--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -340,7 +340,7 @@ namespace MissionPlanner.Log
             this.Text = "Log Browser - " + Path.GetFileName(FileName);
 
             CreateChart(zg1);
-
+            chk_time_CheckedChanged(null, null);
             // try and grab vehicle version from messages
             string vehicle_msg = null;
             foreach (var item in logdata.GetEnumeratorType("MSG"))

--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -2194,38 +2194,59 @@ main()
 
                             if (ans != null && ans.Lat != 0 && ans.Lng != 0)
                             {
-                                routelistcmd.Add(ans);
-                                samplelistcmd.Add(i);
-
-                                mapoverlay.Markers.Add(new GMapMarkerWP(ans, item["CNum"]));
-
-                                //FMT, 146, 45, CMD, QHHHfffffff, TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt
-                                //CMD, 43368479, 19, 18, 85, 0, 0, 0, 0, -27.27409, 151.2901, 0
-
-                                if (item["CTot"] != null && item["CNum"] != null &&
-                                    (int.Parse(item["CTot"]) - 1) == int.Parse(item["CNum"]))
+                                bool duplicate = false;
+                                foreach (GMapMarkerWP m in mapoverlay.Markers)
                                 {
-                                    //split the route in several small parts (due to memory errors)
-                                    GMapRoute route_part = new GMapRoute(routelistcmd, "routecmd_" + rtcnt);
-                                    route_part.Stroke = new Pen(Color.FromArgb(127, Color.Indigo), 2);
+                                    if (m.Tag?.ToString() == item["CNum"].ToString())
+                                    {
+                                        duplicate = true;
+                                        break;
+                                    }
+                                }
 
-                                    LogRouteInfo lri = new LogRouteInfo();
-                                    lri.firstpoint = firstpointpos;
-                                    lri.lastpoint = i;
-                                    lri.samples.AddRange(samplelistcmd);
-
-                                    route_part.Tag = lri;
-                                    route_part.IsHitTestVisible = false;
-                                    mapoverlay.Routes.Add(route_part);
-
-                                    rtcnt++;
-
-                                    //clear the list and set the last point as first point for the next route
-                                    routelistcmd.Clear();
-                                    samplelistcmd.Clear();
-                                    firstpointcmd = i;
-                                    samplelistcmd.Add(firstpointcmd);
+                                if (!duplicate)
+                                {
                                     routelistcmd.Add(ans);
+                                    samplelistcmd.Add(i);
+
+                                    GMapMarker newWP = new GMapMarkerWP(ans, item["CNum"]);
+                                    newWP.Tag = item["CNum"].ToString();
+
+                                    //mapoverlay.Markers.Add(new GMapMarkerWP(ans, item["CNum"]));
+                                    mapoverlay.Markers.Add(newWP);
+
+                                    //FMT, 146, 45, CMD, QHHHfffffff, TimeUS,CTot,CNum,CId,Prm1,Prm2,Prm3,Prm4,Lat,Lng,Alt
+                                    //CMD, 43368479, 19, 18, 85, 0, 0, 0, 0, -27.27409, 151.2901, 0
+
+                                    if (item["CTot"] != null && item["CNum"] != null &&
+                                        (int.Parse(item["CTot"]) - 1) == int.Parse(item["CNum"]))
+                                    {
+                                        //split the route in several small parts (due to memory errors)
+                                        GMapRoute route_part = new GMapRoute(routelistcmd, "routecmd_" + rtcnt);
+                                        route_part.Stroke = new Pen(Color.FromArgb(127, Color.Indigo), 2);
+
+                                        LogRouteInfo lri = new LogRouteInfo();
+                                        lri.firstpoint = firstpointpos;
+                                        lri.lastpoint = i;
+                                        lri.samples.AddRange(samplelistcmd);
+
+                                        route_part.Tag = lri;
+                                        route_part.IsHitTestVisible = false;
+                                        mapoverlay.Routes.Add(route_part);
+
+                                        rtcnt++;
+
+                                        //clear the list and set the last point as first point for the next route
+                                        routelistcmd.Clear();
+                                        samplelistcmd.Clear();
+                                        firstpointcmd = i;
+                                        samplelistcmd.Add(firstpointcmd);
+                                        routelistcmd.Add(ans);
+                                    }
+                                }
+                                else
+                                {
+                                    mapoverlay.Markers.Add(new GMapMarkerWP(ans, item["CNum"]));
                                 }
                             }
                         }


### PR DESCRIPTION
The LogBrowse ParamTreeView shows only the first param occurrence, which is recorded at the beginning of logging. The fix iterates through param log entries and keeps only the latest value of every param. This solves ISSUE #2758. 
**Note!, if there are multiple flights in the same log and the user changes param value between flights, the value shown will be the last one, which can be misleading looking at flights at the beginning of the log file.**

Also, fix the graph x-axis name issue when it changes back to "Line Number" at log file load, regardless of the Time checkbox state.

And a similar issue in the MAP when waypoints were moved or changed during logging ISSUE #2711