### PR TITLE
GCSViews: Set the home position to the seventh decimal place

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5610,9 +5610,9 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                         try
                         {
                             sw.WriteLine("0\t1\t0\t16\t0\t0\t0\t0\t" +
-                                         double.Parse(TXT_homelat.Text).ToString("0.000000", new CultureInfo("en-US")) +
+                                         double.Parse(TXT_homelat.Text).ToString("0.0000000", new CultureInfo("en-US")) +
                                          "\t" +
-                                         double.Parse(TXT_homelng.Text).ToString("0.000000", new CultureInfo("en-US")) +
+                                         double.Parse(TXT_homelng.Text).ToString("0.0000000", new CultureInfo("en-US")) +
                                          "\t" +
                                          double.Parse(TXT_homealt.Text).ToString("0.000000", new CultureInfo("en-US")) +
                                          "\t1");


### PR DESCRIPTION
I discovered that my home position was in the sixth decimal place.
The ArduPilot is valid to the seventh decimal place.
I increased the digits to the seventh decimal place.

![Screenshot from 2022-01-23 10-42-45](https://user-images.githubusercontent.com/646194/150661335-1df7db5c-ece4-4331-a115-39b91c03de69.png)
