### PR TITLE
Reboot: auto reconnect

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -2407,12 +2407,27 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             {
                 var ans1 = doCommand((byte) sysidcurrent, (byte) compidcurrent, MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN,
                     param1, 0, 0, 0, 0, 0, 0);
-                if (ans1)
-                    return true;
-                var ans2 = doCommand((byte) sysidcurrent, (byte) compidcurrent, MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN, 1, 0,
+                var ans2 = false;
+                if (!ans1)
+                {
+                    ans2 = doCommand((byte)sysidcurrent, (byte)compidcurrent, MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN, 1, 0,
                     0, 0, 0, 0, 0);
-                if (ans2)
+                }
+                // Successful reboot
+                if (ans1 || ans2)
+                {
+                    // Not going into bootloader and on a serial connection
+                    if (!bootloadermode && (BaseStream is SerialPort))
+                    {
+                        // Direct USB will disconnect after a reboot, wait and see if we should re-connect
+                        Thread.Sleep(500);
+                        if (!BaseStream.IsOpen)
+                        {
+                            Open(true);
+                        }
+                    }
                     return true;
+                }
 
                 giveComport = false;
                 return false;

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1699,7 +1699,9 @@ namespace MissionPlanner.GCSViews
 
                     if (CMB_action.Text == actions.Preflight_Reboot_Shutdown.ToString())
                     {
-                        param1 = 1; // reboot
+                        MainV2.comPort.doReboot();
+                        ((Control) sender).Enabled = true;
+                        return;
                     }
 
                     if (CMB_action.Text == actions.Battery_Reset.ToString())


### PR DESCRIPTION
This auto reconnects after a sending a reboot command, useful when doing initial setup where lots of reboots are needed. Also handy for catching very early start up messages. 

Testing:
- direct USB reconnects
- USB telemetry does not reconnect because the link is not closed
- TCP to SITL does not reconnect (it would be nice to get this working in the future, maybe SITL does not close the link correctly)
- firmware upload works as normal



