### PR TITLE
GCSViews: Allow flight mode channels up to channel 16

### DIFF
--- a/GCSViews/ConfigurationView/ConfigFlightModes.cs
+++ b/GCSViews/ConfigurationView/ConfigFlightModes.cs
@@ -287,6 +287,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     case 8:
                         pwm = MainV2.comPort.MAV.cs.ch8in;
                         break;
+                    case 9:
+                        pwm = MainV2.comPort.MAV.cs.ch9in;
+                        break;
+                    case 10:
+                        pwm = MainV2.comPort.MAV.cs.ch10in;
+                        break;
+                    case 11:
+                        pwm = MainV2.comPort.MAV.cs.ch11in;
+                        break;
+                    case 12:
+                        pwm = MainV2.comPort.MAV.cs.ch12in;
+                        break;
+                    case 13:
+                        pwm = MainV2.comPort.MAV.cs.ch13in;
+                        break;
+                    case 14:
+                        pwm = MainV2.comPort.MAV.cs.ch14in;
+                        break;
+                    case 15:
+                        pwm = MainV2.comPort.MAV.cs.ch15in;
+                        break;
+                    case 16:
+                        pwm = MainV2.comPort.MAV.cs.ch16in;
+                        break;
                     default:
 
                         break;


### PR DESCRIPTION
I have an inexpensive radio that supports 16 channels.
ArduPilot supports up to channel 16.
I allow up to channel 16 to be assigned as a flight mode switch.

AFTER
![Screenshot from 2022-06-13 05-26-42](https://user-images.githubusercontent.com/646194/173252716-540560f5-00c4-4e47-836a-98f3d6ed1d3d.png)
