### PR TITLE
Add empty persistent panel between HUD and tabs

### DIFF
--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -170,6 +170,7 @@ namespace MissionPlanner.GCSViews
             this.but_bintolog = new MissionPlanner.Controls.MyButton();
             this.but_dflogtokml = new MissionPlanner.Controls.MyButton();
             this.BUT_loganalysis = new MissionPlanner.Controls.MyButton();
+            this.panel_persistent = new System.Windows.Forms.Panel();
             this.tableMap = new System.Windows.Forms.TableLayoutPanel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.zg1 = new ZedGraph.ZedGraphControl();
@@ -298,6 +299,7 @@ namespace MissionPlanner.GCSViews
             // SubMainLeft.Panel2
             // 
             this.SubMainLeft.Panel2.Controls.Add(this.tabControlactions);
+            this.SubMainLeft.Panel2.Controls.Add(this.panel_persistent);
             // 
             // hud1
             // 
@@ -2252,6 +2254,11 @@ namespace MissionPlanner.GCSViews
             this.BUT_loganalysis.UseVisualStyleBackColor = true;
             this.BUT_loganalysis.Click += new System.EventHandler(this.BUT_loganalysis_Click);
             // 
+            // panel_persistent
+            // 
+            resources.ApplyResources(this.panel_persistent, "panel_persistent");
+            this.panel_persistent.Name = "panel_persistent";
+            // 
             // tableMap
             // 
             resources.ApplyResources(this.tableMap, "tableMap");
@@ -2662,6 +2669,7 @@ namespace MissionPlanner.GCSViews
             this.MainH.ResumeLayout(false);
             this.SubMainLeft.Panel1.ResumeLayout(false);
             this.SubMainLeft.Panel2.ResumeLayout(false);
+            this.SubMainLeft.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.SubMainLeft)).EndInit();
             this.SubMainLeft.ResumeLayout(false);
             this.contextMenuStripHud.ResumeLayout(false);
@@ -2933,5 +2941,6 @@ namespace MissionPlanner.GCSViews
         private ToolStripMenuItem showIconsToolStripMenuItem;
         private ToolStripMenuItem multiLineToolStripMenuItem;
         private Controls.MyButton BUT_SendMSG;
+        public Panel panel_persistent;
     }
 }

--- a/GCSViews/FlightData.resx
+++ b/GCSViews/FlightData.resx
@@ -4798,6 +4798,33 @@
   <data name="&gt;&gt;tabControlactions.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="panel_persistent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panel_persistent.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panel_persistent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="panel_persistent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>298, 0</value>
+  </data>
+  <data name="panel_persistent.TabIndex" type="System.Int32, mscorlib">
+    <value>85</value>
+  </data>
+  <data name="&gt;&gt;panel_persistent.Name" xml:space="preserve">
+    <value>panel_persistent</value>
+  </data>
+  <data name="&gt;&gt;panel_persistent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel_persistent.Parent" xml:space="preserve">
+    <value>SubMainLeft.Panel2</value>
+  </data>
+  <data name="&gt;&gt;panel_persistent.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="&gt;&gt;SubMainLeft.Panel2.Name" xml:space="preserve">
     <value>SubMainLeft.Panel2</value>
   </data>

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -905,6 +905,9 @@
     <None Include="plugins\example19-multiforward.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="plugins\example21-persistentsimple.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Compile Include="plugins\example20-multiplepositions.cs" />
     <Compile Include="Utilities\AirMarket.cs">
       <SubType>UserControl</SubType>

--- a/Plugins/example21-persistentsimple.cs
+++ b/Plugins/example21-persistentsimple.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Windows.Forms;
+using MissionPlanner;
+using MissionPlanner.Plugin;
+using MissionPlanner.Controls;
+
+namespace PersistentSimpleActions
+{
+    public class PersistentSimpleActions : Plugin
+    {
+        private string _Name = "Persistent Simple Actions";
+        private string _Version = "0.1";
+        private string _Author = "Bob Long";
+
+        public override string Name { get { return _Name; } }
+        public override string Version { get { return _Version; } }
+        public override string Author { get { return _Author; } }
+
+        // CHANGE THIS TO TRUE TO USE THIS PLUGIN
+        public override bool Init() { return false; }
+
+        public override bool Loaded() 
+        {
+            MyButton button1 = new MyButton();
+            MyButton button2 = new MyButton();
+            MyButton button3 = new MyButton();
+            ToolTip toolTip1 = new ToolTip();
+
+            // Rename these .Text fields to any valid mode and the code will automatically work
+            button1.Text = "Auto";
+            button2.Text = "Loiter";
+            button3.Text = "RTL";
+
+            // 
+            // button1
+            // 
+            button1.Location = new System.Drawing.Point(4, 4);
+            button1.Size = new System.Drawing.Size(75, 23);
+            toolTip1.SetToolTip(button1, "Change mode to " + button1.Text);
+            button1.Click += new EventHandler(but_mode_Click);
+            // 
+            // button2
+            // 
+            button2.Location = new System.Drawing.Point(85, 4);
+            button2.Size = new System.Drawing.Size(75, 23);
+            toolTip1.SetToolTip(button2, "Change mode to " + button2.Text);
+            button2.Click += new EventHandler(but_mode_Click);
+            // 
+            // button3
+            // 
+            button3.Location = new System.Drawing.Point(166, 4);
+            button3.Size = new System.Drawing.Size(75, 23);
+            toolTip1.SetToolTip(button3, "Change mode to " + button3.Text);
+            button3.Click += new EventHandler(but_mode_Click);
+
+            // Increase the minimum size of the persistent panel. Not necessary, but adds a little
+            // more gap between the buttons and the tabs.
+            MainV2.instance.FlightData.panel_persistent.MinimumSize = new System.Drawing.Size(0, 35);
+
+            // Add the buttons
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(button1);
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(button2);
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(button3); 
+            
+            return true;
+        }
+
+        public override bool Exit() { return true; }
+
+        private void but_mode_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                ((Control)sender).Enabled = false;
+                MainV2.comPort.setMode(((Control)sender).Text);
+            }
+            catch
+            {
+                CustomMessageBox.Show(Strings.CommandFailed, Strings.ERROR);
+            }
+
+            ((Control)sender).Enabled = true;
+        }
+
+    }
+}


### PR DESCRIPTION
This adds an empty, zero-sized panel between the HUD and the tabs. This allows for the creation of plugins that add buttons or readouts that are always visible, and don't require clicking around through tabs.

As an example of how this could be useful, I have included an example .cs plugin in this pull request (disabled by default), similar to tabActionsSimple, with three mode switch buttons. The three modes can be changed to anything by simply tweaking three lines in the .cs file without having to rebuild anything.

![image](https://user-images.githubusercontent.com/14059190/182519514-d05335ee-ac78-4b2d-976a-fef25e64d3f1.png)