### PR TITLE
ParamCompare: Compare float values not strings so that matches are correct

### DIFF
--- a/Controls/paramcompare.cs
+++ b/Controls/paramcompare.cs
@@ -40,7 +40,7 @@ namespace MissionPlanner.Controls
                 {
                     if (param.ContainsKey(value) && param2.ContainsKey(value))
                     {
-                        if (((double)param[value]).ToString() != param2[value].ToString())
+                        if ((float)param[value] != (float)param2[value])
                         // this will throw is there is no matching key
                         {
                             Console.WriteLine("{0} {1} vs {2}", value, param[value], param2[value]);


### PR DESCRIPTION
This should fix the problem where the values are identical within float precision but show as different. 

Not sure if this would work in PX4 though.... since ArduPilot doesn't have strings in parameters.

Before PR
![image](https://user-images.githubusercontent.com/69225461/175194621-c1a434f2-0c8b-4f53-ae4e-e3d3195b77f7.png)


After PR:
![image](https://user-images.githubusercontent.com/69225461/175195020-b3aedbae-ec09-4037-9e2d-85989ade0146.png)
