### PR TITLE
suppress errors when not analog battery monitor

### DIFF
--- a/GCSViews/ConfigurationView/ConfigBatteryMonitoring.cs
+++ b/GCSViews/ConfigurationView/ConfigBatteryMonitoring.cs
@@ -292,7 +292,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_VOLT_MULT Failed", Strings.ERROR);
+                if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
+                    (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
+                     MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
+                   CustomMessageBox.Show("Set BATT_VOLT_MULT Failed", Strings.ERROR);
+                }
             }
         }
 
@@ -312,7 +316,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_VOLT_MULT Failed", Strings.ERROR);
+                if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
+                    (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
+                     MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
+                  CustomMessageBox.Show("Set BATT_VOLT_MULT Failed", Strings.ERROR);
+                }
             }
         }
 
@@ -332,7 +340,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_AMP_PERVOLT Failed", Strings.ERROR);
+                if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
+                    (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
+                     MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
+                  CustomMessageBox.Show("Set BATT_AMP_PERVOLT Failed", Strings.ERROR);
+                }
             }
         }
 
@@ -621,7 +633,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_AMP_PERVOLT Failed", Strings.ERROR);
+                if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
+                    (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
+                     MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
+                  CustomMessageBox.Show("Set BATT_AMP_PERVOLT Failed", Strings.ERROR);
+                }
             }
         }
     }


### PR DESCRIPTION
this is an attempt to get rid of these errors when using an I2C battery monitor, which doesn't have the multiplier params:
![image](https://user-images.githubusercontent.com/831867/156106334-9018c6b6-b1a7-4fe1-886a-bded4aae73e9.png)
![image](https://user-images.githubusercontent.com/831867/156106346-632bd45f-f2d0-4310-b11f-aff124dee031.png)
tested successfully in both SITL and with Pixhawk5X with I2C battery monitor