### PR TITLE
Fix typo at setup->advanced

### DIFF
--- a/temp.resx
+++ b/temp.resx
@@ -1909,7 +1909,7 @@
     <value>53</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
-    <value>regenerage the param info used inside mp</value>
+    <value>regenerate the param info used inside mp</value>
   </data>
   <data name="&gt;&gt;label7.Name" xml:space="preserve">
     <value>label7</value>


### PR DESCRIPTION
Change "regenerage" to "regenerate".
closes #2797 