### PR TITLE
MyButton: add disabled text color

### DIFF
--- a/ExtLibs/Controls/MyButton.cs
+++ b/ExtLibs/Controls/MyButton.cs
@@ -19,6 +19,7 @@ namespace MissionPlanner.Controls
         internal Color _BGGradTop;
         internal Color _BGGradBot;
         internal Color _TextColor;
+        internal Color _TextColorNotEnabled;
         internal Color _Outline;
         internal Color _ColorNotEnabled;
         internal Color _ColorMouseOver;
@@ -46,6 +47,8 @@ namespace MissionPlanner.Controls
         [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Colors")]
         [DefaultValue(typeof(Color), "0x40, 0x57, 0x04")]
         public Color TextColor { get { return _TextColor; } set { _TextColor = value; this.Invalidate(); } }
+        [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Colors")]
+        public Color TextColorNotEnabled { get { return (_TextColorNotEnabled.IsEmpty) ? _TextColor : _TextColorNotEnabled; } set { _TextColorNotEnabled = value; this.Invalidate(); } }
         [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Colors")]
         [DefaultValue(typeof(Color), "0x79, 0x94, 0x29")]
         public Color Outline { get { return _Outline; } set { _Outline = value; this.Invalidate(); } }
@@ -115,7 +118,7 @@ namespace MissionPlanner.Controls
 
                 gr.DrawPath(mypen, outline);
 
-                SolidBrush mybrush = new SolidBrush(TextColor);
+                SolidBrush mybrush = this.Enabled ? new SolidBrush(TextColor) : new SolidBrush(TextColorNotEnabled);
 
                 if (_mouseover)
                 {

--- a/Utilities/ThemeManager.cs
+++ b/Utilities/ThemeManager.cs
@@ -178,6 +178,7 @@ namespace MissionPlanner.Utilities
         public static Color BannerColor1;
         public static Color BannerColor2;
         public static Color ButtonTextColor;
+        public static Color ButtonTextColorNotEnabled;
         public static Color CurrentPPMBackground;
         public static Color ZedGraphChartFill;
         public static Color ZedGraphPaneFill;
@@ -1152,6 +1153,7 @@ mc:Ignorable=""d""
                     but.BGGradTop = ButBG;
                     but.BGGradBot = ButBGBot;
                     but.TextColor = ButtonTextColor;
+                    but.TextColorNotEnabled = ButtonTextColorNotEnabled;
                     but.Outline = ButBorder;
                     but.ColorMouseDown = ColorMouseDown;        //sets the colour of buttons for different situations
                     but.ColorMouseOver = ColorMouseOver;


### PR DESCRIPTION
Add the ability to set a disabled button text color in a theme. For example
![image](https://user-images.githubusercontent.com/14059190/204872677-6b17fed8-8809-46a8-a219-b01387f8c45c.png)

At the moment, this is a secret capability, just like button border color currently is. It has to be manually added to the color theme text file by adding

```
<ThemeColor>
  <strColorItemName>Disabled Button Text</strColorItemName>
  <clrColor Web="#5C5C5C" />
  <strVariableName>ButtonTextColorNotEnabled</strVariableName>
</ThemeColor>
```

If the color is not set in the theme, it defaults to the button text color.

Alternatively, I'd be happy to amend the PR to fully integrate this to the existing themes and add button border color to them while I'm there.