### PR TITLE
Change the indentation of DO_AUX_FUNCTION

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -111,15 +111,15 @@
       <Y></Y>
       <Z></Z>
     </DO_LAND_START>
-		<DO_AUX_FUNCTION>
-			<P1>AuxFunction</P1>
-			<P2>SwitchPosition</P2>
-			<P3></P3>
-			<P4></P4>
-			<X></X>
-			<Y></Y>
-			<Z></Z>
-		</DO_AUX_FUNCTION>
+    <DO_AUX_FUNCTION>
+      <P1>AuxFunction</P1>
+      <P2>SwitchPosition</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_AUX_FUNCTION>
     <DO_GUIDED_LIMITS>
       <P1>timeout S</P1>
       <P2>min alt</P2>
@@ -784,15 +784,15 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </DO_SET_ROI>
-		<DO_AUX_FUNCTION>
-			<P1>AuxFunction</P1>
-			<P2>SwitchPosition</P2>
-			<P3></P3>
-			<P4></P4>
-			<X></X>
-			<Y></Y>
-			<Z></Z>
-		</DO_AUX_FUNCTION>
+    <DO_AUX_FUNCTION>
+      <P1>AuxFunction</P1>
+      <P2>SwitchPosition</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_AUX_FUNCTION>
     <DO_SET_REVERSE>
       <P1>Direction (0=F,1=R)</P1>
       <P2></P2>


### PR DESCRIPTION
I don't think indentation is necessary unless the DO_AUX_FUNCTION command needs to be emphasized with indentation.
Indentation for other commands is whitespace.
The indent for this command is tabs.