### PR TITLE
GMapMarkerWP: Show WP Numbers Fixes #2913

### DIFF
--- a/ExtLibs/Maps/GMapMarkerWP.cs
+++ b/ExtLibs/Maps/GMapMarkerWP.cs
@@ -55,8 +55,7 @@ namespace MissionPlanner.Maps
             if (txtsize.Width > 15)
                 midw -= 4;
 
-            if (Overlay.Control.Zoom> 16 || IsMouseOver)
-                g.DrawImageUnscaled(fontBitmaps[wpno], midw,midh);
+            g.DrawImageUnscaled(fontBitmaps[wpno], midw,midh);
         }
     }
 }

--- a/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerWP.cs
+++ b/ExtLibs/Xamarin/Xamarin/Maps/GMapMarkerWP.cs
@@ -53,8 +53,7 @@ namespace MissionPlanner.Maps
             if (txtsize.Width > 15)
                 midw -= 4;
 
-            if (Overlay.Control.Zoom> 16 || IsMouseOver)
-                g.DrawImageUnscaled(fontBitmaps[wpno], midw,midh);
+            g.DrawImageUnscaled(fontBitmaps[wpno], midw,midh);
         }
     }
 }


### PR DESCRIPTION
Fixes it so that WP labels show up at all zoom levels.

I'm not sure how compatible this is with android or other screen size builds though.

