### PR TITLE
CurrentState:init with APMFirmware config.xml

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -204,6 +204,9 @@ namespace MissionPlanner
 
             var t = Type.GetType("Mono.Runtime");
             MONO = t != null;
+
+            // Initialize firmware type from settings file
+            Enum.TryParse(Settings.Instance.APMFirmware, out firmware);
         }
 
         // propery name, Name   Name starts with MAV_ will link to named_value_float messages


### PR DESCRIPTION
We store the firmware type of the last connected vehicle in config.xml, but to my knowledge, nothing actually checks that setting. This changes that. This will allow people who solely operate, for example, ArduPlane, to plan missions before being connected to the bird or to a SITL instance.

Additionally, this should provide a workaround for those being plagued by #2904. It doesn't resolve the underlying issue, but fixes the symptom for those not frequently switching vehicle types.