### PR TITLE
ConnectionControl: Link status display string with UI language specification

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -754,6 +754,16 @@ namespace MissionPlanner
             Application.DoEvents();
 
             instance = this;
+
+            MyView = new MainSwitcher(this);
+
+            View = MyView;
+
+            if (Settings.Instance.ContainsKey("language") && !string.IsNullOrEmpty(Settings.Instance["language"]))
+            {
+                changelanguage(CultureInfoEx.GetCultureInfo(Settings.Instance["language"]));
+            }
+
             InitializeComponent();
 
             //Init Theme table and load BurntKermit as a default
@@ -776,9 +786,6 @@ namespace MissionPlanner
 
             Utilities.ThemeManager.ApplyThemeTo(this);
 
-            MyView = new MainSwitcher(this);
-
-            View = MyView;
 
             // define default basestream
             comPort.BaseStream = new SerialPort();
@@ -858,11 +865,6 @@ namespace MissionPlanner
             }
 
             MissionPlanner.Utilities.Tracking.cid = new Guid(Settings.Instance["guid"].ToString());
-
-            if (Settings.Instance.ContainsKey("language") && !string.IsNullOrEmpty(Settings.Instance["language"]))
-            {
-                changelanguage(CultureInfoEx.GetCultureInfo(Settings.Instance["language"]));
-            }
 
             if (splash != null)
             {


### PR DESCRIPTION
I made changes to #2902.
I have learned that ConnectionControl is mobile before the UI language is set.
I made the UI language setting before the initialization of ConnectionControl.

AFTER
1. UI LANG IS English
![Screenshot from 2022-10-08 19-13-35](https://user-images.githubusercontent.com/646194/194703208-724ae147-c649-4019-bf07-fa26c478e92b.png)

2. UI LANG is Japanese
![Screenshot from 2022-10-08 19-14-21](https://user-images.githubusercontent.com/646194/194703261-a7a10a07-4f34-44b2-8e8a-4c097352225b.png)

3. UI LANG is Korean
![Screenshot from 2022-10-08 19-15-13](https://user-images.githubusercontent.com/646194/194703280-526595d1-1941-46be-be30-298c47bb1373.png)