### PR TITLE
FlightMode: Set flight mode setting to setup only

### DIFF
--- a/GCSViews/SoftwareConfig.cs
+++ b/GCSViews/SoftwareConfig.cs
@@ -62,11 +62,6 @@ namespace MissionPlanner.GCSViews
                 {
                     if (MainV2.comPort.BaseStream.IsOpen)
                     {
-                        if (MainV2.DisplayConfiguration.displayFlightModes)
-                        {
-                            start = AddBackstageViewPage(typeof(ConfigFlightModes), Strings.FlightModes);
-                        }
-
                         if (MainV2.comPort.MAV.cs.firmware == Firmwares.ArduCopter2)
                             AddBackstageViewPage(typeof(ConfigAC_Fence), Strings.GeoFence);
 


### PR DESCRIPTION
The flight mode settings are located on the Setup and Configure screen.
I would prefer one screen.
I removed it from the config screen.

AFTER
![Screenshot from 2022-10-10 00-48-53](https://user-images.githubusercontent.com/646194/194767052-1a76a306-f757-4048-9eb6-c176b008dbb4.png)

BEFORE
![flight-002](https://user-images.githubusercontent.com/646194/194767027-4b044793-be5e-4320-bb29-5218a0974c89.png)

![flight-001](https://user-images.githubusercontent.com/646194/194767018-d6138312-c34f-455b-8ead-d6abeec95102.png)