### PR TITLE
Mavlink: Display the number of parameters read

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -1923,7 +1923,17 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                                  (indexsreceived.Count * 100) / param_total);
                         if (frmProgressReporter != null)
                             this.frmProgressReporter.UpdateProgressAndStatus(
-                                (indexsreceived.Count * 100) / param_total, "Already Got param " + paramID);
+                                (indexsreceived.Count * 100) / param_total, "Already Got param " + "(" + indexsreceived.Count.ToString() + "/" + param_total.ToString() + ") " + paramID);
+                        return true;
+                    }
+                    // check if we future have it
+                    if (indexsreceived.Count < par.param_index)
+                    {
+                        log.Info("Future got " + (par.param_index) + " '" + paramID + "' " +
+                                 (indexsreceived.Count * 100) / param_total);
+                        if (frmProgressReporter != null)
+                            this.frmProgressReporter.UpdateProgressAndStatus(
+                                (indexsreceived.Count * 100) / param_total, "Future Got param " + "(" + indexsreceived.Count.ToString() + "/" + param_total.ToString() + ") " + paramID);
                         return true;
                     }
 
@@ -1962,7 +1972,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
 
                     if (frmProgressReporter != null)
                         this.frmProgressReporter.UpdateProgressAndStatus((indexsreceived.Count * 100) / param_total,
-                            Strings.Gotparam + paramID);
+                            Strings.Gotparam + "(" + indexsreceived.Count.ToString() + "/" + param_total.ToString() + ") " + paramID);
 
                     // we hit the last param - lets escape eq total = 176 index = 0-175
                     if (par.param_index == (param_total - 1))


### PR DESCRIPTION
It takes me a long time to read all the config parameters.
I can visualize the waiting time by displaying the numbers.
I don't see a progress bar indicating how many or few parameters there are.

I am receiving config parameters and the FC sends me updated parameter values on its own.
I have tried to ignore future params.
I can receive future parameters later.

![IMG-8967](https://user-images.githubusercontent.com/646194/176999389-135dd24f-0988-406c-9cec-5b8e76a17506.jpg)
![IMG-8968](https://user-images.githubusercontent.com/646194/176999393-f329ec1c-eabe-4b55-8d98-ed9b863817e4.jpg)