### PR TITLE
ArduPilot: Mavlink: MAVLinkInterface: retain defualt param value over…

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -1527,7 +1527,8 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                 return false;
             }
 
-            if (MAVlist[sysid, compid].param[paramname].Value == value && !force)
+            MAVLinkParam param = MAVlist[sysid, compid].param[paramname];
+            if (param.Value == value && !force)
             {
                 log.Warn("setParam " + paramname + " not modified as same");
                 return true;
@@ -1588,7 +1589,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                     {
                         var offset = Marshal.OffsetOf(typeof(mavlink_param_value_t), "param_value");
                         MAVlist[sysid, compid].param[st] = new MAVLinkParam(st, BitConverter.GetBytes(par.param_value),
-                            MAV_PARAM_TYPE.REAL32, (MAV_PARAM_TYPE) par.param_type);
+                            MAV_PARAM_TYPE.REAL32, (MAV_PARAM_TYPE) par.param_type, param.default_value);
                     }
                     else
                     {


### PR DESCRIPTION
… set and check

Follow up to https://github.com/ArduPilot/MissionPlanner/pull/2907. When writing prams the value re-fetched to check this replaced the original entry loosing the default value. This change stashes the param and then copy across the default.

Without we get defaults going to NAN after a pram change.
![image](https://user-images.githubusercontent.com/33176108/180885485-a166b83f-3670-4ae3-b1ce-9839252cb8f5.png)
