### PR TITLE
GCSViews: Configuration: RadioOutput: allow upto 32 servos if  enabled

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRadioOutput.cs
+++ b/GCSViews/ConfigurationView/ConfigRadioOutput.cs
@@ -14,8 +14,17 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             bindingSource1.DataSource = typeof(CurrentState);
 
+            var num_servos = 16;
+
+            // See if 32 servo support is enabled
+            if (MainV2.comPort.MAV.param.ContainsKey("SERVO_32_ENABLE") &&
+                    (MainV2.comPort.MAV.param["SERVO_32_ENABLE"].Value > 0))
+            {
+                num_servos = 32;
+            }
+
             SuspendLayout();
-            foreach (var i in Enumerable.Range(1, 16))
+            foreach (var i in Enumerable.Range(1, num_servos))
             {
                 setup(i);
             }


### PR DESCRIPTION
Allows configuration of the full 32 servos from the Servo Output page if enabled.

![image](https://user-images.githubusercontent.com/33176108/203325804-358f1e04-62ca-4864-885d-f2aad76ebac4.png)
