### PR TITLE
Feature: Dropout forms for Flight Data and Flight Planner

### DIFF
--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -569,6 +569,7 @@ namespace MissionPlanner.GCSViews
             this.tabControlactions.SelectedIndex = 0;
             this.tabControlactions.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.tabControl1_DrawItem);
             this.tabControlactions.SelectedIndexChanged += new System.EventHandler(this.tabControl1_SelectedIndexChanged);
+            this.tabControlactions.DoubleClick += TabControlactions_DoubleClick;
             this.tabControlactions.ControlAdded += (sender, e) => ManageLeftPanelVisibility();
             this.tabControlactions.ControlRemoved += (sender, e) => ManageLeftPanelVisibility();
             // 

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -288,6 +288,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.MainH, "MainH");
             this.MainH.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.MainH.Name = "MainH";
+            MainH.VisibleChanged += MainH_VisibleChanged;
             // 
             // MainH.Panel1
             // 

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -39,7 +39,6 @@ namespace MissionPlanner.GCSViews
             this.quickView6 = new MissionPlanner.Controls.QuickView();
             this.contextMenuStripQuickView = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.setViewCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.undockToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bindingSourceQuickTab = new System.Windows.Forms.BindingSource(this.components);
             this.quickView5 = new MissionPlanner.Controls.QuickView();
             this.quickView4 = new MissionPlanner.Controls.QuickView();
@@ -628,8 +627,7 @@ namespace MissionPlanner.GCSViews
             // contextMenuStripQuickView
             // 
             this.contextMenuStripQuickView.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.setViewCountToolStripMenuItem,
-            this.undockToolStripMenuItem});
+            this.setViewCountToolStripMenuItem});
             this.contextMenuStripQuickView.Name = "contextMenuStripQuickView";
             resources.ApplyResources(this.contextMenuStripQuickView, "contextMenuStripQuickView");
             // 
@@ -638,12 +636,6 @@ namespace MissionPlanner.GCSViews
             this.setViewCountToolStripMenuItem.Name = "setViewCountToolStripMenuItem";
             resources.ApplyResources(this.setViewCountToolStripMenuItem, "setViewCountToolStripMenuItem");
             this.setViewCountToolStripMenuItem.Click += new System.EventHandler(this.setViewCountToolStripMenuItem_Click);
-            // 
-            // undockToolStripMenuItem
-            // 
-            this.undockToolStripMenuItem.Name = "undockToolStripMenuItem";
-            resources.ApplyResources(this.undockToolStripMenuItem, "undockToolStripMenuItem");
-            this.undockToolStripMenuItem.Click += new System.EventHandler(this.undockDockToolStripMenuItem_Click);
             // 
             // bindingSourceQuickTab
             // 
@@ -3000,7 +2992,6 @@ namespace MissionPlanner.GCSViews
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.ToolStripMenuItem setBatteryCellCountToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem undockToolStripMenuItem;
         private System.Windows.Forms.Button ALT_btn;
         private System.Windows.Forms.Button STBY_btn;
         private System.Windows.Forms.Button ON_btn;

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -569,6 +569,7 @@ namespace MissionPlanner.GCSViews
             this.tabControlactions.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.tabControl1_DrawItem);
             this.tabControlactions.SelectedIndexChanged += new System.EventHandler(this.tabControl1_SelectedIndexChanged);
             this.tabControlactions.DoubleClick += TabControlactions_DoubleClick;
+            this.tabControlactions.ControlAdded += TabControlactions_ControlAdded;
             this.tabControlactions.ControlAdded += (sender, e) => ManageLeftPanelVisibility();
             this.tabControlactions.ControlRemoved += (sender, e) => ManageLeftPanelVisibility();
             // 

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -2476,17 +2476,6 @@ namespace MissionPlanner.GCSViews
             POI.POIDelete((GMapMarkerPOI) CurrentGMapMarker);
         }
 
-        void dropout_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            (sender as Form).SaveStartupLocation();
-            //GetFormFromGuid(GetOrCreateGuid("fd_hud_guid")).Controls.Add(hud1);
-            ((sender as Form).Tag as Control).Controls.Add(hud1);
-            //SubMainLeft.Panel1.Controls.Add(hud1);
-            if (hud1.Parent == SubMainLeft.Panel1)
-                SubMainLeft.Panel1Collapsed = false;
-            huddropout = false;
-        }
-
         void dropout_Resize(object sender, EventArgs e)
         {
             if (huddropoutresize)
@@ -3128,9 +3117,25 @@ namespace MissionPlanner.GCSViews
             dropout.Controls.Add(hud1);
             dropout.Resize += dropout_Resize;
             dropout.FormClosed += dropout_FormClosed;
+            dropout.ResizeEnd += (s2, e2) => dropout.SaveStartupLocation();
+            dropout.LocationChanged += (s3, e3) => dropout.SaveStartupLocation();
             dropout.RestoreStartupLocation();
             dropout.Show();
+            dropout.BringToFront();
             huddropout = true;
+            SetDropoutsState(hud1.Name, true);
+        }
+
+        void dropout_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            (sender as Form).SaveStartupLocation();
+            //GetFormFromGuid(GetOrCreateGuid("fd_hud_guid")).Controls.Add(hud1);
+            ((sender as Form).Tag as Control).Controls.Add(hud1);
+            //SubMainLeft.Panel1.Controls.Add(hud1);
+            if (hud1.Parent == SubMainLeft.Panel1)
+                SubMainLeft.Panel1Collapsed = false;
+            huddropout = false;
+            SetDropoutsState(hud1.Name, false);
         }
 
         private void hud1_ekfclick(object sender, EventArgs e)
@@ -5253,6 +5258,7 @@ namespace MissionPlanner.GCSViews
             // Initialize list with default values
             DropoutsState = new List<DropoutsStateItem> // Individual Control items
             {
+                new DropoutsStateItem {Name = myhud.Name, Dropped = false},
                 new DropoutsStateItem {Name = "FlightPlanner", Dropped = false},
             };
             foreach (TabPage item in tabControlactions.TabPages) // Tabpages in bulk
@@ -5269,6 +5275,10 @@ namespace MissionPlanner.GCSViews
             {
                 if (item.Dropped)
                 {
+                    if (item.Name == myhud.Name) // HUD
+                    {
+                        hud1_DoubleClick(null, EventArgs.Empty);
+                    }
                     if (tabControlactions.TabPages.Select(TP => (TP as TabPage).Name).Contains(item.Name)) // One of the tabpages
                     {
                         tabControlactions.SelectTab(item.Name);

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -4931,6 +4931,7 @@ namespace MissionPlanner.GCSViews
             dropoutForm.FormBorderStyle = FormBorderStyle.Sizable;
             dropoutForm.Size = new Size(sourceTP.Width, sourceTP.Width);
             dropoutForm.RestoreStartupLocation();
+            sourceTP.Tag = sourceTC.SelectedIndex;
 
             dropoutTab.Appearance = TabAppearance.FlatButtons;
             dropoutTab.ItemSize = new Size(0, 0);
@@ -4958,6 +4959,30 @@ namespace MissionPlanner.GCSViews
             SetDropoutsState(dropoutTP.Name, false);
             isDropperdOut.Remove(dropoutForm);
             tabControlactions.Controls.Add(dropoutTP);
+        }
+
+        /// <summary>
+        /// This is to prevent an infinite recursive loop call of TabControlactions_ControlAdded
+        /// </summary>
+        private bool tabInserting = false;
+
+        /// <summary>
+        /// Tries to use tabpage tag as insertion index
+        /// </summary>
+        private void TabControlactions_ControlAdded(object sender, ControlEventArgs e)
+        {
+            TabControl tc = sender as TabControl;
+            TabPage tp = e.Control as TabPage;
+
+            if (!tabInserting && tp.Tag != null && int.TryParse(tp.Tag.ToString(), out int tabIndex))
+            {
+                tabInserting = true;
+                tc.Controls.Remove(tp);
+                if (tabIndex > tc.TabPages.Count) tabIndex = tc.TabPages.Count;
+                tc.TabPages.Insert(tabIndex, tp);
+                tc.SelectedTab = tp;
+                tabInserting = false;
+            }
         }
 
         private void tabPage1_Resize(object sender, EventArgs e)

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -5371,8 +5371,6 @@ namespace MissionPlanner.GCSViews
                     MainV2.comPort.MAV.cs.UpdateCurrentSettings(
                         bindingSourceHud.UpdateDataSource(MainV2.comPort.MAV.cs));
                 }
-                //if the tab detached wi have to update it 
-                if (tabQuickDetached) MainV2.comPort.MAV.cs.UpdateCurrentSettings(bindingSourceQuickTab.UpdateDataSource(MainV2.comPort.MAV.cs));
 
                 // if any tabs are dropped out, we have to update them
                 foreach (Form form in isDropperdOut)
@@ -6017,46 +6015,7 @@ namespace MissionPlanner.GCSViews
             hud1.displayCellVoltage = true;
             hud1.batterycellcount = iCellCount;
         }
-        private bool tabQuickDetached = false;
         private bool tuningwasrightclick;
-
-        private void undockDockToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-
-            Form dropout = new Form();
-            TabControl tab = new TabControl();
-            dropout.FormBorderStyle = FormBorderStyle.Sizable;
-            dropout.ShowInTaskbar = false;
-            dropout.Size = new Size(300, 450);
-            tabQuickDetached = true;
-            tab.Appearance = TabAppearance.FlatButtons;
-            tab.ItemSize = new Size(0, 0);
-            tab.SizeMode = TabSizeMode.Fixed;
-            tab.Size = new Size(dropout.ClientSize.Width, dropout.ClientSize.Height + 22);
-            tab.Location = new Point(0, -22);
-
-            tab.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-
-            dropout.Text = "Flight DATA";
-            tabControlactions.Controls.Remove(tabQuick);
-            tab.Controls.Add(tabQuick);
-            tabQuick.BorderStyle = BorderStyle.Fixed3D;
-            dropout.FormClosed += dropoutQuick_FormClosed;
-            dropout.Controls.Add(tab);
-            dropout.RestoreStartupLocation();
-            dropout.Show();
-            tabQuickDetached = true;
-            (sender as ToolStripMenuItem).Visible = false;
-        }
-
-        void dropoutQuick_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            (sender as Form).SaveStartupLocation();
-            tabControlactions.Controls.Add(tabQuick);
-            tabControlactions.SelectedTab = tabQuick;
-            tabQuickDetached = false;
-            contextMenuStripQuickView.Items["undockToolStripMenuItem"].Visible = true;
-        }
 
         private void IDENT_btn_Click(object sender, EventArgs e)
         {

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -5260,6 +5260,7 @@ namespace MissionPlanner.GCSViews
             {
                 new DropoutsStateItem {Name = myhud.Name, Dropped = false},
                 new DropoutsStateItem {Name = "FlightPlanner", Dropped = false},
+                new DropoutsStateItem {Name = "ConnectionStats", Dropped = false}
             };
             foreach (TabPage item in tabControlactions.TabPages) // Tabpages in bulk
                 DropoutsState.Add(new DropoutsStateItem {Name = item.Name, Dropped = false});
@@ -5287,6 +5288,11 @@ namespace MissionPlanner.GCSViews
                     if (item.Name == "FlightPlanner")
                     {
                         flightPlannerToolStripMenuItem_Click(null, EventArgs.Empty);
+                    }
+                    if (item.Name == "ConnectionStats")
+                    {
+                        // trigger MainV2._connectionControl.ShowLinkStats event
+                        MainV2.instance.ShowConnectionStatsForm();
                     }
                     //if (item.Name == "whatever")
                     //{

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -1403,6 +1403,12 @@ namespace MissionPlanner
 
         private void MenuFlightPlanner_Click(object sender, EventArgs e)
         {
+            // Close dropout window (if there is one)
+            MainSwitcher.Screen flightPlannerScreen = MainV2.View.screens.Where(s => s.Name == "FlightPlanner").FirstOrDefault();
+            if (flightPlannerScreen.Control.ParentForm != null)
+                flightPlannerScreen.Control.ParentForm.Close();
+            
+            // Show flight planner screen
             MyView.ShowScreen("FlightPlanner");
 
             // save config

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -553,7 +553,7 @@ namespace MissionPlanner
 
         /// <summary>
         /// This 'Control' is the toolstrip control that holds the comport combo, baudrate combo etc
-        /// Otiginally seperate controls, each hosted in a toolstip sqaure, combined into this custom
+        /// Originally seperate controls, each hosted in a toolstip sqaure, combined into this custom
         /// control for layout reasons.
         /// </summary>
         public static ConnectionControl _connectionControl;
@@ -1346,7 +1346,7 @@ namespace MissionPlanner
             }
         }
 
-        private void ShowConnectionStatsForm()
+        public void ShowConnectionStatsForm()
         {
             if (this.connectionStatsForm == null || this.connectionStatsForm.IsDisposed)
             {
@@ -1368,8 +1368,20 @@ namespace MissionPlanner
                 this.connectionStatsForm.Width = _connectionStats.Width;
             }
 
+            this.connectionStatsForm.RestoreStartupLocation();
+            this.connectionStatsForm.FormClosed += ConnectionStatsForm_FormClosed;
+            this.connectionStatsForm.ResizeEnd += (s1, e1) => this.connectionStatsForm.SaveStartupLocation();
+            this.connectionStatsForm.LocationChanged += (s2, e2) => this.connectionStatsForm.SaveStartupLocation();
             this.connectionStatsForm.Show();
+            this.connectionStatsForm.BringToFront();
+            FlightData.SetDropoutsState("ConnectionStats", true);
             ThemeManager.ApplyThemeTo(this.connectionStatsForm);
+        }
+
+        private void ConnectionStatsForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            this.connectionStatsForm.SaveStartupLocation();
+            FlightData.SetDropoutsState("ConnectionStats", false);
         }
 
         private void CMB_serialport_Click(object sender, EventArgs e)


### PR DESCRIPTION
This feature makes it possible to drop out a various elements from the Flight Data screen into seperate windows.

Fetaures include:
 - Extendable dropout form management (new controls can be added as needed)
 - Under the HUD Tabs:
   - Dropout form functionality on a double click on the tab header (and off-session saving of it's position, size and dropped-out state)
    - Removal of "undock" action from Quick tab (has been replaced by the double click method)
    - Indexed in-order insertion of tabs (when their dropout forms are closed)
 - Flight Planner: Dropout form functionality with the same off-session saving and loading
   - (the dropout window closes if the user swithes to the Flight Planner window using menu strip at the top)
 - HUD: Off-session saving and loading of positoon, size and dropped-out state
 - Connection Stats Window: Off-session saving and loading of positoon, size and dropped-out state

All saving and loading is handled using the already existing functions from the `ControlHelpers` and `Settings` classes.