### PR TITLE
GCSViews: Change the delimiter

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1631,7 +1631,7 @@ namespace MissionPlanner.GCSViews
                     pos.Lat = lat;
                     pos.Lng = lng;
                     item.Position = pos;
-                    item.ToolTipText = tag + " - " + alt;
+                    item.ToolTipText = tag + " : " + alt;
 
                     var rect = overlay.Markers.OfType<GMapMarkerRect>().Where(a => a.InnerMarker == item);
                     var mBorders = rect.First();


### PR DESCRIPTION
I am unclear about the "-" separator in the altitude display in guided mode and the "-" for relative altitude below 0 meters.
I see "-50" for 50 meters relative altitude.
I changed the "-" to ":" to clarify.

AFTER
![Screenshot from 2022-10-08 06-58-08](https://user-images.githubusercontent.com/646194/194669843-b5ef07f0-ae57-49c6-8aa5-14b0dcd4c21f.png)

BEFORE
![Screenshot from 2022-10-08 06-25-51](https://user-images.githubusercontent.com/646194/194669817-e8143eaa-e9c1-4122-8325-dabff89fad5b.png)

