### PR TITLE
Fix for ISSUE #2771, New Firmware available "Show me again" checkbox does not work

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -206,7 +206,7 @@ namespace MissionPlanner
             form.Text = title;
             label.Text = promptText;
 
-            chk.Tag = ($"SHOWAGAIN_{title.Replace(" ", "_").Replace('+', '_')}");
+            chk.Tag = ($"SHOWAGAIN_{title.Replace(" ", "_").Replace('+', '_').Replace('-', '_').Replace('.', '_')}");
             chk.AutoSize = true;
             chk.Text = Strings.ShowMeAgain;
             chk.Checked = true;


### PR DESCRIPTION
Fix for ISSUE #2771
The annoying "New Firmware available" pop-up at the startup now disappears when the checkbox "Show me again" is unchecked. 

