### PR TITLE
ConfigPlanner: Ensure flight trajectory does not disappear for more than 1 hour

### DIFF
--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -189,7 +189,7 @@
             0});
             resources.ApplyResources(this.NUM_tracklength, "NUM_tracklength");
             this.NUM_tracklength.Maximum = new decimal(new int[] {
-            2000,
+            200000,
             0,
             0,
             0});


### PR DESCRIPTION
I sometimes let them fly for more than 40 minutes.
MP takes about 10 minutes and erases from the old track.
I would like to see the flight trajectory to verify the actual flight.
I change the max track length from 2000 to 200000.

AFTER
![Screenshot from 2022-10-15 15-42-37](https://user-images.githubusercontent.com/646194/195973786-5167d03b-b610-452c-8c03-b72f2fa0ea2d.png)


![Screenshot from 2022-10-15 15-41-42](https://user-images.githubusercontent.com/646194/195973799-ef58342a-4582-43af-96fe-8c3567cf4629.png)