### PR TITLE
Fix: Empty left panel collapse on Flight Data screen

### DIFF
--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -295,6 +295,8 @@ namespace MissionPlanner.GCSViews
             // SubMainLeft.Panel1
             // 
             this.SubMainLeft.Panel1.Controls.Add(this.hud1);
+            this.SubMainLeft.Panel1.ControlAdded += (sender, e) => ManageLeftPanelVisibility();
+            this.SubMainLeft.Panel1.ControlRemoved += (sender, e) => ManageLeftPanelVisibility();
             // 
             // SubMainLeft.Panel2
             // 
@@ -551,6 +553,8 @@ namespace MissionPlanner.GCSViews
             this.tabControlactions.SelectedIndex = 0;
             this.tabControlactions.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.tabControl1_DrawItem);
             this.tabControlactions.SelectedIndexChanged += new System.EventHandler(this.tabControl1_SelectedIndexChanged);
+            this.tabControlactions.ControlAdded += (sender, e) => ManageLeftPanelVisibility();
+            this.tabControlactions.ControlRemoved += (sender, e) => ManageLeftPanelVisibility();
             // 
             // contextMenuStripactionstab
             // 
@@ -2258,6 +2262,8 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.panel_persistent, "panel_persistent");
             this.panel_persistent.Name = "panel_persistent";
+            this.panel_persistent.ControlAdded += (sender, e) => ManageLeftPanelVisibility();
+            this.panel_persistent.ControlRemoved += (sender, e) => ManageLeftPanelVisibility();
             // 
             // tableMap
             // 

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -2895,6 +2895,33 @@ namespace MissionPlanner.GCSViews
             frm.Show();
         }
 
+        /// <summary>
+        /// <para>Collapses or expands MainH.Panel1 depending on no. of controls within.</para>
+        /// If you add controls to <b>SubMainLeft</b> that can be hidden, displaced or removed, add their first parent control here. <br/>
+        /// Otherwise they'll prevent the collapsing of <b>SubMainLeft</b>.
+        /// </summary>
+        private void ManageLeftPanelVisibility()
+        {
+            // Define controls to check, ADD THEM HERE
+            List<Control> controlsToCheck = new List<Control>()
+            {
+                SubMainLeft.Panel1, // contains hud1
+                panel_persistent,   // might contain plugin controls
+                tabControlactions   // contains the tabs
+            };
+
+            bool controlsEmpty = controlsToCheck.Sum(x => x.Controls.Count) == 0;
+            bool panelVisible = !MainH.Panel1Collapsed;
+
+            // if controls are empty, but panel is visible -> hide
+            if (controlsEmpty && panelVisible)
+                MainH.Panel1Collapsed = true;
+
+            // if controls have content, but panel is hidden -> show
+            if (!controlsEmpty && !panelVisible)
+                MainH.Panel1Collapsed = false;
+        }
+
         private void loadFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
             POI.POILoad();


### PR DESCRIPTION
When all relevant controls are removed from the left panel (MainH.Panel1) on Flight Data (e.g. into dropout Forms), it should be collapsed to have a full sized map screen / HUD available.