### PR TITLE
ArduPilot: State fix Battery Voltage Reporting for Batts >65.5V

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -2537,7 +2537,6 @@ namespace MissionPlanner
 
                             load = sysstatus.load / 10.0f;
 
-                            battery_voltage = sysstatus.voltage_battery / 1000.0f;
                             battery_remaining = sysstatus.battery_remaining;
                             current = sysstatus.current_battery / 100.0f;
 
@@ -2660,7 +2659,6 @@ namespace MissionPlanner
 
                         {
                             var bat = mavLinkMessage.ToStructure<MAVLink.mavlink_battery2_t>();
-                            _battery_voltage2 = bat.voltage / 1000.0f;
                             current2 = bat.current_battery / 100.0f;
                         }
 
@@ -2669,6 +2667,11 @@ namespace MissionPlanner
 
                         {
                             var bats = mavLinkMessage.ToStructure<MAVLink.mavlink_battery_status_t>();
+
+                            // Compute the total battery system voltage by adding up all the individual cells
+                            // This is used due to the 65.536V max. voltage limitation of sysstatus.battery_voltage and battery_status.voltage
+                            // This is available even if the montior type doesn't support cell monitoring
+                            double temp_battery_voltage = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0) + bats.voltages_ext.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
 
                             if (bats.id == 0)
                             {
@@ -2705,6 +2708,7 @@ namespace MissionPlanner
 
                                 battery_usedmah = bats.current_consumed;
                                 battery_remaining = bats.battery_remaining;
+                                battery_voltage = temp_battery_voltage;
                                 _current = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp = bats.temperature / 100.0;
@@ -2714,6 +2718,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah2 = bats.current_consumed;
                                 battery_remaining2 = bats.battery_remaining;
+                                battery_voltage2 = temp_battery_voltage;
                                 _current2 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp2 = bats.temperature / 100.0;
@@ -2723,7 +2728,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah3 = bats.current_consumed;
                                 battery_remaining3 = bats.battery_remaining;
-                                battery_voltage3 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage3 = temp_battery_voltage;
                                 current3 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp3 = bats.temperature / 100.0;
@@ -2733,7 +2738,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah4 = bats.current_consumed;
                                 battery_remaining4 = bats.battery_remaining;
-                                battery_voltage4 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage4 = temp_battery_voltage;
                                 current4 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp4 = bats.temperature / 100.0;
@@ -2743,7 +2748,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah5 = bats.current_consumed;
                                 battery_remaining5 = bats.battery_remaining;
-                                battery_voltage5 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage5 = temp_battery_voltage;
                                 current5 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp5 = bats.temperature / 100.0;
@@ -2753,7 +2758,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah6 = bats.current_consumed;
                                 battery_remaining6 = bats.battery_remaining;
-                                battery_voltage6 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage6 = temp_battery_voltage;
                                 current6 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp6 = bats.temperature / 100.0;
@@ -2763,7 +2768,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah7 = bats.current_consumed;
                                 battery_remaining7 = bats.battery_remaining;
-                                battery_voltage7 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage7 = temp_battery_voltage;
                                 current7 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp7 = bats.temperature / 100.0;
@@ -2773,7 +2778,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah8 = bats.current_consumed;
                                 battery_remaining8 = bats.battery_remaining;
-                                battery_voltage8 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage8 = temp_battery_voltage;
                                 current8 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp8 = bats.temperature / 100.0;
@@ -2783,7 +2788,7 @@ namespace MissionPlanner
                             {
                                 battery_usedmah9 = bats.current_consumed;
                                 battery_remaining9 = bats.battery_remaining;
-                                battery_voltage9 = bats.voltages.Sum(a => a != ushort.MaxValue ? a / 1000.0 : 0);
+                                battery_voltage9 = temp_battery_voltage;
                                 current9 = bats.current_battery / 100.0f;
                                 if (bats.temperature != short.MaxValue)
                                     battery_temp9 = bats.temperature / 100.0;


### PR DESCRIPTION
Request from ArduPilot Partner

This allows the HUD to report voltages greater than 65V. This limitation comes from the mavlink fields only being uint16s.

In ArduPilot we fill the cell fields to overcome this deficiency even if the monitor type doesn't report cell voltages.

I'm not sure how to make this compatible with systems not reporting the `battery_status` message. But I'm not sure  how old that message is or how important compatibility is with systems not reporting battery_status?

I think the battery2 message isn't used anymore as well?

![image](https://user-images.githubusercontent.com/69225461/165397349-75929010-ffcc-4ab0-bf43-e1fcccd2eee6.png)
