### PR TITLE
ExtLibs: Display units for horizontal and vertical accuracy

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -338,11 +338,11 @@ namespace MissionPlanner
         [GroupText("Position")]
         public float satcount { get; set; }
 
-        [DisplayText("Horizontal Accuracy")]
+        [DisplayText("H Acc (m)")]
         [GroupText("Position")]
         public float gpsh_acc { get; private set; }
 
-        [DisplayText("Vertical Accuracy")]
+        [DisplayText("V Acc (m)")]
         [GroupText("Position")]
         public float gpsv_acc { get; private set; }
 
@@ -390,11 +390,11 @@ namespace MissionPlanner
         public float groundcourse2 { get; set; }
 
 
-        [DisplayText("Horizontal Accuracy")]
+        [DisplayText("H Acc2 (m)")]
         [GroupText("Position")]
         public float gpsh_acc2 { get; private set; }
 
-        [DisplayText("Vertical Accuracy")]
+        [DisplayText("V Acc2 (m)")]
         [GroupText("Position")]
         public float gpsv_acc2 { get; private set; }
 


### PR DESCRIPTION
Display units for horizontal and vertical accuracy.
Items without units were recognized as index values.
I learned that they are units of meters.
I shortened the item name because it was long.

![Screenshot from 2022-09-30 06-19-31](https://user-images.githubusercontent.com/646194/193146110-e22a3902-498b-40ca-bb48-09851566c170.png)