### PR TITLE
ConfigBatteryMonitoring: Change missing item string

### DIFF
--- a/GCSViews/ConfigurationView/ConfigBatteryMonitoring.resx
+++ b/GCSViews/ConfigurationView/ConfigBatteryMonitoring.resx
@@ -181,7 +181,7 @@
     <value>160, 68</value>
   </data>
   <data name="CMB_batmonsensortype.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 21</value>
+    <value>162, 20</value>
   </data>
   <data name="CMB_batmonsensortype.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -208,7 +208,7 @@
     <value>330, 44</value>
   </data>
   <data name="label29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 13</value>
+    <value>92, 12</value>
   </data>
   <data name="label29.TabIndex" type="System.Int32, mscorlib">
     <value>43</value>
@@ -235,7 +235,7 @@
     <value>106, 45</value>
   </data>
   <data name="label30.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
+    <value>48, 11</value>
   </data>
   <data name="label30.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -256,10 +256,10 @@
     <value>8</value>
   </data>
   <data name="TXT_battcapacity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 41</value>
+    <value>425, 45</value>
   </data>
   <data name="TXT_battcapacity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
+    <value>50, 19</value>
   </data>
   <data name="TXT_battcapacity.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -688,7 +688,7 @@
     <value>160, 95</value>
   </data>
   <data name="CMB_HWVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 21</value>
+    <value>162, 20</value>
   </data>
   <data name="CMB_HWVersion.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -739,10 +739,10 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>476, 44</value>
+    <value>481, 45</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 13</value>
+    <value>28, 12</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -772,7 +772,7 @@
     <value>333, 67</value>
   </data>
   <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>140, 17</value>
+    <value>151, 16</value>
   </data>
   <data name="CHK_speechbattery.TabIndex" type="System.Int32, mscorlib">
     <value>65</value>
@@ -799,7 +799,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="TXT_measuredvoltage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 19</value>
   </data>
   <data name="TXT_measuredvoltage.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -823,7 +823,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="TXT_voltage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 19</value>
   </data>
   <data name="TXT_voltage.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
@@ -853,7 +853,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="label35.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
+    <value>107, 12</value>
   </data>
   <data name="label35.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -880,7 +880,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="TXT_divider_VOLT_MULT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 19</value>
   </data>
   <data name="TXT_divider_VOLT_MULT.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -910,7 +910,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="label34.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 13</value>
+    <value>143, 12</value>
   </data>
   <data name="label34.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -937,7 +937,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="TXT_AMP_PERVLT.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 19</value>
   </data>
   <data name="TXT_AMP_PERVLT.TabIndex" type="System.Int32, mscorlib">
     <value>38</value>
@@ -967,7 +967,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
-    <value>135, 13</value>
+    <value>145, 12</value>
   </data>
   <data name="label33.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -1000,7 +1000,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 13</value>
+    <value>149, 12</value>
   </data>
   <data name="label32.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -1027,7 +1027,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="txt_current.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 19</value>
   </data>
   <data name="txt_current.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1057,7 +1057,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 13</value>
+    <value>102, 12</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -1084,7 +1084,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="txt_meascurrent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 19</value>
   </data>
   <data name="txt_meascurrent.TabIndex" type="System.Int32, mscorlib">
     <value>40</value>
@@ -1114,7 +1114,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 13</value>
+    <value>108, 12</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>39</value>


### PR DESCRIPTION
MONITOR was displayed in MONITO.
I changed the layout.

AFTER
![Screenshot from 2022-06-23 07-50-18](https://user-images.githubusercontent.com/646194/175168608-078f9dcf-c4ad-403c-a00a-d9b9c23c8f60.png)

BEFORE
![Screenshot from 2022-06-22 08-28-48](https://user-images.githubusercontent.com/646194/175171858-7f2df375-3dc1-460c-b82a-b97a20500d74.png)
