### PR TITLE
Update generator.cs

### DIFF
--- a/plugins/generator.cs
+++ b/plugins/generator.cs
@@ -420,7 +420,7 @@ namespace generator
                     MainV2.instance.BeginInvoke((MethodInvoker)delegate
                    {
                        gen.aGaugeSpeed.Value1 = (float)(generator_speed / 1000.0);
-                       uint min = (run_time) / 60;
+                       uint min = ((run_time) / 60) % 60;
                        uint hour = ((run_time) / 3600);
                        gen.runTimeTxt.Text = hour.ToString("D4") + ":" + min.ToString("D2");
                        int nhour = timemaint / 3600;


### PR DESCRIPTION
There was a bug (actually wrong equation) on generator run_time print on the UI. Example given:
Previously it was shown as 2:145 for run_time value of: 8710 (which is in seconds.) After my proposed change, it will be displayed correctly as: 2:25 for same run_time value.