### PR TITLE
MavCmd: alphebetise and fixup rover command list

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -837,15 +837,6 @@
       <Y></Y>
       <Z></Z>
     </DO_CHANGE_SPEED>
-    <DO_SET_HOME>
-      <P1>Current(1)/Spec(0)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </DO_SET_HOME>
     <DO_SET_RELAY>
       <P1>Relay No</P1>
       <P2>off(0)/on(1)</P2>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -775,9 +775,9 @@
       <Z></Z>
     </DO_AUX_FUNCTION>
     <DO_CHANGE_SPEED>
-      <P1>Type (0=as 1=gs)</P1>
+      <P1></P1>
       <P2>Speed (m/s)</P2>
-      <P3>Throttle(%)</P3>
+      <P3></P3>
       <P4></P4>
       <X></X>
       <Y></Y>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -729,6 +729,15 @@
       <Y></Y>
       <Z></Z>
     </DELAY>
+    <GUIDED_ENABLE>
+      <P1>on=1/off=0</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </GUIDED_ENABLE>
     <LOITER_UNLIM>
       <P1></P1>
       <P2></P2>
@@ -747,6 +756,15 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </LOITER_TIME>
+    <SCRIPT_TIME>
+      <P1>command</P1>
+      <P2>timeout</P2>
+      <P3>arg1</P3>
+      <P4>arg2</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SCRIPT_TIME>
     <SET_YAW_SPEED>
       <P1>angle(CD)</P1>
       <P2>Speed(0..1)</P2>
@@ -819,6 +837,15 @@
       <Y></Y>
       <Z></Z>
     </DO_JUMP>
+    <DO_GUIDED_LIMITS>
+      <P1>timeout S</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4>max dist</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_GUIDED_LIMITS>
     <DO_MOUNT_CONFIGURE>
       <P1></P1>
       <P2></P2>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -714,7 +714,7 @@
     <LOITER_UNLIM>
       <P1></P1>
       <P2></P2>
-      <P3>Dir 1=CW</P3>
+      <P3></P3>
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
@@ -723,7 +723,7 @@
     <LOITER_TIME>
       <P1>Time s</P1>
       <P2></P2>
-      <P3>Dir 1=CW</P3>
+      <P3></P3>
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
@@ -734,9 +734,9 @@
       <P2></P2>
       <P3></P3>
       <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
     </RETURN_TO_LAUNCH>
     <CONDITION_DELAY>
       <P1>Time (sec)</P1>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -793,21 +793,21 @@
       <Z></Z>
     </DO_CHANGE_SPEED>
     <DO_DIGICAM_CONFIGURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
+      <P1>Mode</P1>
+      <P2>Shutter Speed</P2>
+      <P3>Aperture</P3>
+      <P4>ISO</P4>
+      <X>ExposureMode</X>
+      <Y>CommandID</Y>
       <Z></Z>
     </DO_DIGICAM_CONFIGURE>
     <DO_DIGICAM_CONTROL>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
+      <P1>On/Off</P1>
+      <P2>Zoom Position</P2>
+      <P3>Zoom Step</P3>
+      <P4>Focus Lock</P4>
+      <X>Shutter Cmd</X>
+      <Y>CommandID</Y>
       <Z></Z>
     </DO_DIGICAM_CONTROL>
     <DO_GIMBAL_MANAGER_PITCHYAW>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -618,15 +618,6 @@
       <Y>CommandID</Y>
       <Z></Z>
     </DO_DIGICAM_CONTROL>
-    <DO_MOUNT_CONFIGURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_MOUNT_CONFIGURE>
     <DO_MOUNT_CONTROL>
       <P1>Pitch</P1>
       <P2>Roll</P2>
@@ -846,15 +837,6 @@
       <Y></Y>
       <Z></Z>
     </DO_GUIDED_LIMITS>
-    <DO_MOUNT_CONFIGURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_MOUNT_CONFIGURE>
     <DO_MOUNT_CONTROL>
       <P1>Pitch</P1>
       <P2>Roll</P2>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -711,6 +711,24 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </WAYPOINT>
+    <RETURN_TO_LAUNCH>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </RETURN_TO_LAUNCH>
+    <DELAY>
+      <P1>Seconds (or -1)</P1>
+      <P2>Hour UTC (or -1)</P2>
+      <P3>Minute UTC (or -1)</P3>
+      <P4>Second UTC</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DELAY>
     <LOITER_UNLIM>
       <P1></P1>
       <P2></P2>
@@ -729,33 +747,6 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </LOITER_TIME>
-    <RETURN_TO_LAUNCH>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </RETURN_TO_LAUNCH>
-    <CONDITION_DELAY>
-      <P1>Time (sec)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </CONDITION_DELAY>
-    <CONDITION_DISTANCE>
-      <P1>Dist (m)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </CONDITION_DISTANCE>
     <SET_YAW_SPEED>
       <P1>angle(CD)</P1>
       <P2>Speed(0..1)</P2>
@@ -765,33 +756,6 @@
       <Y></Y>
       <Z></Z>
     </SET_YAW_SPEED>
-    <DELAY>
-      <P1>Seconds (or -1)</P1>
-      <P2>Hour UTC (or -1)</P2>
-      <P3>Minute UTC (or -1)</P3>
-      <P4>Second UTC</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DELAY>
-    <DO_GRIPPER>
-      <P1>Gripper No</P1>
-      <P2>drop(0)/grab(1)</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_GRIPPER>
-    <DO_SET_ROI>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </DO_SET_ROI>
     <DO_AUX_FUNCTION>
       <P1>AuxFunction</P1>
       <P2>SwitchPosition</P2>
@@ -801,33 +765,6 @@
       <Y></Y>
       <Z></Z>
     </DO_AUX_FUNCTION>
-    <DO_SET_REVERSE>
-      <P1>Direction (0=F,1=R)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_REVERSE>
-    <DO_SET_CAM_TRIGG_DIST>
-      <P1>Dist (m)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_CAM_TRIGG_DIST>
-    <DO_JUMP>
-      <P1>WP #</P1>
-      <P2>Repeat#</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_JUMP>
     <DO_CHANGE_SPEED>
       <P1>Type (0=as 1=gs)</P1>
       <P2>Speed (m/s)</P2>
@@ -837,42 +774,6 @@
       <Y></Y>
       <Z></Z>
     </DO_CHANGE_SPEED>
-    <DO_SET_RELAY>
-      <P1>Relay No</P1>
-      <P2>off(0)/on(1)</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_RELAY>
-    <DO_REPEAT_RELAY>
-      <P1>Relay No</P1>
-      <P2>Repeat#</P2>
-      <P3>Delay (s)</P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_REPEAT_RELAY>
-    <DO_SET_SERVO>
-      <P1>Ser No</P1>
-      <P2>PWM</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_SERVO>
-    <DO_REPEAT_SERVO>
-      <P1>Ser No</P1>
-      <P2>PWM</P2>
-      <P3>Repeat#</P3>
-      <P4>Delay (s)</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_REPEAT_SERVO>
     <DO_DIGICAM_CONFIGURE>
       <P1></P1>
       <P2></P2>
@@ -891,6 +792,33 @@
       <Y></Y>
       <Z></Z>
     </DO_DIGICAM_CONTROL>
+    <DO_GIMBAL_MANAGER_PITCHYAW>
+      <P1>Pitch Angle</P1>
+      <P2>Yaw Angle</P2>
+      <P3>Pitch Rate</P3>
+      <P4>Yaw Rate</P4>
+      <X>Flags</X>
+      <Y></Y>
+      <Z>Gimbal Id</Z>
+    </DO_GIMBAL_MANAGER_PITCHYAW>
+    <DO_GRIPPER>
+      <P1>Gripper No</P1>
+      <P2>drop(0)/grab(1)</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_GRIPPER>
+    <DO_JUMP>
+      <P1>WP #</P1>
+      <P2>Repeat#</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP>
     <DO_MOUNT_CONFIGURE>
       <P1></P1>
       <P2></P2>
@@ -909,24 +837,42 @@
       <Y></Y>
       <Z></Z>
     </DO_MOUNT_CONTROL>
-    <DO_GIMBAL_MANAGER_PITCHYAW>
-      <P1>Pitch Angle</P1>
-      <P2>Yaw Angle</P2>
-      <P3>Pitch Rate</P3>
-      <P4>Yaw Rate</P4>
-      <X>Flags</X>
+    <DO_REPEAT_RELAY>
+      <P1>Relay No</P1>
+      <P2>Repeat#</P2>
+      <P3>Delay (s)</P3>
+      <P4></P4>
+      <X></X>
       <Y></Y>
-      <Z>Gimbal Id</Z>
-    </DO_GIMBAL_MANAGER_PITCHYAW>
-    <DO_SPRAYER>
-      <P1>Sprayer Enable</P1>
+      <Z></Z>
+    </DO_REPEAT_RELAY>
+    <DO_REPEAT_SERVO>
+      <P1>Ser No</P1>
+      <P2>PWM</P2>
+      <P3>Repeat#</P3>
+      <P4>Delay (s)</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_REPEAT_SERVO>
+    <DO_SET_CAM_TRIGG_DIST>
+      <P1>Dist (m)</P1>
       <P2></P2>
       <P3></P3>
       <P4></P4>
       <X></X>
       <Y></Y>
       <Z></Z>
-    </DO_SPRAYER>
+    </DO_SET_CAM_TRIGG_DIST>
+    <DO_SET_RELAY>
+      <P1>Relay No</P1>
+      <P2>off(0)/on(1)</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_RELAY>
     <DO_SET_RESUME_REPEAT_DIST>
       <P1>Distance(m)</P1>
       <P2></P2>
@@ -936,5 +882,59 @@
       <Y></Y>
       <Z></Z>
     </DO_SET_RESUME_REPEAT_DIST>
+    <DO_SET_REVERSE>
+      <P1>Direction (0=F,1=R)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_REVERSE>
+    <DO_SET_ROI>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z>Alt</Z>
+    </DO_SET_ROI>
+    <DO_SET_SERVO>
+      <P1>Ser No</P1>
+      <P2>PWM</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_SERVO>
+    <DO_SPRAYER>
+      <P1>Sprayer Enable</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SPRAYER>
+    <CONDITION_DELAY>
+      <P1>Time (sec)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </CONDITION_DELAY>
+    <CONDITION_DISTANCE>
+      <P1>Dist (m)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </CONDITION_DISTANCE>
   </APRover>
 </CMD>


### PR DESCRIPTION
This PR makes a few changes primarily to the Rover command list (there is one change to the Plane list)

- alphebetise the rover command list.  Like Copter's list the nav commands appear at the top with the two most common commands (WAYPOINT and RETURN_TO_LAUNCH) appearing right at the top.  Other less popular nav commands are then in alphabetical order.  "do" and "conditional" commands are next and are all in alphabetical order.
- removed unsupported do-set-home
- removed unsupported do-mount-configure from both rover and **plane**'s lists.
- added titles to the do-digicam-configure and do-digicam-control messages (for rover)
- removed unsupported arguments from do-change-speed (for rover)

I have tested this on my local machine by copying the mavcmd.xml and confirming the commands appear as expected

![image](https://user-images.githubusercontent.com/1498098/178173972-71a6867b-a583-4df2-bc1f-f52dfb7cfce8.png)
