### PR TITLE
mavcmd: move SCRIPT_TIME up and add ATTITUDE_TIME

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -111,6 +111,15 @@
       <Y></Y>
       <Z></Z>
     </SCRIPT_TIME>
+    <ATTITUDE_TIME>
+      <P1>Time (sec)</P1>
+      <P2>Roll</P2>
+      <P3>Pitch</P3>
+      <P4>Yaw</P4>
+      <X>ClimbRate</X>
+      <Y></Y>
+      <Z></Z>
+    </ATTITUDE_TIME>
     <DO_LAND_START>
       <P1></P1>
       <P2></P2>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -102,6 +102,15 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </PAYLOAD_PLACE>
+    <SCRIPT_TIME>
+      <P1>command</P1>
+      <P2>timeout</P2>
+      <P3>arg1</P3>
+      <P4>arg2</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SCRIPT_TIME>
     <DO_LAND_START>
       <P1></P1>
       <P2></P2>
@@ -300,15 +309,6 @@
       <Y></Y>
       <Z></Z>
     </DO_SPRAYER>
-    <SCRIPT_TIME>
-      <P1>command</P1>
-      <P2>timeout</P2>
-      <P3>arg1</P3>
-      <P4>arg2</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </SCRIPT_TIME>
     <DO_AUTOTUNE_ENABLE>
       <P1>enable</P1>
       <P2></P2>


### PR DESCRIPTION
This resolves two minor issues that I've raised recently

- https://github.com/ArduPilot/MissionPlanner/issues/2876
- https://github.com/ArduPilot/MissionPlanner/issues/2864

I have lightly tested this and the commands appear in the correct place.  The only issue is that Mavlink.cs doesn't contain ATTITUDE_TIME=42703 on my machine but I suspect a proper re-build using the latest ArduPilot/mavlink will resolve this.
![image](https://user-images.githubusercontent.com/1498098/172083416-7ae6a9bb-5e14-491d-8af0-b4b0417fcec2.png)
