### PR TITLE
Grid: Remove duplicated ToolstripMenu item creation.

### DIFF
--- a/Grid/GridPlugin.cs
+++ b/Grid/GridPlugin.cs
@@ -31,29 +31,6 @@ namespace MissionPlanner.Grid
 
         public override bool Loaded()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GridUI));
-            var temp = (string)(resources.GetObject("$this.Text"));
-
-            but = new ToolStripMenuItem(temp);
-            but.Click += but_Click;
-
-            bool hit = false;
-            ToolStripItemCollection col = Host.FPMenuMap.Items;
-            int index = col.Count;
-            foreach (ToolStripItem item in col)
-            {
-                if (item.Text.Equals(Strings.AutoWP))
-                {
-                    index = col.IndexOf(item);
-                    ((ToolStripMenuItem)item).DropDownItems.Add(but);
-                    hit = true;
-                    break;
-                }
-            }
-
-            if (hit == false)
-                col.Add(but);
-
             return true;
         }
 


### PR DESCRIPTION
Toolstrip menu item is also created in FlightPlanner.