### PR TITLE
ConfigurationView: Display all item strings

### DIFF
--- a/GCSViews/ConfigurationView/ConfigPlanner.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.resx
@@ -1430,7 +1430,7 @@
     <value>520, 10</value>
   </data>
   <data name="CHK_hudshow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>133, 18</value>
   </data>
   <data name="CHK_hudshow.TabIndex" type="System.Int32, mscorlib">
     <value>73</value>


### PR DESCRIPTION
Item strings "Enable HUD Overlay" were partially hidden.
I show this string.

AFTER
![Screenshot from 2022-11-17 05-56-54](https://user-images.githubusercontent.com/646194/202297747-13c5dd46-75af-4df6-8988-535d6a95c9ec.png)

BEFORE
![Screenshot from 2022-11-17 05-43-36](https://user-images.githubusercontent.com/646194/202297718-0522ec7a-7b27-43b6-a8c4-bc67c70684af.png)
