### PR TITLE
ConfigMount: Change to group and item names

### DIFF
--- a/GCSViews/ConfigurationView/ConfigMount.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.cs
@@ -97,8 +97,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 }
             }
 
-            CMB_mnt_type.setup(ParameterMetaDataRepository.GetParameterOptionsInt("MNT_TYPE",
-                MainV2.comPort.MAV.cs.firmware.ToString()), "MNT_TYPE", MainV2.comPort.MAV.param);
+            CMB_mnt_type.setup(ParameterMetaDataRepository.GetParameterOptionsInt(ParamHead + "TYPE",
+                MainV2.comPort.MAV.cs.firmware.ToString()), ParamHead + "TYPE", MainV2.comPort.MAV.param);
         }
 
         public void Activate()


### PR DESCRIPTION
The other parameter names are group and item names.
I want the group name and the item name.
This change will be an obstacle when supporting MNT2.

AFTER
![Screenshot from 2022-10-12 07-13-38](https://user-images.githubusercontent.com/646194/195209389-d071c0bc-86ca-4552-82a5-3d5226cc2b40.png)


![Screenshot from 2022-10-12 07-14-14](https://user-images.githubusercontent.com/646194/195209357-f7202253-9ae5-40e7-9b2c-f57740a8d7f6.png)
