### PR TITLE
Open Drone ID - Fix Tab Problem

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -4192,7 +4192,7 @@ namespace MissionPlanner.GCSViews
             POI.POISave();
         }
 
-        private void saveTabControlActions()
+        public void saveTabControlActions()
         {
             string answer = "";
 

--- a/Plugins/OpenDroneID2/OpenDroneID_Plugin.cs
+++ b/Plugins/OpenDroneID2/OpenDroneID_Plugin.cs
@@ -32,21 +32,24 @@ namespace OpenDroneID_Plugin
         {
             myODID_UI.setHost(Host);
 
-            
+
 
             return true;
         }
 
         public override bool Loaded()
         {
+            forceSettings();
+
+            //TODO Uncomment once Beta is updates
+            Host.MainForm.FlightData.TabListOriginal.Add(tab);
 
             tabctrl = Host.MainForm.FlightData.tabControlactions;
             tab.Text = "Drone ID";
             tab.Controls.Add(myODID_UI);
             tabctrl.TabPages.Insert(5,tab);
 
-            //TODO Uncomment once Beta is updates
-            Host.MainForm.FlightData.TabListOriginal.Add(tab);
+
 
             Host.MainForm.FlightPlanner.updateDisplayView();
 
@@ -55,6 +58,24 @@ namespace OpenDroneID_Plugin
 
             return true;
         }
+
+
+        private void forceSettings()
+        {
+            
+
+            string tabs = Settings.Instance["tabcontrolactions"];
+
+            // setup default if doesnt exist
+            if (tabs == null)
+            {
+                CustomMessageBox.Show("Restart Mission Planner to enable Drone ID Tab");
+                Host.MainForm.FlightData.saveTabControlActions();
+                tabs = Settings.Instance["tabcontrolactions"];
+                Settings.Instance.Save();
+            }
+        }
+
 
         public override bool Exit()
         {

--- a/Plugins/OpenDroneID2/OpenDroneID_Plugin.cs
+++ b/Plugins/OpenDroneID2/OpenDroneID_Plugin.cs
@@ -46,7 +46,7 @@ namespace OpenDroneID_Plugin
             tabctrl.TabPages.Insert(5,tab);
 
             //TODO Uncomment once Beta is updates
-            //Host.MainForm.FlightData.TabListOriginal.Add(tab);
+            Host.MainForm.FlightData.TabListOriginal.Add(tab);
 
             Host.MainForm.FlightPlanner.updateDisplayView();
 


### PR DESCRIPTION
Adds a forceful creating of config.xml on load, and instructs the user that the tab will be available on reboot. It appears that part of this problem is that the Loaded() plugin override executes before the MainV2 form is drawn. For CS based plugins, perhaps they are executed AFTER. In either case, it would be handy to have a plugin function, or postpone the loading of plugins, until after the mainform is drawn. 

Note: this fix requires saveTabControlActions in FlightData to be public. 