### PR TITLE
FlightPlanner: do not display tracker home when same as home location

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -6410,7 +6410,7 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                 if(DateTime.Now.Second % 10 == 0)
                     routesoverlay.Markers.Clear();
 
-                if (MainV2.comPort.MAV.cs.TrackerLocation != MainV2.comPort.MAV.cs.PlannedHomeLocation &&
+                if (MainV2.comPort.MAV.cs.TrackerLocation != MainV2.comPort.MAV.cs.HomeLocation &&
                     MainV2.comPort.MAV.cs.TrackerLocation.Lng != 0)
                 {
                     addpolygonmarker(this, "Tracker Home", MainV2.comPort.MAV.cs.TrackerLocation.Lng,


### PR DESCRIPTION
fix this issue
https://discuss.ardupilot.org/t/how-delete-tracker-home-point/69980

TrackerLocation returns HomeLocation here.
https://github.com/ArduPilot/MissionPlanner/blob/master/ExtLibs/ArduPilot/CurrentState.cs#L1293

Tracker Home is often displayed because PlannedHomeLocation and HomeLocation are different.
This PR changed to compare TrackerLocation and HomeLocation to judge displaying "Tracker Home".