### PR TITLE
Param refresh: add show again check box

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -179,12 +179,13 @@ namespace MissionPlanner
             return form;
         }
 
-        public static DialogResult MessageShowAgain(string title, string promptText)
+        public static DialogResult MessageShowAgain(string title, string promptText, bool show_cancel = false)
         {
             Form form = new Form();
             System.Windows.Forms.Label label = new System.Windows.Forms.Label();
             CheckBox chk = new CheckBox();
             Controls.MyButton buttonOk = new Controls.MyButton();
+            Controls.MyButton buttonCancel = new Controls.MyButton();
             System.ComponentModel.ComponentResourceManager resources =
                 new System.ComponentModel.ComponentResourceManager(typeof(MainV2));
             try
@@ -220,6 +221,7 @@ namespace MissionPlanner
                 form.Dispose();
                 chk.Dispose();
                 buttonOk.Dispose();
+                buttonCancel.Dispose();
                 label.Dispose();
                 return DialogResult.OK;
             }
@@ -228,13 +230,18 @@ namespace MissionPlanner
 
             buttonOk.Text = Strings.OK;
             buttonOk.DialogResult = DialogResult.OK;
-            buttonOk.Location = new Point(form.Right - 100, 80);
+            buttonOk.Location = new Point(form.Right - (show_cancel ? 180 : 100), 80);
+
+            buttonCancel.Text = Strings.Cancel;
+            buttonCancel.DialogResult = DialogResult.Cancel;
+            buttonCancel.Location = new Point(form.Right - 90, 80);
+            buttonCancel.Visible = show_cancel;
 
             label.SetBounds(9, 9, 372, 13);
 
             label.AutoSize = true;
 
-            form.Controls.AddRange(new Control[] { label, chk, buttonOk });
+            form.Controls.AddRange(new Control[] { label, chk, buttonOk, buttonCancel });
 
             if (link != "" && linktext != "")
             {

--- a/GCSViews/ConfigurationView/ConfigADSB.cs
+++ b/GCSViews/ConfigurationView/ConfigADSB.cs
@@ -214,8 +214,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!MainV2.comPort.BaseStream.IsOpen)
                 return;
 
-            if ((int)DialogResult.OK ==
-                CustomMessageBox.Show(Strings.WarningUpdateParamList, Strings.ERROR, MessageBoxButtons.OKCancel))
+            if (DialogResult.OK == Common.MessageShowAgain("Refresh Params", Strings.WarningUpdateParamList, true))
             {
                 ((Control)sender).Enabled = false;
 

--- a/GCSViews/ConfigurationView/ConfigFriendlyParams.cs
+++ b/GCSViews/ConfigurationView/ConfigFriendlyParams.cs
@@ -213,8 +213,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!MainV2.comPort.BaseStream.IsOpen)
                 return;
 
-            if ((int)DialogResult.OK ==
-                CustomMessageBox.Show(Strings.WarningUpdateParamList, Strings.ERROR, MessageBoxButtons.OKCancel))
+            if (DialogResult.OK ==  Common.MessageShowAgain("Refresh Params", Strings.WarningUpdateParamList, true))
             {
                 ((Control)sender).Enabled = false;
 

--- a/GCSViews/ConfigurationView/ConfigOSD.cs
+++ b/GCSViews/ConfigurationView/ConfigOSD.cs
@@ -308,8 +308,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!MainV2.comPort.BaseStream.IsOpen)
                 return;
 
-            if (!MainV2.comPort.MAV.cs.armed || (int)DialogResult.OK ==
-                CustomMessageBox.Show(Strings.WarningUpdateParamList, Strings.ERROR, MessageBoxButtons.OKCancel))
+            if (!MainV2.comPort.MAV.cs.armed || (DialogResult.OK ==  Common.MessageShowAgain("Refresh Params", Strings.WarningUpdateParamList, true)))
             {
                 this.Enabled = false;
 

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -337,8 +337,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!MainV2.comPort.BaseStream.IsOpen)
                 return;
 
-            if (!MainV2.comPort.MAV.cs.armed || (int)DialogResult.OK ==
-                CustomMessageBox.Show(Strings.WarningUpdateParamList, Strings.ERROR, MessageBoxButtons.OKCancel))
+            if (!MainV2.comPort.MAV.cs.armed || DialogResult.OK ==
+                Common.MessageShowAgain("Refresh Params", Strings.WarningUpdateParamList, true))
             {
                 ((Control)sender).Enabled = false;
 

--- a/GCSViews/ConfigurationView/ConfigRawParamsTree.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParamsTree.cs
@@ -295,8 +295,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!MainV2.comPort.BaseStream.IsOpen)
                 return;
 
-            if (!MainV2.comPort.MAV.cs.armed || (int)DialogResult.OK ==
-                CustomMessageBox.Show(Strings.WarningUpdateParamList, Strings.ERROR, MessageBoxButtons.OKCancel))
+            if (!MainV2.comPort.MAV.cs.armed || (DialogResult.OK ==  Common.MessageShowAgain("Refresh Params", Strings.WarningUpdateParamList, true)))
             {
                 ((Control)sender).Enabled = false;
 


### PR DESCRIPTION
Allows to skip the "DON'T DO THIS IF YOU ARE IN THE AIR" warning on param refresh. Currently:
![Capture](https://user-images.githubusercontent.com/33176108/180617491-2fdf4d0b-500f-48e7-b2a8-5791c8d6ce55.PNG)

With this change:
![image](https://user-images.githubusercontent.com/33176108/180617496-bd64bc30-1765-45d3-b3eb-0efcdfb09939.png)

Skip box works as expected.
