### PR TITLE
PLAN: Add MAV_CMD_NAV_SCRIPT_TIME to the command list

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -282,6 +282,15 @@
       <Y></Y>
       <Z></Z>
     </DO_SPRAYER>
+    <SCRIPT_TIME>
+      <P1>command</P1>
+      <P2>timeout</P2>
+      <P3>arg1</P3>
+      <P4>arg2</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SCRIPT_TIME>
 
   </AC2>
   <!-- -->


### PR DESCRIPTION
The following discus says that the MAV_CMD_NAV_SCRIPT_TIME message is not in the plan's command list.
I have added it to the command list.

https://discuss.ardupilot.org/t/copter-4-2-and-fast-descent/83565

MAV_CMD_NAV_SCRIPT_TIME SPEC:
https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_NAV_SCRIPT_TIME

AFTER
PLAN FUNCTION
![Screenshot from 2022-03-31 05-50-10](https://user-images.githubusercontent.com/646194/160930443-dabd4cb6-2e64-4179-8b36-a60084527fd3.png)

PLAN FILE
![Screenshot from 2022-03-31 05-51-32](https://user-images.githubusercontent.com/646194/160930474-a402f2a1-10f7-410a-9061-f1dacfccf48a.png)
