### PR TITLE
Add speech armed only option

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -2517,7 +2517,8 @@ namespace MissionPlanner
                                 {
                                     if (oldmode != mode && Speech != null && Speech.speechEnable &&
                                         parent?.parent?.MAV?.cs == this &&
-                                        Settings.Instance.GetBoolean("speechmodeenabled"))
+                                        Settings.Instance.GetBoolean("speechmodeenabled") &&
+                                        (armed || !Settings.Instance.GetBoolean("speech_armed_only")))
                                         Speech.SpeakAsync(Common.speechConversion(parent,
                                             "" + Settings.Instance["speechmode"]));
                                 }
@@ -3027,7 +3028,8 @@ namespace MissionPlanner
                             {
                                 if (oldwp != wpno && Speech != null && Speech.speechEnable && parent != null &&
                                     parent.parent.MAV.cs == this &&
-                                    Settings.Instance.GetBoolean("speechwaypointenabled"))
+                                    Settings.Instance.GetBoolean("speechwaypointenabled") &&
+                                    (armed || !Settings.Instance.GetBoolean("speech_armed_only")))
                                     Speech.SpeakAsync(Common.speechConversion(parent,
                                         "" + Settings.Instance["speechwaypoint"]));
                             }

--- a/ExtLibs/Xamarin/Xamarin/GCSViews/FlightData.xaml.cs
+++ b/ExtLibs/Xamarin/Xamarin/GCSViews/FlightData.xaml.cs
@@ -801,7 +801,7 @@ namespace Xamarin
                     {
                     }
 
-                    if (LogPlayBackSpeed >= 4 && MainV2.speechEnable)
+                    if (LogPlayBackSpeed >= 4 && MainV2.speechEnabled())
                         MainV2.speechEngine.SpeakAsyncCancelAll();
 
                     double timetook = (DateTime.Now - tsreal).TotalMilliseconds;

--- a/ExtLibs/Xamarin/Xamarin/GCSViews/WinForms.xaml.cs
+++ b/ExtLibs/Xamarin/Xamarin/GCSViews/WinForms.xaml.cs
@@ -1212,7 +1212,7 @@ namespace Xamarin.GCSViews
 
         public void SpeakAsync(string text)
         {
-            if (!speechEnable)
+            if (!MainV2.speechEnabled())
                 return;
 
             if (text == null || String.IsNullOrWhiteSpace(text))

--- a/ExtLibs/Xamarin/Xamarin/Linked/MainV2.cs
+++ b/ExtLibs/Xamarin/Xamarin/Linked/MainV2.cs
@@ -117,7 +117,7 @@ namespace MissionPlanner
                     }
 
                     // 30 seconds interval speech options
-                    if (speechEnable && speechEngine != null && (DateTime.Now - speechcustomtime).TotalSeconds > 30 &&
+                    if (MainV2.speechEnabled() && speechEngine != null && (DateTime.Now - speechcustomtime).TotalSeconds > 30 &&
                         (MainV2.comPort.logreadmode || comPort.BaseStream.IsOpen))
                     {
                         if (MainV2.speechEngine.IsReady)
@@ -158,7 +158,7 @@ namespace MissionPlanner
                     }
 
                     // speech for airspeed alerts
-                    if (speechEnable && speechEngine != null && (DateTime.Now - speechlowspeedtime).TotalSeconds > 10 &&
+                    if (speechEnabled() && speechEngine != null && (DateTime.Now - speechlowspeedtime).TotalSeconds > 10 &&
                         (MainV2.comPort.logreadmode || comPort.BaseStream.IsOpen))
                     {
                         if (Settings.Instance.GetBoolean("speechlowspeedenabled") == true && MainV2.comPort.MAV.cs.armed)
@@ -192,7 +192,7 @@ namespace MissionPlanner
                     }
 
                     // speech altitude warning - message high warning
-                    if (speechEnable && speechEngine != null &&
+                    if ((speechEnabled()  && speechEngine != null &&
                         (MainV2.comPort.logreadmode || comPort.BaseStream.IsOpen))
                     {
                         float warnalt = float.MaxValue;

--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -106,6 +106,7 @@
             this.label7 = new System.Windows.Forms.Label();
             this.CHK_params_bg = new System.Windows.Forms.CheckBox();
             this.chk_slowMachine = new System.Windows.Forms.CheckBox();
+            this.CHK_speechArmedOnly = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_gcsid)).BeginInit();
             this.SuspendLayout();
@@ -735,9 +736,17 @@
             this.chk_slowMachine.UseVisualStyleBackColor = true;
             this.chk_slowMachine.CheckedChanged += new System.EventHandler(this.chk_slowMachine_CheckedChanged);
             // 
+            // CHK_speechArmedOnly
+            // 
+            resources.ApplyResources(this.CHK_speechArmedOnly, "CHK_speechArmedOnly");
+            this.CHK_speechArmedOnly.Name = "CHK_speechArmedOnly";
+            this.CHK_speechArmedOnly.UseVisualStyleBackColor = true;
+            this.CHK_speechArmedOnly.CheckedChanged += new System.EventHandler(this.CHK_speechArmedOnly_CheckedChanged);
+            // 
             // ConfigPlanner
             // 
             resources.ApplyResources(this, "$this");
+            this.Controls.Add(this.CHK_speechArmedOnly);
             this.Controls.Add(this.chk_slowMachine);
             this.Controls.Add(this.CHK_params_bg);
             this.Controls.Add(this.label7);
@@ -903,5 +912,6 @@
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.CheckBox CHK_params_bg;
         private System.Windows.Forms.CheckBox chk_slowMachine;
+        private System.Windows.Forms.CheckBox CHK_speechArmedOnly;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -134,6 +134,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             SetCheckboxFromConfig("ShowNoFly", chk_shownofly);
             SetCheckboxFromConfig("Params_BG", CHK_params_bg);
             SetCheckboxFromConfig("SlowMachine", chk_slowMachine);
+            SetCheckboxFromConfig("speech_armed_only", CHK_speechArmedOnly);
 
             // this can't fail because it set at startup
             NUM_tracklength.Value = Settings.Instance.GetInt32("NUM_tracklength", 200);
@@ -337,6 +338,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (CHK_enablespeech.Checked)
             {
+                CHK_speechArmedOnly.Visible = true;
                 CHK_speechwaypoint.Visible = true;
                 CHK_speechaltwarning.Visible = true;
                 CHK_speechbattery.Visible = true;
@@ -347,6 +349,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             else
             {
+                CHK_speechArmedOnly.Visible = false;
                 CHK_speechwaypoint.Visible = false;
                 CHK_speechaltwarning.Visible = false;
                 CHK_speechbattery.Visible = false;
@@ -992,6 +995,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private void chk_slowMachine_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Instance["SlowMachine"] = chk_slowMachine.Checked.ToString();
+        }
+
+        private void CHK_speechArmedOnly_CheckedChanged(object sender, EventArgs e)
+        {
+            MainV2.speech_armed_only = CHK_speechArmedOnly.Checked;
+            Settings.Instance["speech_armed_only"] = CHK_speechArmedOnly.Checked.ToString();
         }
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>33</value>
   </data>
   <data name="CMB_ratesensors.Items" xml:space="preserve">
     <value>-1</value>
@@ -211,7 +211,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_ratesensors.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>34</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -241,7 +241,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>35</value>
   </data>
   <data name="CMB_videoresolutions.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 35</value>
@@ -262,7 +262,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_videoresolutions.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>36</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -292,7 +292,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>36</value>
+    <value>37</value>
   </data>
   <data name="CHK_GDIPlus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -319,7 +319,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_GDIPlus.ZOrder" xml:space="preserve">
-    <value>37</value>
+    <value>38</value>
   </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -349,7 +349,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>38</value>
+    <value>39</value>
   </data>
   <data name="CHK_loadwponconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -376,7 +376,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_loadwponconnect.ZOrder" xml:space="preserve">
-    <value>39</value>
+    <value>40</value>
   </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -406,7 +406,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>40</value>
+    <value>41</value>
   </data>
   <data name="NUM_tracklength.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 273</value>
@@ -427,7 +427,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;NUM_tracklength.ZOrder" xml:space="preserve">
-    <value>41</value>
+    <value>42</value>
   </data>
   <data name="CHK_speechaltwarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -436,7 +436,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speechaltwarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>515, 89</value>
+    <value>624, 89</value>
   </data>
   <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
     <value>81, 17</value>
@@ -460,7 +460,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechaltwarning.ZOrder" xml:space="preserve">
-    <value>42</value>
+    <value>43</value>
   </data>
   <data name="label108.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -490,7 +490,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label108.ZOrder" xml:space="preserve">
-    <value>43</value>
+    <value>44</value>
   </data>
   <data name="CHK_resetapmonconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -517,7 +517,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_resetapmonconnect.ZOrder" xml:space="preserve">
-    <value>44</value>
+    <value>45</value>
   </data>
   <data name="CHK_mavdebug.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -547,7 +547,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_mavdebug.ZOrder" xml:space="preserve">
-    <value>45</value>
+    <value>46</value>
   </data>
   <data name="label107.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -574,7 +574,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label107.ZOrder" xml:space="preserve">
-    <value>46</value>
+    <value>47</value>
   </data>
   <data name="CMB_raterc.Items" xml:space="preserve">
     <value>-1</value>
@@ -640,7 +640,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_raterc.ZOrder" xml:space="preserve">
-    <value>47</value>
+    <value>48</value>
   </data>
   <data name="label104.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -667,7 +667,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label104.ZOrder" xml:space="preserve">
-    <value>48</value>
+    <value>49</value>
   </data>
   <data name="label103.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -694,7 +694,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label103.ZOrder" xml:space="preserve">
-    <value>49</value>
+    <value>50</value>
   </data>
   <data name="label102.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -721,7 +721,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label102.ZOrder" xml:space="preserve">
-    <value>50</value>
+    <value>51</value>
   </data>
   <data name="label101.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -751,7 +751,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label101.ZOrder" xml:space="preserve">
-    <value>51</value>
+    <value>52</value>
   </data>
   <data name="CMB_ratestatus.Items" xml:space="preserve">
     <value>-1</value>
@@ -817,7 +817,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_ratestatus.ZOrder" xml:space="preserve">
-    <value>52</value>
+    <value>53</value>
   </data>
   <data name="CMB_rateposition.Items" xml:space="preserve">
     <value>-1</value>
@@ -883,7 +883,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_rateposition.ZOrder" xml:space="preserve">
-    <value>53</value>
+    <value>54</value>
   </data>
   <data name="CMB_rateattitude.Items" xml:space="preserve">
     <value>-1</value>
@@ -946,7 +946,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_rateattitude.ZOrder" xml:space="preserve">
-    <value>54</value>
+    <value>55</value>
   </data>
   <data name="label99.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -974,7 +974,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label99.ZOrder" xml:space="preserve">
-    <value>55</value>
+    <value>56</value>
   </data>
   <data name="label98.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1004,7 +1004,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label98.ZOrder" xml:space="preserve">
-    <value>56</value>
+    <value>57</value>
   </data>
   <data name="label97.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1034,7 +1034,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label97.ZOrder" xml:space="preserve">
-    <value>57</value>
+    <value>58</value>
   </data>
   <data name="CMB_speedunits.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 195</value>
@@ -1055,7 +1055,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_speedunits.ZOrder" xml:space="preserve">
-    <value>58</value>
+    <value>59</value>
   </data>
   <data name="CMB_distunits.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 168</value>
@@ -1076,7 +1076,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_distunits.ZOrder" xml:space="preserve">
-    <value>59</value>
+    <value>60</value>
   </data>
   <data name="label96.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1106,7 +1106,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label96.ZOrder" xml:space="preserve">
-    <value>60</value>
+    <value>61</value>
   </data>
   <data name="label95.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1136,7 +1136,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label95.ZOrder" xml:space="preserve">
-    <value>61</value>
+    <value>62</value>
   </data>
   <data name="CHK_speechbattery.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1145,7 +1145,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speechbattery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>412, 89</value>
+    <value>521, 89</value>
   </data>
   <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 17</value>
@@ -1169,7 +1169,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechbattery.ZOrder" xml:space="preserve">
-    <value>62</value>
+    <value>63</value>
   </data>
   <data name="CHK_speechcustom.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1178,7 +1178,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speechcustom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>332, 89</value>
+    <value>441, 89</value>
   </data>
   <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
     <value>81, 17</value>
@@ -1202,7 +1202,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechcustom.ZOrder" xml:space="preserve">
-    <value>63</value>
+    <value>64</value>
   </data>
   <data name="CHK_speechmode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1211,7 +1211,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speechmode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>280, 89</value>
+    <value>389, 89</value>
   </data>
   <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 17</value>
@@ -1235,7 +1235,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechmode.ZOrder" xml:space="preserve">
-    <value>64</value>
+    <value>65</value>
   </data>
   <data name="CHK_speechwaypoint.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1244,7 +1244,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speechwaypoint.Location" type="System.Drawing.Point, System.Drawing">
-    <value>207, 89</value>
+    <value>316, 89</value>
   </data>
   <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
     <value>71, 17</value>
@@ -1268,7 +1268,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechwaypoint.ZOrder" xml:space="preserve">
-    <value>65</value>
+    <value>66</value>
   </data>
   <data name="label94.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1298,7 +1298,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label94.ZOrder" xml:space="preserve">
-    <value>66</value>
+    <value>67</value>
   </data>
   <data name="CMB_osdcolor.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 62</value>
@@ -1319,7 +1319,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_osdcolor.ZOrder" xml:space="preserve">
-    <value>67</value>
+    <value>68</value>
   </data>
   <data name="CMB_language.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 112</value>
@@ -1340,7 +1340,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_language.ZOrder" xml:space="preserve">
-    <value>68</value>
+    <value>69</value>
   </data>
   <data name="label93.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1370,7 +1370,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label93.ZOrder" xml:space="preserve">
-    <value>69</value>
+    <value>70</value>
   </data>
   <data name="CHK_enablespeech.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1400,7 +1400,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_enablespeech.ZOrder" xml:space="preserve">
-    <value>70</value>
+    <value>71</value>
   </data>
   <data name="CHK_hudshow.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1427,7 +1427,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_hudshow.ZOrder" xml:space="preserve">
-    <value>71</value>
+    <value>72</value>
   </data>
   <data name="label92.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1457,7 +1457,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label92.ZOrder" xml:space="preserve">
-    <value>72</value>
+    <value>73</value>
   </data>
   <data name="CMB_videosources.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 8</value>
@@ -1478,7 +1478,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_videosources.ZOrder" xml:space="preserve">
-    <value>73</value>
+    <value>74</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1508,7 +1508,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>30</value>
+    <value>31</value>
   </data>
   <data name="CHK_maprotation.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1535,7 +1535,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_maprotation.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>32</value>
   </data>
   <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1562,7 +1562,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>29</value>
   </data>
   <data name="CHK_disttohomeflightdata.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1589,7 +1589,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_disttohomeflightdata.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>30</value>
   </data>
   <data name="BUT_Joystick.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1616,7 +1616,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_Joystick.ZOrder" xml:space="preserve">
-    <value>74</value>
+    <value>75</value>
   </data>
   <data name="BUT_videostop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1643,7 +1643,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_videostop.ZOrder" xml:space="preserve">
-    <value>75</value>
+    <value>76</value>
   </data>
   <data name="BUT_videostart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1670,7 +1670,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_videostart.ZOrder" xml:space="preserve">
-    <value>76</value>
+    <value>77</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1700,7 +1700,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>28</value>
   </data>
   <data name="txt_log_dir.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 368</value>
@@ -1721,7 +1721,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txt_log_dir.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>27</value>
   </data>
   <data name="BUT_logdirbrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1748,7 +1748,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_logdirbrowse.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>26</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1778,7 +1778,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>25</value>
   </data>
   <data name="CMB_theme.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 394</value>
@@ -1799,7 +1799,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_theme.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>24</value>
   </data>
   <data name="BUT_themecustom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1826,7 +1826,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_themecustom.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>23</value>
   </data>
   <data name="CHK_speecharmdisarm.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1835,7 +1835,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speecharmdisarm.Location" type="System.Drawing.Point, System.Drawing">
-    <value>594, 89</value>
+    <value>703, 89</value>
   </data>
   <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
     <value>81, 17</value>
@@ -1859,7 +1859,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speecharmdisarm.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>22</value>
   </data>
   <data name="BUT_Vario.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1886,7 +1886,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_Vario.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="chk_analytics.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1916,7 +1916,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_analytics.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>20</value>
   </data>
   <data name="CHK_beta.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1946,7 +1946,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_beta.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="CHK_Password.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1976,7 +1976,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_Password.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="CHK_speechlowspeed.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1985,7 +1985,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_speechlowspeed.Location" type="System.Drawing.Point, System.Drawing">
-    <value>671, 89</value>
+    <value>780, 89</value>
   </data>
   <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 17</value>
@@ -2009,7 +2009,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechlowspeed.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="CHK_showairports.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2039,7 +2039,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_showairports.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="chk_ADSB.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2069,7 +2069,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_ADSB.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="chk_tfr.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2099,7 +2099,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_tfr.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="chk_temp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -2129,7 +2129,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_temp.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="chk_norcreceiver.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2159,7 +2159,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_norcreceiver.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="but_AAsignin.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2186,7 +2186,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;but_AAsignin.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="CMB_Layout.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 421</value>
@@ -2207,7 +2207,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_Layout.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2237,7 +2237,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="CHK_AutoParamCommit.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2264,7 +2264,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_AutoParamCommit.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="chk_shownofly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2294,7 +2294,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_shownofly.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2324,7 +2324,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="CMB_altunits.Location" type="System.Drawing.Point, System.Drawing">
     <value>320, 168</value>
@@ -2345,7 +2345,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_altunits.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="num_gcsid.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 448</value>
@@ -2366,7 +2366,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;num_gcsid.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2396,7 +2396,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="CHK_params_bg.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2426,7 +2426,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_params_bg.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="chk_slowMachine.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2456,6 +2456,39 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_slowMachine.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CHK_speechArmedOnly.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechArmedOnly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Location" type="System.Drawing.Point, System.Drawing">
+    <value>206, 89</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>109, 17</value>
+  </data>
+  <data name="CHK_speechArmedOnly.TabIndex" type="System.Int32, mscorlib">
+    <value>124</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Text" xml:space="preserve">
+    <value>Only when Armed</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.Name" xml:space="preserve">
+    <value>CHK_speechArmedOnly</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -2465,7 +2498,7 @@
     <value>True</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>816, 576</value>
+    <value>906, 576</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ConfigPlanner</value>

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -457,6 +457,18 @@ namespace MissionPlanner
             }
         }
 
+        public static bool speech_armed_only = false;
+        public static bool speechEnabled()
+        {
+            if (!speechEnable) {
+                return false;
+            }
+            if (speech_armed_only) {
+                return MainV2.comPort.MAV.cs.armed;
+            }
+            return true;
+        }
+
         /// <summary>
         /// spech engine static class
         /// </summary>
@@ -2696,7 +2708,7 @@ namespace MissionPlanner
                     }
 
                     // 30 seconds interval speech options
-                    if (speechEnable && speechEngine != null && (DateTime.Now - speechcustomtime).TotalSeconds > 30 &&
+                    if (speechEnabled() && speechEngine != null && (DateTime.Now - speechcustomtime).TotalSeconds > 30 &&
                         (MainV2.comPort.logreadmode || comPort.BaseStream.IsOpen))
                     {
                         if (MainV2.speechEngine.IsReady)
@@ -2740,7 +2752,7 @@ namespace MissionPlanner
                     }
 
                     // speech for airspeed alerts
-                    if (speechEnable && speechEngine != null && (DateTime.Now - speechlowspeedtime).TotalSeconds > 10 &&
+                    if (speechEnabled() && speechEngine != null && (DateTime.Now - speechlowspeedtime).TotalSeconds > 10 &&
                         (MainV2.comPort.logreadmode || comPort.BaseStream.IsOpen))
                     {
                         if (Settings.Instance.GetBoolean("speechlowspeedenabled") == true &&
@@ -2777,7 +2789,7 @@ namespace MissionPlanner
                     }
 
                     // speech altitude warning - message high warning
-                    if (speechEnable && speechEngine != null &&
+                    if (speechEnabled() && speechEngine != null &&
                         (MainV2.comPort.logreadmode || comPort.BaseStream.IsOpen))
                     {
                         float warnalt = float.MaxValue;
@@ -2858,7 +2870,7 @@ namespace MissionPlanner
                     {
                         var msg = "WARNING No Data for " + (int)(DateTime.Now - MainV2.comPort.MAV.lastvalidpacket).TotalSeconds + " Seconds";
                         MainV2.comPort.MAV.cs.messageHigh = msg;
-                        if (speechEnable && speechEngine != null)
+                        if (speechEnabled() && speechEngine != null)
                         {
                             if (MainV2.speechEngine.IsReady)
                             {


### PR DESCRIPTION
This adds a check box to enable speech only when armed. 

![image](https://user-images.githubusercontent.com/33176108/163678621-5391df21-c947-4b53-985b-8673995187dd.png)

Speech is very useful, but somewhat annoying when disarmed, log download for example will often result in a few pre-arm warnings that will get announced. I mute the PC to avoid this but then often end up forgetting to un-mute again for the next flight. 

My first go at "GUI" stuff in MP. 

I suspect the `Xamarin` stuff is wrong, it seems it is not used for the windows build? How can I test?