### PR TITLE
MAVLink: allow more args to SCRIPT_TIME

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -3386,6 +3386,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                         if (loc.id == (ushort) MAV_CMD.DO_DIGICAM_CONTROL ||
                             loc.id == (ushort) MAV_CMD.DO_DIGICAM_CONFIGURE ||
                             loc.id == (ushort) MAV_CMD.ATTITUDE_TIME ||
+                            loc.id == (ushort) MAV_CMD.SCRIPT_TIME ||
                             loc.id == (ushort) MAV_CMD.DO_GIMBAL_MANAGER_PITCHYAW)
                         {
                             loc.lat = wp.x;
@@ -3854,6 +3855,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
                 if (loc.id == (ushort) MAV_CMD.DO_DIGICAM_CONTROL || 
                     loc.id == (ushort) MAV_CMD.DO_DIGICAM_CONFIGURE || 
                     loc.id == (ushort) MAV_CMD.ATTITUDE_TIME ||
+                    loc.id == (ushort) MAV_CMD.SCRIPT_TIME ||
                     loc.id == (ushort) MAV_CMD.DO_GIMBAL_MANAGER_PITCHYAW)
                 {
                     req.y = (int) (loc.lng);

--- a/ExtLibs/Utilities/locationwp.cs
+++ b/ExtLibs/Utilities/locationwp.cs
@@ -32,6 +32,20 @@ namespace MissionPlanner.Utilities
             return (MAVLink.mavlink_mission_item_int_t)Convert(input, true);
         }
 
+        public static bool isLocationCommand(ushort id)
+        {
+            switch (id)
+            {
+            case (ushort)MAVLink.MAV_CMD.DO_DIGICAM_CONTROL:
+            case (ushort)MAVLink.MAV_CMD.ATTITUDE_TIME:
+            case (ushort)MAVLink.MAV_CMD.SCRIPT_TIME:
+            case (ushort)MAVLink.MAV_CMD.DO_GIMBAL_MANAGER_PITCHYAW:
+                return false;
+            default:
+                return true;
+            }
+        }
+
         public static implicit operator Locationwp(MAVLink.mavlink_set_position_target_global_int_t input)
         {
             Locationwp temp = new Locationwp()
@@ -72,6 +86,12 @@ namespace MissionPlanner.Utilities
 
         public static implicit operator Locationwp(MAVLink.mavlink_mission_item_int_t input)
         {
+            double x = input.x;
+            double y = input.y;
+            if (isLocationCommand(input.command)) {
+                x *= 1.0e-7;
+                y *= 1.0e-7;
+            }
             Locationwp temp = new Locationwp()
             {
                 id = input.command,
@@ -79,8 +99,8 @@ namespace MissionPlanner.Utilities
                 p2 = input.param2,
                 p3 = input.param3,
                 p4 = input.param4,
-                lat = input.x / 1.0e7,
-                lng = input.y / 1.0e7,
+                lat = x,
+                lng = y,
                 alt = input.z,
                 _seq = input.seq,
                 frame = input.frame
@@ -125,6 +145,12 @@ namespace MissionPlanner.Utilities
         {
             if (isint)
             {
+                double x = cmd.lat;
+                double y = cmd.lng;
+                if (isLocationCommand(cmd.id)) {
+                    x *= 1.0e7;
+                    y *= 1.0e7;
+                }
                 var temp = new MAVLink.mavlink_mission_item_int_t()
                 {
                     command = cmd.id,
@@ -132,8 +158,8 @@ namespace MissionPlanner.Utilities
                     param2 = cmd.p2,
                     param3 = cmd.p3,
                     param4 = cmd.p4,
-                    x = (int)(cmd.lat * 1.0e7),
-                    y = (int)(cmd.lng * 1.0e7),
+                    x = (int)(x),
+                    y = (int)(y),
                     z = (float) cmd.alt,
                     seq = cmd._seq,
                     frame = cmd.frame

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -107,8 +107,8 @@
       <P2>timeout</P2>
       <P3>arg1</P3>
       <P4>arg2</P4>
-      <X></X>
-      <Y></Y>
+      <X>arg3</X>
+      <Y>arg4</Y>
       <Z></Z>
     </SCRIPT_TIME>
     <SPLINE_WAYPOINT>
@@ -434,8 +434,8 @@
       <P2>timeout</P2>
       <P3>arg1</P3>
       <P4>arg2</P4>
-      <X></X>
-      <Y></Y>
+      <X>arg3</X>
+      <Y>arg4</Y>
       <Z></Z>
     </SCRIPT_TIME>
     <DO_VTOL_TRANSITION>
@@ -752,8 +752,8 @@
       <P2>timeout</P2>
       <P3>arg1</P3>
       <P4>arg2</P4>
-      <X></X>
-      <Y></Y>
+      <X>arg3</X>
+      <Y>arg4</Y>
       <Z></Z>
     </SCRIPT_TIME>
     <SET_YAW_SPEED>


### PR DESCRIPTION
this fixes extra 2 args on SCRIPT_TIME and fixes several WP types for MAVFtp
