### PR TITLE
Plugins:Make the Mission Planner neutral

### DIFF
--- a/Plugins/example16-donate.cs
+++ b/Plugins/example16-donate.cs
@@ -44,6 +44,8 @@ namespace donate
 
         public override bool Loaded()
         {
+            return true;
+            
             var MenuCustom = new System.Windows.Forms.ToolStripButton();
             MenuCustom.Name = "MenuCustom";
             MenuCustom.Margin = new System.Windows.Forms.Padding(0);


### PR DESCRIPTION
I would like the Mission Planner to be neutral.
I think that donations to Ukraine should be collected on Facebook at CUBEPILOT .ORG.
I have responded not to show.

AFTER:
![Screenshot from 2022-04-24 18-19-37](https://user-images.githubusercontent.com/646194/164969914-5bb4ac00-632a-4137-9b08-ea5467a60135.png)

