### PR TITLE
ArduPilot: Temperature Reporting

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -2903,6 +2903,7 @@ namespace MissionPlanner
                         }
 
                         break;
+                    // SENSOR_OFFSET message was removed in Copter-4.2
                     case (uint)MAVLink.MAVLINK_MSG_ID.SENSOR_OFFSETS:
 
                         {

--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -2875,6 +2875,8 @@ namespace MissionPlanner
                             var pres = mavLinkMessage.ToStructure<MAVLink.mavlink_scaled_pressure_t>();
                             press_abs = pres.press_abs;
                             press_temp = pres.temperature;
+
+                            airspeed1_temp = pres.temperature_press_diff;
                         }
 
                         break;
@@ -2884,6 +2886,8 @@ namespace MissionPlanner
                             var pres = mavLinkMessage.ToStructure<MAVLink.mavlink_scaled_pressure2_t>();
                             press_abs2 = pres.press_abs;
                             press_temp2 = pres.temperature;
+
+                            airspeed2_temp = pres.temperature_press_diff;
                         }
 
                         break;

--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -502,9 +502,9 @@ namespace MissionPlanner
         [GroupText("Sensor")]
         public float magfield => (float)Math.Sqrt(Math.Pow(mx, 2) + Math.Pow(my, 2) + Math.Pow(mz, 2));
 
-        [DisplayText("IMU Temperature")]
+        [DisplayText("IMU1 Temperature")]
         [GroupText("Sensor")]
-        public float imu_temp { get; set; }
+        public float imu1_temp { get; set; }
 
         // accel2
         [DisplayText("Accel2 X")]
@@ -559,7 +559,7 @@ namespace MissionPlanner
 
         [DisplayText("IMU2 Temperature")]
         [GroupText("Sensor")]
-        public float imu_temp2 { get; set; }
+        public float imu2_temp { get; set; }
 
         // accel3
         [DisplayText("Accel3 X")]
@@ -615,7 +615,7 @@ namespace MissionPlanner
 
         [DisplayText("IMU3 Temperature")]
         [GroupText("Sensor")]
-        public float imu_temp3 { get; set; }
+        public float imu3_temp { get; set; }
 
         // hygrometer1
       [DisplayText("hygrotemp1 (cdegC)")]
@@ -3344,7 +3344,7 @@ namespace MissionPlanner
                             my = imu.ymag;
                             mz = imu.zmag;
 
-                            imu_temp = imu.temperature / 100.0f;
+                            imu1_temp = imu.temperature / 100.0f;
 
                             var timesec = imu.time_usec * 1.0e-6;
 
@@ -3382,7 +3382,7 @@ namespace MissionPlanner
                             my = imu.ymag;
                             mz = imu.zmag;
 
-                            //MAVLink.packets[(byte)MAVLink.MSG_NAMES.RAW_IMU);
+                            imu1_temp = imu.temperature / 100.0f;
                         }
 
                         break;
@@ -3403,7 +3403,7 @@ namespace MissionPlanner
                             my2 = imu2.ymag;
                             mz2 = imu2.zmag;
 
-                            imu_temp2 = imu2.temperature / 100.0f;
+                            imu2_temp = imu2.temperature / 100.0f;
                         }
 
 
@@ -3425,7 +3425,7 @@ namespace MissionPlanner
                             my3 = imu3.ymag;
                             mz3 = imu3.zmag;
 
-                            imu_temp3 = imu3.temperature / 100.0f;
+                            imu3_temp = imu3.temperature / 100.0f;
                         }
 
                         break;

--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -437,6 +437,12 @@ namespace MissionPlanner
         [DisplayText("Airspeed Ratio")]
         public float asratio { get; set; }
 
+        [DisplayText("Airspeed1 Temperature")]
+        public float airspeed1_temp { get; set; }
+
+        [DisplayText("Airspeed2 Temperature")]
+        public float airspeed2_temp { get; set; }
+
         [GroupText("Position")]
         [DisplayText("GroundSpeed (speed)")]
         public float groundspeed
@@ -2157,7 +2163,7 @@ namespace MissionPlanner
                             gpsstatus = highlatency.gps_fix_type;
                             battery_remaining = highlatency.battery_remaining;
                             press_temp = highlatency.temperature;
-                            raw_temp = highlatency.temperature_air;
+                            airspeed1_temp = highlatency.temperature_air;
                             failsafe = highlatency.failsafe > 0;
                             wpno = highlatency.wp_num;
                             wp_dist = highlatency.wp_distance;
@@ -2234,7 +2240,7 @@ namespace MissionPlanner
                             wind_dir = highlatency.wind_heading * 2;
                             gpshdop = highlatency.eph;
                             // epv
-                            raw_temp = highlatency.temperature_air;
+                            airspeed1_temp = highlatency.temperature_air;
                             climbrate = highlatency.climb_rate;
                             battery_remaining = highlatency.battery;
 


### PR DESCRIPTION
Fixes HIGH_LATENCY messages to place air_temperature fields into air temperature and not IMU temperature

Adds air_temperature fields

Adds a note so so that handling of SENSOR_OFFSETS can be removed in the future

Renames IMU_Temperature fields: I think we should standardize around the idea of `INSTANCE1_sensor`  `INSTASNCE2_sensor`

Not IMU_Temp1,  IMU_Temp2   ....  
The first IMU doesn't have three temperature sensors ... 

I realize there are a lot of fields listed the other way and a few the way I'm suggesting.

BTW thanks for adding the IMU temperatures. I didn't notice you fixed it until I tried to rebase on master. That is when I saw the difference in naming ;)