### PR TITLE
Setup/Camera Gimbal update for 4.3

### DIFF
--- a/GCSViews/ConfigurationView/ConfigMount.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.cs
@@ -149,10 +149,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 updateRoll();
                 updateYaw();
 
-                CHK_stab_tilt.setup(1, 0, ParamHead + "STAB_TILT", MainV2.comPort.MAV.param);
-                CHK_stab_roll.setup(1, 0, ParamHead + "STAB_ROLL", MainV2.comPort.MAV.param);
-                CHK_stab_pan.setup(1, 0, ParamHead + "STAB_PAN", MainV2.comPort.MAV.param);
-
                 NUD_NEUTRAL_x.setup(-180, 180, 1, 1, ParamHead + "NEUTRAL_X", MainV2.comPort.MAV.param);
                 NUD_NEUTRAL_y.setup(-180, 180, 1, 1, ParamHead + "NEUTRAL_Y", MainV2.comPort.MAV.param);
                 NUD_NEUTRAL_z.setup(-180, 180, 1, 1, ParamHead + "NEUTRAL_Z", MainV2.comPort.MAV.param);
@@ -239,11 +235,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (mavlinkComboBoxTilt.Text != "Disable")
             {
                 MainV2.comPort.setParam(mavlinkComboBoxTilt.Text + "_FUNCTION", 7);
-                //MainV2.MainV2.comPort.setParam(ParamHead+"STAB_TILT", 1);
             }
             else
             {
-                //MainV2.comPort.setParam(ParamHead+"STAB_TILT", 0);
                 ensureDisabled(mavlinkComboBoxTilt, 7);
             }
 
@@ -267,11 +261,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (mavlinkComboBoxRoll.Text != "Disable")
             {
                 MainV2.comPort.setParam(mavlinkComboBoxRoll.Text + "_FUNCTION", 8);
-                //MainV2.comPort.setParam(ParamHead+"STAB_ROLL", 1);
             }
             else
             {
-                //MainV2.comPort.setParam(ParamHead+"STAB_ROLL", 0);
                 ensureDisabled(mavlinkComboBoxRoll, 8);
             }
 
@@ -294,11 +286,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (mavlinkComboBoxPan.Text != "Disable")
             {
                 MainV2.comPort.setParam(mavlinkComboBoxPan.Text + "_FUNCTION", 6);
-                //MainV2.comPort.setParam(ParamHead+"STAB_PAN", 1);
             }
             else
             {
-                //MainV2.comPort.setParam(ParamHead+"STAB_PAN", 0);
                 ensureDisabled(mavlinkComboBoxPan, 6);
             }
 

--- a/GCSViews/ConfigurationView/ConfigMount.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.cs
@@ -153,10 +153,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 CHK_stab_roll.setup(1, 0, ParamHead + "STAB_ROLL", MainV2.comPort.MAV.param);
                 CHK_stab_pan.setup(1, 0, ParamHead + "STAB_PAN", MainV2.comPort.MAV.param);
 
-                NUD_CONTROL_x.setup(-180, 180, 1, 1, ParamHead + "CONTROL_X", MainV2.comPort.MAV.param);
-                NUD_CONTROL_y.setup(-180, 180, 1, 1, ParamHead + "CONTROL_Y", MainV2.comPort.MAV.param);
-                NUD_CONTROL_z.setup(-180, 180, 1, 1, ParamHead + "CONTROL_Z", MainV2.comPort.MAV.param);
-
                 NUD_NEUTRAL_x.setup(-180, 180, 1, 1, ParamHead + "NEUTRAL_X", MainV2.comPort.MAV.param);
                 NUD_NEUTRAL_y.setup(-180, 180, 1, 1, ParamHead + "NEUTRAL_Y", MainV2.comPort.MAV.param);
                 NUD_NEUTRAL_z.setup(-180, 180, 1, 1, ParamHead + "NEUTRAL_Z", MainV2.comPort.MAV.param);

--- a/GCSViews/ConfigurationView/ConfigMount.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.cs
@@ -15,7 +15,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
     {
         private readonly Transition _NoErrorTransition;
         private Transition[] _ErrorTransition;
-        public string ParamHead = "MNT_";
+        public string ParamHead = "MNT1_";
         private bool startup = true;
 
         public ConfigMount()
@@ -244,8 +244,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             mavlinkNumericUpDownTSM.setup(800, 2200, 1, 1, mavlinkComboBoxTilt.Text + "_MIN", MainV2.comPort.MAV.param);
             mavlinkNumericUpDownTSMX.setup(800, 2200, 1, 1, mavlinkComboBoxTilt.Text + "_MAX", MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownTAM.setup(-90, 0, 100, 1, ParamHead + "ANGMIN_TIL", MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownTAMX.setup(0, 90, 100, 1, ParamHead + "ANGMAX_TIL", MainV2.comPort.MAV.param);
+            mavlinkNumericUpDownTAM.setup(-90, 0, 1, 1, ParamHead + "PITCH_MIN", MainV2.comPort.MAV.param);
+            mavlinkNumericUpDownTAMX.setup(0, 90, 1, 1, ParamHead + "PITCH_MAX", MainV2.comPort.MAV.param);
             mavlinkCheckBoxTR.setup(new double[] { -1, 1 }, new double[] { 1, 0 },
                 new string[] { mavlinkComboBoxTilt.Text + "_REV", mavlinkComboBoxTilt.Text + "_REVERSED" },
                 MainV2.comPort.MAV.param);
@@ -269,8 +269,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             mavlinkNumericUpDownRSM.setup(800, 2200, 1, 1, mavlinkComboBoxRoll.Text + "_MIN", MainV2.comPort.MAV.param);
             mavlinkNumericUpDownRSMX.setup(800, 2200, 1, 1, mavlinkComboBoxRoll.Text + "_MAX", MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownRAM.setup(-90, 0, 100, 1, ParamHead + "ANGMIN_ROL", MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownRAMX.setup(0, 90, 100, 1, ParamHead + "ANGMAX_ROL", MainV2.comPort.MAV.param);
+            mavlinkNumericUpDownRAM.setup(-90, 0, 1, 1, ParamHead + "ROLL_MIN", MainV2.comPort.MAV.param);
+            mavlinkNumericUpDownRAMX.setup(0, 90, 1, 1, ParamHead + "ROLL_MAX", MainV2.comPort.MAV.param);
             mavlinkCheckBoxRR.setup(new double[] { -1, 1 }, new double[] { 1, 0 },
                 new string[] { mavlinkComboBoxRoll.Text + "_REV", mavlinkComboBoxRoll.Text + "_REVERSED" },
                 MainV2.comPort.MAV.param);
@@ -294,8 +294,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             mavlinkNumericUpDownPSM.setup(800, 2200, 1, 1, mavlinkComboBoxPan.Text + "_MIN", MainV2.comPort.MAV.param);
             mavlinkNumericUpDownPSMX.setup(800, 2200, 1, 1, mavlinkComboBoxPan.Text + "_MAX", MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownPAM.setup(-180, 0, 100, 1, ParamHead + "ANGMIN_PAN", MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownPAMX.setup(0, 180, 100, 1, ParamHead + "ANGMAX_PAN", MainV2.comPort.MAV.param);
+            mavlinkNumericUpDownPAM.setup(-180, 0, 1, 1, ParamHead + "YAW_MIN", MainV2.comPort.MAV.param);
+            mavlinkNumericUpDownPAMX.setup(0, 180, 1, 1, ParamHead + "YAW_MAX", MainV2.comPort.MAV.param);
             mavlinkCheckBoxPR.setup(new double[] { -1, 1 }, new double[] { 1, 0 },
                 new string[] { mavlinkComboBoxPan.Text + "_REV", mavlinkComboBoxPan.Text + "_REVERSED" },
                 MainV2.comPort.MAV.param);

--- a/GCSViews/ConfigurationView/ConfigMount.designer.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.designer.cs
@@ -66,6 +66,40 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.label22 = new System.Windows.Forms.Label();
             this.label23 = new System.Windows.Forms.Label();
             this.label24 = new System.Windows.Forms.Label();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.label27 = new System.Windows.Forms.Label();
+            this.label26 = new System.Windows.Forms.Label();
+            this.label25 = new System.Windows.Forms.Label();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.label28 = new System.Windows.Forms.Label();
+            this.label29 = new System.Windows.Forms.Label();
+            this.label30 = new System.Windows.Forms.Label();
+            this.CMB_shuttertype = new System.Windows.Forms.ComboBox();
+            this.label35 = new System.Windows.Forms.Label();
+            this.label36 = new System.Windows.Forms.Label();
+            this.label37 = new System.Windows.Forms.Label();
+            this.label38 = new System.Windows.Forms.Label();
+            this.label39 = new System.Windows.Forms.Label();
+            this.label40 = new System.Windows.Forms.Label();
+            this.label41 = new System.Windows.Forms.Label();
+            this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.pictureBox4 = new System.Windows.Forms.PictureBox();
+            this.label34 = new System.Windows.Forms.Label();
+            this.label42 = new System.Windows.Forms.Label();
+            this.label43 = new System.Windows.Forms.Label();
+            this.label44 = new System.Windows.Forms.Label();
+            this.CMB_mnt_type = new MissionPlanner.Controls.MavlinkComboBox();
+            this.mavlinkNumericUpDownshut_duration = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownshut_pushed = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownshut_notpushed = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownShutM = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.mavlinkNumericUpDownShutMX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.NUD_NEUTRAL_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.NUD_NEUTRAL_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.NUD_NEUTRAL_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.NUD_RETRACT_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.NUD_RETRACT_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.NUD_RETRACT_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CMB_inputch_pan = new MissionPlanner.Controls.MavlinkComboBox();
             this.CMB_inputch_roll = new MissionPlanner.Controls.MavlinkComboBox();
             this.CMB_inputch_tilt = new MissionPlanner.Controls.MavlinkComboBox();
@@ -84,46 +118,23 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.mavlinkNumericUpDownRSM = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.mavlinkNumericUpDownRSMX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.mavlinkCheckBoxRR = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.label27 = new System.Windows.Forms.Label();
-            this.NUD_RETRACT_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label26 = new System.Windows.Forms.Label();
-            this.NUD_RETRACT_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label25 = new System.Windows.Forms.Label();
-            this.NUD_RETRACT_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
-            this.label28 = new System.Windows.Forms.Label();
-            this.NUD_NEUTRAL_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label29 = new System.Windows.Forms.Label();
-            this.NUD_NEUTRAL_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label30 = new System.Windows.Forms.Label();
-            this.NUD_NEUTRAL_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.CHK_stab_tilt = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CHK_stab_roll = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CHK_stab_pan = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CMB_shuttertype = new System.Windows.Forms.ComboBox();
-            this.label35 = new System.Windows.Forms.Label();
-            this.label36 = new System.Windows.Forms.Label();
-            this.label37 = new System.Windows.Forms.Label();
-            this.label38 = new System.Windows.Forms.Label();
-            this.mavlinkNumericUpDownshut_pushed = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.mavlinkNumericUpDownshut_notpushed = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label39 = new System.Windows.Forms.Label();
-            this.label40 = new System.Windows.Forms.Label();
-            this.mavlinkNumericUpDownShutM = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.mavlinkNumericUpDownShutMX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label41 = new System.Windows.Forms.Label();
-            this.groupBox7 = new System.Windows.Forms.GroupBox();
-            this.pictureBox4 = new System.Windows.Forms.PictureBox();
-            this.label34 = new System.Windows.Forms.Label();
-            this.mavlinkNumericUpDownshut_duration = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label42 = new System.Windows.Forms.Label();
-            this.CMB_mnt_type = new MissionPlanner.Controls.MavlinkComboBox();
-            this.label43 = new System.Windows.Forms.Label();
-            this.label44 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
+            this.groupBox4.SuspendLayout();
+            this.groupBox5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_duration)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutMX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAM)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAMX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTSM)).BeginInit();
@@ -136,20 +147,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownRAMX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownRSM)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownRSMX)).BeginInit();
-            this.groupBox4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).BeginInit();
-            this.groupBox5.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutMX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_duration)).BeginInit();
             this.SuspendLayout();
             // 
             // pictureBox1
@@ -356,6 +353,413 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.label24, "label24");
             this.label24.Name = "label24";
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.label27);
+            this.groupBox4.Controls.Add(this.NUD_RETRACT_z);
+            this.groupBox4.Controls.Add(this.label26);
+            this.groupBox4.Controls.Add(this.NUD_RETRACT_y);
+            this.groupBox4.Controls.Add(this.label25);
+            this.groupBox4.Controls.Add(this.NUD_RETRACT_x);
+            resources.ApplyResources(this.groupBox4, "groupBox4");
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.TabStop = false;
+            // 
+            // label27
+            // 
+            resources.ApplyResources(this.label27, "label27");
+            this.label27.Name = "label27";
+            // 
+            // label26
+            // 
+            resources.ApplyResources(this.label26, "label26");
+            this.label26.Name = "label26";
+            // 
+            // label25
+            // 
+            resources.ApplyResources(this.label25, "label25");
+            this.label25.Name = "label25";
+            // 
+            // groupBox5
+            // 
+            this.groupBox5.Controls.Add(this.label28);
+            this.groupBox5.Controls.Add(this.NUD_NEUTRAL_z);
+            this.groupBox5.Controls.Add(this.label29);
+            this.groupBox5.Controls.Add(this.NUD_NEUTRAL_y);
+            this.groupBox5.Controls.Add(this.label30);
+            this.groupBox5.Controls.Add(this.NUD_NEUTRAL_x);
+            resources.ApplyResources(this.groupBox5, "groupBox5");
+            this.groupBox5.Name = "groupBox5";
+            this.groupBox5.TabStop = false;
+            // 
+            // label28
+            // 
+            resources.ApplyResources(this.label28, "label28");
+            this.label28.Name = "label28";
+            // 
+            // label29
+            // 
+            resources.ApplyResources(this.label29, "label29");
+            this.label29.Name = "label29";
+            // 
+            // label30
+            // 
+            resources.ApplyResources(this.label30, "label30");
+            this.label30.Name = "label30";
+            // 
+            // CMB_shuttertype
+            // 
+            this.CMB_shuttertype.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CMB_shuttertype.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_shuttertype, "CMB_shuttertype");
+            this.CMB_shuttertype.Name = "CMB_shuttertype";
+            this.CMB_shuttertype.SelectedIndexChanged += new System.EventHandler(this.mavlinkComboBox_SelectedIndexChanged);
+            // 
+            // label35
+            // 
+            resources.ApplyResources(this.label35, "label35");
+            this.label35.Name = "label35";
+            // 
+            // label36
+            // 
+            resources.ApplyResources(this.label36, "label36");
+            this.label36.Name = "label36";
+            // 
+            // label37
+            // 
+            resources.ApplyResources(this.label37, "label37");
+            this.label37.Name = "label37";
+            // 
+            // label38
+            // 
+            resources.ApplyResources(this.label38, "label38");
+            this.label38.Name = "label38";
+            // 
+            // label39
+            // 
+            resources.ApplyResources(this.label39, "label39");
+            this.label39.Name = "label39";
+            // 
+            // label40
+            // 
+            resources.ApplyResources(this.label40, "label40");
+            this.label40.Name = "label40";
+            // 
+            // label41
+            // 
+            resources.ApplyResources(this.label41, "label41");
+            this.label41.Name = "label41";
+            // 
+            // groupBox7
+            // 
+            resources.ApplyResources(this.groupBox7, "groupBox7");
+            this.groupBox7.Name = "groupBox7";
+            this.groupBox7.TabStop = false;
+            // 
+            // pictureBox4
+            // 
+            this.pictureBox4.BackgroundImage = global::MissionPlanner.Properties.Resources.Shutter;
+            resources.ApplyResources(this.pictureBox4, "pictureBox4");
+            this.pictureBox4.Name = "pictureBox4";
+            this.pictureBox4.TabStop = false;
+            // 
+            // label34
+            // 
+            resources.ApplyResources(this.label34, "label34");
+            this.label34.Name = "label34";
+            // 
+            // label42
+            // 
+            resources.ApplyResources(this.label42, "label42");
+            this.label42.Name = "label42";
+            // 
+            // label43
+            // 
+            resources.ApplyResources(this.label43, "label43");
+            this.label43.Name = "label43";
+            // 
+            // label44
+            // 
+            resources.ApplyResources(this.label44, "label44");
+            this.label44.Name = "label44";
+            // 
+            // CMB_mnt_type
+            // 
+            this.CMB_mnt_type.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            resources.ApplyResources(this.CMB_mnt_type, "CMB_mnt_type");
+            this.CMB_mnt_type.FormattingEnabled = true;
+            this.CMB_mnt_type.Name = "CMB_mnt_type";
+            this.CMB_mnt_type.ParamName = null;
+            this.CMB_mnt_type.SubControl = null;
+            // 
+            // mavlinkNumericUpDownshut_duration
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownshut_duration, "mavlinkNumericUpDownshut_duration");
+            this.mavlinkNumericUpDownshut_duration.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_duration.Max = 1F;
+            this.mavlinkNumericUpDownshut_duration.Min = 0F;
+            this.mavlinkNumericUpDownshut_duration.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_duration.Name = "mavlinkNumericUpDownshut_duration";
+            this.mavlinkNumericUpDownshut_duration.ParamName = null;
+            this.mavlinkNumericUpDownshut_duration.Value = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            // 
+            // mavlinkNumericUpDownshut_pushed
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownshut_pushed, "mavlinkNumericUpDownshut_pushed");
+            this.mavlinkNumericUpDownshut_pushed.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_pushed.Max = 1F;
+            this.mavlinkNumericUpDownshut_pushed.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_pushed.Min = 0F;
+            this.mavlinkNumericUpDownshut_pushed.Name = "mavlinkNumericUpDownshut_pushed";
+            this.mavlinkNumericUpDownshut_pushed.ParamName = null;
+            this.mavlinkNumericUpDownshut_pushed.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // mavlinkNumericUpDownshut_notpushed
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownshut_notpushed, "mavlinkNumericUpDownshut_notpushed");
+            this.mavlinkNumericUpDownshut_notpushed.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_notpushed.Max = 1F;
+            this.mavlinkNumericUpDownshut_notpushed.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_notpushed.Min = 0F;
+            this.mavlinkNumericUpDownshut_notpushed.Minimum = new decimal(new int[] {
+            800,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownshut_notpushed.Name = "mavlinkNumericUpDownshut_notpushed";
+            this.mavlinkNumericUpDownshut_notpushed.ParamName = null;
+            this.mavlinkNumericUpDownshut_notpushed.Value = new decimal(new int[] {
+            2000,
+            0,
+            0,
+            0});
+            // 
+            // mavlinkNumericUpDownShutM
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownShutM, "mavlinkNumericUpDownShutM");
+            this.mavlinkNumericUpDownShutM.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownShutM.Max = 1F;
+            this.mavlinkNumericUpDownShutM.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownShutM.Min = 0F;
+            this.mavlinkNumericUpDownShutM.Minimum = new decimal(new int[] {
+            800,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownShutM.Name = "mavlinkNumericUpDownShutM";
+            this.mavlinkNumericUpDownShutM.ParamName = null;
+            this.mavlinkNumericUpDownShutM.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // mavlinkNumericUpDownShutMX
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownShutMX, "mavlinkNumericUpDownShutMX");
+            this.mavlinkNumericUpDownShutMX.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownShutMX.Max = 1F;
+            this.mavlinkNumericUpDownShutMX.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownShutMX.Min = 0F;
+            this.mavlinkNumericUpDownShutMX.Minimum = new decimal(new int[] {
+            800,
+            0,
+            0,
+            0});
+            this.mavlinkNumericUpDownShutMX.Name = "mavlinkNumericUpDownShutMX";
+            this.mavlinkNumericUpDownShutMX.ParamName = null;
+            this.mavlinkNumericUpDownShutMX.Value = new decimal(new int[] {
+            2000,
+            0,
+            0,
+            0});
+            // 
+            // NUD_NEUTRAL_z
+            // 
+            resources.ApplyResources(this.NUD_NEUTRAL_z, "NUD_NEUTRAL_z");
+            this.NUD_NEUTRAL_z.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_z.Max = 1F;
+            this.NUD_NEUTRAL_z.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_z.Min = 0F;
+            this.NUD_NEUTRAL_z.Name = "NUD_NEUTRAL_z";
+            this.NUD_NEUTRAL_z.ParamName = null;
+            this.NUD_NEUTRAL_z.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // NUD_NEUTRAL_y
+            // 
+            resources.ApplyResources(this.NUD_NEUTRAL_y, "NUD_NEUTRAL_y");
+            this.NUD_NEUTRAL_y.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_y.Max = 1F;
+            this.NUD_NEUTRAL_y.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_y.Min = 0F;
+            this.NUD_NEUTRAL_y.Name = "NUD_NEUTRAL_y";
+            this.NUD_NEUTRAL_y.ParamName = null;
+            this.NUD_NEUTRAL_y.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // NUD_NEUTRAL_x
+            // 
+            resources.ApplyResources(this.NUD_NEUTRAL_x, "NUD_NEUTRAL_x");
+            this.NUD_NEUTRAL_x.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_x.Max = 1F;
+            this.NUD_NEUTRAL_x.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_x.Min = 0F;
+            this.NUD_NEUTRAL_x.Name = "NUD_NEUTRAL_x";
+            this.NUD_NEUTRAL_x.ParamName = null;
+            this.NUD_NEUTRAL_x.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // NUD_RETRACT_z
+            // 
+            resources.ApplyResources(this.NUD_RETRACT_z, "NUD_RETRACT_z");
+            this.NUD_RETRACT_z.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_z.Max = 1F;
+            this.NUD_RETRACT_z.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_z.Min = 0F;
+            this.NUD_RETRACT_z.Name = "NUD_RETRACT_z";
+            this.NUD_RETRACT_z.ParamName = null;
+            this.NUD_RETRACT_z.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // NUD_RETRACT_y
+            // 
+            resources.ApplyResources(this.NUD_RETRACT_y, "NUD_RETRACT_y");
+            this.NUD_RETRACT_y.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_y.Max = 1F;
+            this.NUD_RETRACT_y.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_y.Min = 0F;
+            this.NUD_RETRACT_y.Name = "NUD_RETRACT_y";
+            this.NUD_RETRACT_y.ParamName = null;
+            this.NUD_RETRACT_y.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
+            // NUD_RETRACT_x
+            // 
+            resources.ApplyResources(this.NUD_RETRACT_x, "NUD_RETRACT_x");
+            this.NUD_RETRACT_x.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_x.Max = 1F;
+            this.NUD_RETRACT_x.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_x.Min = 0F;
+            this.NUD_RETRACT_x.Name = "NUD_RETRACT_x";
+            this.NUD_RETRACT_x.ParamName = null;
+            this.NUD_RETRACT_x.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
             // 
             // CMB_inputch_pan
             // 
@@ -735,440 +1139,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.mavlinkCheckBoxRR.ParamName = null;
             this.mavlinkCheckBoxRR.UseVisualStyleBackColor = true;
             // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.label27);
-            this.groupBox4.Controls.Add(this.NUD_RETRACT_z);
-            this.groupBox4.Controls.Add(this.label26);
-            this.groupBox4.Controls.Add(this.NUD_RETRACT_y);
-            this.groupBox4.Controls.Add(this.label25);
-            this.groupBox4.Controls.Add(this.NUD_RETRACT_x);
-            resources.ApplyResources(this.groupBox4, "groupBox4");
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.TabStop = false;
-            // 
-            // label27
-            // 
-            resources.ApplyResources(this.label27, "label27");
-            this.label27.Name = "label27";
-            // 
-            // NUD_RETRACT_z
-            // 
-            resources.ApplyResources(this.NUD_RETRACT_z, "NUD_RETRACT_z");
-            this.NUD_RETRACT_z.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_z.Max = 1F;
-            this.NUD_RETRACT_z.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_z.Min = 0F;
-            this.NUD_RETRACT_z.Name = "NUD_RETRACT_z";
-            this.NUD_RETRACT_z.ParamName = null;
-            this.NUD_RETRACT_z.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // label26
-            // 
-            resources.ApplyResources(this.label26, "label26");
-            this.label26.Name = "label26";
-            // 
-            // NUD_RETRACT_y
-            // 
-            resources.ApplyResources(this.NUD_RETRACT_y, "NUD_RETRACT_y");
-            this.NUD_RETRACT_y.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_y.Max = 1F;
-            this.NUD_RETRACT_y.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_y.Min = 0F;
-            this.NUD_RETRACT_y.Name = "NUD_RETRACT_y";
-            this.NUD_RETRACT_y.ParamName = null;
-            this.NUD_RETRACT_y.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // label25
-            // 
-            resources.ApplyResources(this.label25, "label25");
-            this.label25.Name = "label25";
-            // 
-            // NUD_RETRACT_x
-            // 
-            resources.ApplyResources(this.NUD_RETRACT_x, "NUD_RETRACT_x");
-            this.NUD_RETRACT_x.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_x.Max = 1F;
-            this.NUD_RETRACT_x.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_x.Min = 0F;
-            this.NUD_RETRACT_x.Name = "NUD_RETRACT_x";
-            this.NUD_RETRACT_x.ParamName = null;
-            this.NUD_RETRACT_x.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // groupBox5
-            // 
-            this.groupBox5.Controls.Add(this.label28);
-            this.groupBox5.Controls.Add(this.NUD_NEUTRAL_z);
-            this.groupBox5.Controls.Add(this.label29);
-            this.groupBox5.Controls.Add(this.NUD_NEUTRAL_y);
-            this.groupBox5.Controls.Add(this.label30);
-            this.groupBox5.Controls.Add(this.NUD_NEUTRAL_x);
-            resources.ApplyResources(this.groupBox5, "groupBox5");
-            this.groupBox5.Name = "groupBox5";
-            this.groupBox5.TabStop = false;
-            // 
-            // label28
-            // 
-            resources.ApplyResources(this.label28, "label28");
-            this.label28.Name = "label28";
-            // 
-            // NUD_NEUTRAL_z
-            // 
-            resources.ApplyResources(this.NUD_NEUTRAL_z, "NUD_NEUTRAL_z");
-            this.NUD_NEUTRAL_z.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_z.Max = 1F;
-            this.NUD_NEUTRAL_z.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_z.Min = 0F;
-            this.NUD_NEUTRAL_z.Name = "NUD_NEUTRAL_z";
-            this.NUD_NEUTRAL_z.ParamName = null;
-            this.NUD_NEUTRAL_z.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // label29
-            // 
-            resources.ApplyResources(this.label29, "label29");
-            this.label29.Name = "label29";
-            // 
-            // NUD_NEUTRAL_y
-            // 
-            resources.ApplyResources(this.NUD_NEUTRAL_y, "NUD_NEUTRAL_y");
-            this.NUD_NEUTRAL_y.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_y.Max = 1F;
-            this.NUD_NEUTRAL_y.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_y.Min = 0F;
-            this.NUD_NEUTRAL_y.Name = "NUD_NEUTRAL_y";
-            this.NUD_NEUTRAL_y.ParamName = null;
-            this.NUD_NEUTRAL_y.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // label30
-            // 
-            resources.ApplyResources(this.label30, "label30");
-            this.label30.Name = "label30";
-            // 
-            // NUD_NEUTRAL_x
-            // 
-            resources.ApplyResources(this.NUD_NEUTRAL_x, "NUD_NEUTRAL_x");
-            this.NUD_NEUTRAL_x.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_x.Max = 1F;
-            this.NUD_NEUTRAL_x.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_x.Min = 0F;
-            this.NUD_NEUTRAL_x.Name = "NUD_NEUTRAL_x";
-            this.NUD_NEUTRAL_x.ParamName = null;
-            this.NUD_NEUTRAL_x.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // CHK_stab_tilt
-            // 
-            resources.ApplyResources(this.CHK_stab_tilt, "CHK_stab_tilt");
-            this.CHK_stab_tilt.Name = "CHK_stab_tilt";
-            this.CHK_stab_tilt.OffValue = 0D;
-            this.CHK_stab_tilt.OnValue = 1D;
-            this.CHK_stab_tilt.ParamName = null;
-            this.CHK_stab_tilt.UseVisualStyleBackColor = true;
-            // 
-            // CHK_stab_roll
-            // 
-            resources.ApplyResources(this.CHK_stab_roll, "CHK_stab_roll");
-            this.CHK_stab_roll.Name = "CHK_stab_roll";
-            this.CHK_stab_roll.OffValue = 0D;
-            this.CHK_stab_roll.OnValue = 1D;
-            this.CHK_stab_roll.ParamName = null;
-            this.CHK_stab_roll.UseVisualStyleBackColor = true;
-            // 
-            // CHK_stab_pan
-            // 
-            resources.ApplyResources(this.CHK_stab_pan, "CHK_stab_pan");
-            this.CHK_stab_pan.Name = "CHK_stab_pan";
-            this.CHK_stab_pan.OffValue = 0D;
-            this.CHK_stab_pan.OnValue = 1D;
-            this.CHK_stab_pan.ParamName = null;
-            this.CHK_stab_pan.UseVisualStyleBackColor = true;
-            // 
-            // CMB_shuttertype
-            // 
-            this.CMB_shuttertype.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.CMB_shuttertype.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_shuttertype, "CMB_shuttertype");
-            this.CMB_shuttertype.Name = "CMB_shuttertype";
-            this.CMB_shuttertype.SelectedIndexChanged += new System.EventHandler(this.mavlinkComboBox_SelectedIndexChanged);
-            // 
-            // label35
-            // 
-            resources.ApplyResources(this.label35, "label35");
-            this.label35.Name = "label35";
-            // 
-            // label36
-            // 
-            resources.ApplyResources(this.label36, "label36");
-            this.label36.Name = "label36";
-            // 
-            // label37
-            // 
-            resources.ApplyResources(this.label37, "label37");
-            this.label37.Name = "label37";
-            // 
-            // label38
-            // 
-            resources.ApplyResources(this.label38, "label38");
-            this.label38.Name = "label38";
-            // 
-            // mavlinkNumericUpDownshut_pushed
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownshut_pushed, "mavlinkNumericUpDownshut_pushed");
-            this.mavlinkNumericUpDownshut_pushed.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_pushed.Max = 1F;
-            this.mavlinkNumericUpDownshut_pushed.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_pushed.Min = 0F;
-            this.mavlinkNumericUpDownshut_pushed.Name = "mavlinkNumericUpDownshut_pushed";
-            this.mavlinkNumericUpDownshut_pushed.ParamName = null;
-            this.mavlinkNumericUpDownshut_pushed.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // mavlinkNumericUpDownshut_notpushed
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownshut_notpushed, "mavlinkNumericUpDownshut_notpushed");
-            this.mavlinkNumericUpDownshut_notpushed.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_notpushed.Max = 1F;
-            this.mavlinkNumericUpDownshut_notpushed.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_notpushed.Min = 0F;
-            this.mavlinkNumericUpDownshut_notpushed.Minimum = new decimal(new int[] {
-            800,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_notpushed.Name = "mavlinkNumericUpDownshut_notpushed";
-            this.mavlinkNumericUpDownshut_notpushed.ParamName = null;
-            this.mavlinkNumericUpDownshut_notpushed.Value = new decimal(new int[] {
-            2000,
-            0,
-            0,
-            0});
-            // 
-            // label39
-            // 
-            resources.ApplyResources(this.label39, "label39");
-            this.label39.Name = "label39";
-            // 
-            // label40
-            // 
-            resources.ApplyResources(this.label40, "label40");
-            this.label40.Name = "label40";
-            // 
-            // mavlinkNumericUpDownShutM
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownShutM, "mavlinkNumericUpDownShutM");
-            this.mavlinkNumericUpDownShutM.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownShutM.Max = 1F;
-            this.mavlinkNumericUpDownShutM.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownShutM.Min = 0F;
-            this.mavlinkNumericUpDownShutM.Minimum = new decimal(new int[] {
-            800,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownShutM.Name = "mavlinkNumericUpDownShutM";
-            this.mavlinkNumericUpDownShutM.ParamName = null;
-            this.mavlinkNumericUpDownShutM.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // mavlinkNumericUpDownShutMX
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownShutMX, "mavlinkNumericUpDownShutMX");
-            this.mavlinkNumericUpDownShutMX.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownShutMX.Max = 1F;
-            this.mavlinkNumericUpDownShutMX.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownShutMX.Min = 0F;
-            this.mavlinkNumericUpDownShutMX.Minimum = new decimal(new int[] {
-            800,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownShutMX.Name = "mavlinkNumericUpDownShutMX";
-            this.mavlinkNumericUpDownShutMX.ParamName = null;
-            this.mavlinkNumericUpDownShutMX.Value = new decimal(new int[] {
-            2000,
-            0,
-            0,
-            0});
-            // 
-            // label41
-            // 
-            resources.ApplyResources(this.label41, "label41");
-            this.label41.Name = "label41";
-            // 
-            // groupBox7
-            // 
-            resources.ApplyResources(this.groupBox7, "groupBox7");
-            this.groupBox7.Name = "groupBox7";
-            this.groupBox7.TabStop = false;
-            // 
-            // pictureBox4
-            // 
-            this.pictureBox4.BackgroundImage = global::MissionPlanner.Properties.Resources.Shutter;
-            resources.ApplyResources(this.pictureBox4, "pictureBox4");
-            this.pictureBox4.Name = "pictureBox4";
-            this.pictureBox4.TabStop = false;
-            // 
-            // label34
-            // 
-            resources.ApplyResources(this.label34, "label34");
-            this.label34.Name = "label34";
-            // 
-            // mavlinkNumericUpDownshut_duration
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownshut_duration, "mavlinkNumericUpDownshut_duration");
-            this.mavlinkNumericUpDownshut_duration.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_duration.Max = 1F;
-            this.mavlinkNumericUpDownshut_duration.Min = 0F;
-            this.mavlinkNumericUpDownshut_duration.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.mavlinkNumericUpDownshut_duration.Name = "mavlinkNumericUpDownshut_duration";
-            this.mavlinkNumericUpDownshut_duration.ParamName = null;
-            this.mavlinkNumericUpDownshut_duration.Value = new decimal(new int[] {
-            20,
-            0,
-            0,
-            0});
-            // 
-            // label42
-            // 
-            resources.ApplyResources(this.label42, "label42");
-            this.label42.Name = "label42";
-            // 
-            // CMB_mnt_type
-            // 
-            this.CMB_mnt_type.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            resources.ApplyResources(this.CMB_mnt_type, "CMB_mnt_type");
-            this.CMB_mnt_type.FormattingEnabled = true;
-            this.CMB_mnt_type.Name = "CMB_mnt_type";
-            this.CMB_mnt_type.ParamName = null;
-            this.CMB_mnt_type.SubControl = null;
-            // 
-            // label43
-            // 
-            resources.ApplyResources(this.label43, "label43");
-            this.label43.Name = "label43";
-            // 
-            // label44
-            // 
-            resources.ApplyResources(this.label44, "label44");
-            this.label44.Name = "label44";
-            // 
             // ConfigMount
             // 
             this.Controls.Add(this.label44);
@@ -1191,9 +1161,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Controls.Add(this.label41);
             this.Controls.Add(this.groupBox7);
             this.Controls.Add(this.pictureBox4);
-            this.Controls.Add(this.CHK_stab_pan);
-            this.Controls.Add(this.CHK_stab_roll);
-            this.Controls.Add(this.CHK_stab_tilt);
             this.Controls.Add(this.groupBox5);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.label24);
@@ -1253,6 +1220,22 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_duration)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutMX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAM)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAMX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTSM)).EndInit();
@@ -1265,22 +1248,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownRAMX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownRSM)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownRSMX)).EndInit();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox4.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).EndInit();
-            this.groupBox5.ResumeLayout(false);
-            this.groupBox5.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutMX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_duration)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1354,9 +1321,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private MavlinkNumericUpDown NUD_NEUTRAL_y;
         private System.Windows.Forms.Label label30;
         private MavlinkNumericUpDown NUD_NEUTRAL_x;
-        private MavlinkCheckBox CHK_stab_tilt;
-        private MavlinkCheckBox CHK_stab_roll;
-        private MavlinkCheckBox CHK_stab_pan;
         private System.Windows.Forms.Label label35;
         private System.Windows.Forms.Label label36;
         private System.Windows.Forms.Label label37;

--- a/GCSViews/ConfigurationView/ConfigMount.designer.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.designer.cs
@@ -68,12 +68,18 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.label24 = new System.Windows.Forms.Label();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.label27 = new System.Windows.Forms.Label();
+            this.NUD_RETRACT_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label26 = new System.Windows.Forms.Label();
+            this.NUD_RETRACT_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label25 = new System.Windows.Forms.Label();
+            this.NUD_RETRACT_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.label28 = new System.Windows.Forms.Label();
+            this.NUD_NEUTRAL_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label29 = new System.Windows.Forms.Label();
+            this.NUD_NEUTRAL_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label30 = new System.Windows.Forms.Label();
+            this.NUD_NEUTRAL_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CMB_shuttertype = new System.Windows.Forms.ComboBox();
             this.label35 = new System.Windows.Forms.Label();
             this.label36 = new System.Windows.Forms.Label();
@@ -94,12 +100,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.mavlinkNumericUpDownshut_notpushed = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.mavlinkNumericUpDownShutM = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.mavlinkNumericUpDownShutMX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.NUD_NEUTRAL_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.NUD_NEUTRAL_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.NUD_NEUTRAL_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.NUD_RETRACT_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.NUD_RETRACT_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.NUD_RETRACT_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CMB_inputch_pan = new MissionPlanner.Controls.MavlinkComboBox();
             this.CMB_inputch_roll = new MissionPlanner.Controls.MavlinkComboBox();
             this.CMB_inputch_tilt = new MissionPlanner.Controls.MavlinkComboBox();
@@ -118,23 +118,27 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.mavlinkNumericUpDownRSM = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.mavlinkNumericUpDownRSMX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.mavlinkCheckBoxRR = new MissionPlanner.Controls.MavlinkCheckBox();
+            this.label31 = new System.Windows.Forms.Label();
+            this.label32 = new System.Windows.Forms.Label();
+            this.label33 = new System.Windows.Forms.Label();
+            this.label45 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
             this.groupBox4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).BeginInit();
             this.groupBox5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_duration)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutMX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAM)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAMX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTSM)).BeginInit();
@@ -371,15 +375,84 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.label27, "label27");
             this.label27.Name = "label27";
             // 
+            // NUD_RETRACT_z
+            // 
+            resources.ApplyResources(this.NUD_RETRACT_z, "NUD_RETRACT_z");
+            this.NUD_RETRACT_z.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_z.Max = 1F;
+            this.NUD_RETRACT_z.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_z.Min = 0F;
+            this.NUD_RETRACT_z.Name = "NUD_RETRACT_z";
+            this.NUD_RETRACT_z.ParamName = null;
+            this.NUD_RETRACT_z.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
             // label26
             // 
             resources.ApplyResources(this.label26, "label26");
             this.label26.Name = "label26";
             // 
+            // NUD_RETRACT_y
+            // 
+            resources.ApplyResources(this.NUD_RETRACT_y, "NUD_RETRACT_y");
+            this.NUD_RETRACT_y.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_y.Max = 1F;
+            this.NUD_RETRACT_y.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_y.Min = 0F;
+            this.NUD_RETRACT_y.Name = "NUD_RETRACT_y";
+            this.NUD_RETRACT_y.ParamName = null;
+            this.NUD_RETRACT_y.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
             // label25
             // 
             resources.ApplyResources(this.label25, "label25");
             this.label25.Name = "label25";
+            // 
+            // NUD_RETRACT_x
+            // 
+            resources.ApplyResources(this.NUD_RETRACT_x, "NUD_RETRACT_x");
+            this.NUD_RETRACT_x.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_x.Max = 1F;
+            this.NUD_RETRACT_x.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_RETRACT_x.Min = 0F;
+            this.NUD_RETRACT_x.Name = "NUD_RETRACT_x";
+            this.NUD_RETRACT_x.ParamName = null;
+            this.NUD_RETRACT_x.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
             // 
             // groupBox5
             // 
@@ -398,15 +471,84 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.label28, "label28");
             this.label28.Name = "label28";
             // 
+            // NUD_NEUTRAL_z
+            // 
+            resources.ApplyResources(this.NUD_NEUTRAL_z, "NUD_NEUTRAL_z");
+            this.NUD_NEUTRAL_z.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_z.Max = 1F;
+            this.NUD_NEUTRAL_z.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_z.Min = 0F;
+            this.NUD_NEUTRAL_z.Name = "NUD_NEUTRAL_z";
+            this.NUD_NEUTRAL_z.ParamName = null;
+            this.NUD_NEUTRAL_z.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
             // label29
             // 
             resources.ApplyResources(this.label29, "label29");
             this.label29.Name = "label29";
             // 
+            // NUD_NEUTRAL_y
+            // 
+            resources.ApplyResources(this.NUD_NEUTRAL_y, "NUD_NEUTRAL_y");
+            this.NUD_NEUTRAL_y.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_y.Max = 1F;
+            this.NUD_NEUTRAL_y.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_y.Min = 0F;
+            this.NUD_NEUTRAL_y.Name = "NUD_NEUTRAL_y";
+            this.NUD_NEUTRAL_y.ParamName = null;
+            this.NUD_NEUTRAL_y.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            // 
             // label30
             // 
             resources.ApplyResources(this.label30, "label30");
             this.label30.Name = "label30";
+            // 
+            // NUD_NEUTRAL_x
+            // 
+            resources.ApplyResources(this.NUD_NEUTRAL_x, "NUD_NEUTRAL_x");
+            this.NUD_NEUTRAL_x.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_x.Max = 1F;
+            this.NUD_NEUTRAL_x.Maximum = new decimal(new int[] {
+            2200,
+            0,
+            0,
+            0});
+            this.NUD_NEUTRAL_x.Min = 0F;
+            this.NUD_NEUTRAL_x.Name = "NUD_NEUTRAL_x";
+            this.NUD_NEUTRAL_x.ParamName = null;
+            this.NUD_NEUTRAL_x.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
             // 
             // CMB_shuttertype
             // 
@@ -619,144 +761,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.mavlinkNumericUpDownShutMX.ParamName = null;
             this.mavlinkNumericUpDownShutMX.Value = new decimal(new int[] {
             2000,
-            0,
-            0,
-            0});
-            // 
-            // NUD_NEUTRAL_z
-            // 
-            resources.ApplyResources(this.NUD_NEUTRAL_z, "NUD_NEUTRAL_z");
-            this.NUD_NEUTRAL_z.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_z.Max = 1F;
-            this.NUD_NEUTRAL_z.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_z.Min = 0F;
-            this.NUD_NEUTRAL_z.Name = "NUD_NEUTRAL_z";
-            this.NUD_NEUTRAL_z.ParamName = null;
-            this.NUD_NEUTRAL_z.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // NUD_NEUTRAL_y
-            // 
-            resources.ApplyResources(this.NUD_NEUTRAL_y, "NUD_NEUTRAL_y");
-            this.NUD_NEUTRAL_y.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_y.Max = 1F;
-            this.NUD_NEUTRAL_y.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_y.Min = 0F;
-            this.NUD_NEUTRAL_y.Name = "NUD_NEUTRAL_y";
-            this.NUD_NEUTRAL_y.ParamName = null;
-            this.NUD_NEUTRAL_y.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // NUD_NEUTRAL_x
-            // 
-            resources.ApplyResources(this.NUD_NEUTRAL_x, "NUD_NEUTRAL_x");
-            this.NUD_NEUTRAL_x.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_x.Max = 1F;
-            this.NUD_NEUTRAL_x.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_NEUTRAL_x.Min = 0F;
-            this.NUD_NEUTRAL_x.Name = "NUD_NEUTRAL_x";
-            this.NUD_NEUTRAL_x.ParamName = null;
-            this.NUD_NEUTRAL_x.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // NUD_RETRACT_z
-            // 
-            resources.ApplyResources(this.NUD_RETRACT_z, "NUD_RETRACT_z");
-            this.NUD_RETRACT_z.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_z.Max = 1F;
-            this.NUD_RETRACT_z.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_z.Min = 0F;
-            this.NUD_RETRACT_z.Name = "NUD_RETRACT_z";
-            this.NUD_RETRACT_z.ParamName = null;
-            this.NUD_RETRACT_z.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // NUD_RETRACT_y
-            // 
-            resources.ApplyResources(this.NUD_RETRACT_y, "NUD_RETRACT_y");
-            this.NUD_RETRACT_y.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_y.Max = 1F;
-            this.NUD_RETRACT_y.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_y.Min = 0F;
-            this.NUD_RETRACT_y.Name = "NUD_RETRACT_y";
-            this.NUD_RETRACT_y.ParamName = null;
-            this.NUD_RETRACT_y.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // NUD_RETRACT_x
-            // 
-            resources.ApplyResources(this.NUD_RETRACT_x, "NUD_RETRACT_x");
-            this.NUD_RETRACT_x.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_x.Max = 1F;
-            this.NUD_RETRACT_x.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_RETRACT_x.Min = 0F;
-            this.NUD_RETRACT_x.Name = "NUD_RETRACT_x";
-            this.NUD_RETRACT_x.ParamName = null;
-            this.NUD_RETRACT_x.Value = new decimal(new int[] {
-            1000,
             0,
             0,
             0});
@@ -1139,8 +1143,36 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.mavlinkCheckBoxRR.ParamName = null;
             this.mavlinkCheckBoxRR.UseVisualStyleBackColor = true;
             // 
+            // label31
+            // 
+            resources.ApplyResources(this.label31, "label31");
+            this.label31.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.label31.Name = "label31";
+            // 
+            // label32
+            // 
+            resources.ApplyResources(this.label32, "label32");
+            this.label32.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.label32.Name = "label32";
+            // 
+            // label33
+            // 
+            resources.ApplyResources(this.label33, "label33");
+            this.label33.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.label33.Name = "label33";
+            // 
+            // label45
+            // 
+            resources.ApplyResources(this.label45, "label45");
+            this.label45.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.label45.Name = "label45";
+            // 
             // ConfigMount
             // 
+            this.Controls.Add(this.label45);
+            this.Controls.Add(this.label33);
+            this.Controls.Add(this.label32);
+            this.Controls.Add(this.label31);
             this.Controls.Add(this.label44);
             this.Controls.Add(this.label43);
             this.Controls.Add(this.CMB_mnt_type);
@@ -1222,20 +1254,20 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).EndInit();
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_duration)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutMX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_z)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_y)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_RETRACT_x)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAM)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTAMX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownTSM)).EndInit();
@@ -1341,5 +1373,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private System.Windows.Forms.Label label43;
         private System.Windows.Forms.Label label44;
         private ComboBox CMB_shuttertype;
+        private Label label31;
+        private Label label32;
+        private Label label33;
+        private Label label45;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigMount.designer.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.designer.cs
@@ -98,17 +98,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.NUD_NEUTRAL_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label30 = new System.Windows.Forms.Label();
             this.NUD_NEUTRAL_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.groupBox6 = new System.Windows.Forms.GroupBox();
-            this.label31 = new System.Windows.Forms.Label();
-            this.NUD_CONTROL_z = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label32 = new System.Windows.Forms.Label();
-            this.NUD_CONTROL_y = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.label33 = new System.Windows.Forms.Label();
-            this.NUD_CONTROL_x = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CHK_stab_tilt = new MissionPlanner.Controls.MavlinkCheckBox();
             this.CHK_stab_roll = new MissionPlanner.Controls.MavlinkCheckBox();
             this.CHK_stab_pan = new MissionPlanner.Controls.MavlinkCheckBox();
-            this.CMB_shuttertype =  new ComboBox();
+            this.CMB_shuttertype = new System.Windows.Forms.ComboBox();
             this.label35 = new System.Windows.Forms.Label();
             this.label36 = new System.Windows.Forms.Label();
             this.label37 = new System.Windows.Forms.Label();
@@ -151,10 +144,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).BeginInit();
-            this.groupBox6.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_CONTROL_z)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_CONTROL_y)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_CONTROL_x)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).BeginInit();
@@ -938,102 +927,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             0,
             0});
             // 
-            // groupBox6
-            // 
-            this.groupBox6.Controls.Add(this.label31);
-            this.groupBox6.Controls.Add(this.NUD_CONTROL_z);
-            this.groupBox6.Controls.Add(this.label32);
-            this.groupBox6.Controls.Add(this.NUD_CONTROL_y);
-            this.groupBox6.Controls.Add(this.label33);
-            this.groupBox6.Controls.Add(this.NUD_CONTROL_x);
-            resources.ApplyResources(this.groupBox6, "groupBox6");
-            this.groupBox6.Name = "groupBox6";
-            this.groupBox6.TabStop = false;
-            // 
-            // label31
-            // 
-            resources.ApplyResources(this.label31, "label31");
-            this.label31.Name = "label31";
-            // 
-            // NUD_CONTROL_z
-            // 
-            resources.ApplyResources(this.NUD_CONTROL_z, "NUD_CONTROL_z");
-            this.NUD_CONTROL_z.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_CONTROL_z.Max = 1F;
-            this.NUD_CONTROL_z.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_CONTROL_z.Min = 0F;
-            this.NUD_CONTROL_z.Name = "NUD_CONTROL_z";
-            this.NUD_CONTROL_z.ParamName = null;
-            this.NUD_CONTROL_z.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // label32
-            // 
-            resources.ApplyResources(this.label32, "label32");
-            this.label32.Name = "label32";
-            // 
-            // NUD_CONTROL_y
-            // 
-            resources.ApplyResources(this.NUD_CONTROL_y, "NUD_CONTROL_y");
-            this.NUD_CONTROL_y.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_CONTROL_y.Max = 1F;
-            this.NUD_CONTROL_y.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_CONTROL_y.Min = 0F;
-            this.NUD_CONTROL_y.Name = "NUD_CONTROL_y";
-            this.NUD_CONTROL_y.ParamName = null;
-            this.NUD_CONTROL_y.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
-            // label33
-            // 
-            resources.ApplyResources(this.label33, "label33");
-            this.label33.Name = "label33";
-            // 
-            // NUD_CONTROL_x
-            // 
-            resources.ApplyResources(this.NUD_CONTROL_x, "NUD_CONTROL_x");
-            this.NUD_CONTROL_x.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.NUD_CONTROL_x.Max = 1F;
-            this.NUD_CONTROL_x.Maximum = new decimal(new int[] {
-            2200,
-            0,
-            0,
-            0});
-            this.NUD_CONTROL_x.Min = 0F;
-            this.NUD_CONTROL_x.Name = "NUD_CONTROL_x";
-            this.NUD_CONTROL_x.ParamName = null;
-            this.NUD_CONTROL_x.Value = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            // 
             // CHK_stab_tilt
             // 
             resources.ApplyResources(this.CHK_stab_tilt, "CHK_stab_tilt");
@@ -1301,7 +1194,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Controls.Add(this.CHK_stab_pan);
             this.Controls.Add(this.CHK_stab_roll);
             this.Controls.Add(this.CHK_stab_tilt);
-            this.Controls.Add(this.groupBox6);
             this.Controls.Add(this.groupBox5);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.label24);
@@ -1383,11 +1275,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_z)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_y)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_NEUTRAL_x)).EndInit();
-            this.groupBox6.ResumeLayout(false);
-            this.groupBox6.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_CONTROL_z)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_CONTROL_y)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_CONTROL_x)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_pushed)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownshut_notpushed)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownShutM)).EndInit();
@@ -1467,13 +1354,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private MavlinkNumericUpDown NUD_NEUTRAL_y;
         private System.Windows.Forms.Label label30;
         private MavlinkNumericUpDown NUD_NEUTRAL_x;
-        private System.Windows.Forms.GroupBox groupBox6;
-        private System.Windows.Forms.Label label31;
-        private MavlinkNumericUpDown NUD_CONTROL_z;
-        private System.Windows.Forms.Label label32;
-        private MavlinkNumericUpDown NUD_CONTROL_y;
-        private System.Windows.Forms.Label label33;
-        private MavlinkNumericUpDown NUD_CONTROL_x;
         private MavlinkCheckBox CHK_stab_tilt;
         private MavlinkCheckBox CHK_stab_roll;
         private MavlinkCheckBox CHK_stab_pan;

--- a/GCSViews/ConfigurationView/ConfigMount.resx
+++ b/GCSViews/ConfigurationView/ConfigMount.resx
@@ -126,10 +126,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 47</value>
+    <value>72, 65</value>
   </data>
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>203, 112</value>
+    <value>164, 94</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
-    <value>73</value>
+    <value>77</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 181</value>
@@ -166,7 +166,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>71</value>
+    <value>75</value>
   </data>
   <data name="pictureBox2.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -175,10 +175,10 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 172</value>
+    <value>72, 192</value>
   </data>
   <data name="pictureBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>203, 112</value>
+    <value>164, 92</value>
   </data>
   <data name="pictureBox2.TabIndex" type="System.Int32, mscorlib">
     <value>53</value>
@@ -193,7 +193,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox2.ZOrder" xml:space="preserve">
-    <value>72</value>
+    <value>76</value>
   </data>
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 54</value>
@@ -214,7 +214,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>70</value>
+    <value>74</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -226,16 +226,16 @@
     <value>NoControl</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 35</value>
+    <value>20, 65</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 20</value>
+    <value>44, 20</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>64</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
-    <value>Tilt</value>
+    <value>Pitch</value>
   </data>
   <data name="&gt;&gt;label5.Name" xml:space="preserve">
     <value>label5</value>
@@ -247,7 +247,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>69</value>
+    <value>73</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -259,7 +259,7 @@
     <value>NoControl</value>
   </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 163</value>
+    <value>21, 192</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
     <value>36, 20</value>
@@ -280,7 +280,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>68</value>
+    <value>72</value>
   </data>
   <data name="LNK_wiki.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -313,7 +313,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;LNK_wiki.ZOrder" xml:space="preserve">
-    <value>67</value>
+    <value>71</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -325,16 +325,16 @@
     <value>NoControl</value>
   </data>
   <data name="label15.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 287</value>
+    <value>20, 316</value>
   </data>
   <data name="label15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 20</value>
+    <value>40, 20</value>
   </data>
   <data name="label15.TabIndex" type="System.Int32, mscorlib">
     <value>80</value>
   </data>
   <data name="label15.Text" xml:space="preserve">
-    <value>Pan</value>
+    <value>Yaw</value>
   </data>
   <data name="&gt;&gt;label15.Name" xml:space="preserve">
     <value>label15</value>
@@ -346,7 +346,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>64</value>
+    <value>68</value>
   </data>
   <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 305</value>
@@ -367,7 +367,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
-    <value>65</value>
+    <value>69</value>
   </data>
   <data name="pictureBox3.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -376,10 +376,10 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 296</value>
+    <value>72, 316</value>
   </data>
   <data name="pictureBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>203, 112</value>
+    <value>164, 92</value>
   </data>
   <data name="pictureBox3.TabIndex" type="System.Int32, mscorlib">
     <value>79</value>
@@ -394,7 +394,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox3.ZOrder" xml:space="preserve">
-    <value>66</value>
+    <value>70</value>
   </data>
   <data name="label9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,7 +427,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>53</value>
+    <value>57</value>
   </data>
   <data name="label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -439,16 +439,16 @@
     <value>NoControl</value>
   </data>
   <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 189</value>
+    <value>272, 189</value>
   </data>
   <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 20</value>
+    <value>50, 20</value>
   </data>
   <data name="label10.TabIndex" type="System.Int32, mscorlib">
     <value>104</value>
   </data>
   <data name="label10.Text" xml:space="preserve">
-    <value>Servo Limits</value>
+    <value>Servo</value>
   </data>
   <data name="&gt;&gt;label10.Name" xml:space="preserve">
     <value>label10</value>
@@ -460,7 +460,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>54</value>
+    <value>58</value>
   </data>
   <data name="label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -490,7 +490,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>55</value>
+    <value>59</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -520,7 +520,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>56</value>
+    <value>60</value>
   </data>
   <data name="label13.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -529,7 +529,7 @@
     <value>NoControl</value>
   </data>
   <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 242</value>
+    <value>246, 267</value>
   </data>
   <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
     <value>27, 13</value>
@@ -550,7 +550,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>59</value>
+    <value>63</value>
   </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -559,7 +559,7 @@
     <value>NoControl</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 214</value>
+    <value>246, 239</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
     <value>24, 13</value>
@@ -580,7 +580,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>60</value>
+    <value>64</value>
   </data>
   <data name="label16.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -613,7 +613,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>42</value>
+    <value>46</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -625,16 +625,16 @@
     <value>NoControl</value>
   </data>
   <data name="label17.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 313</value>
+    <value>272, 313</value>
   </data>
   <data name="label17.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 20</value>
+    <value>50, 20</value>
   </data>
   <data name="label17.TabIndex" type="System.Int32, mscorlib">
     <value>115</value>
   </data>
   <data name="label17.Text" xml:space="preserve">
-    <value>Servo Limits</value>
+    <value>Servo</value>
   </data>
   <data name="&gt;&gt;label17.Name" xml:space="preserve">
     <value>label17</value>
@@ -646,7 +646,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>43</value>
+    <value>47</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -676,7 +676,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>44</value>
+    <value>48</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -706,7 +706,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>45</value>
+    <value>49</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -715,7 +715,7 @@
     <value>NoControl</value>
   </data>
   <data name="label20.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 366</value>
+    <value>246, 391</value>
   </data>
   <data name="label20.Size" type="System.Drawing.Size, System.Drawing">
     <value>27, 13</value>
@@ -736,7 +736,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>48</value>
+    <value>52</value>
   </data>
   <data name="label21.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -745,7 +745,7 @@
     <value>NoControl</value>
   </data>
   <data name="label21.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 338</value>
+    <value>246, 363</value>
   </data>
   <data name="label21.Size" type="System.Drawing.Size, System.Drawing">
     <value>24, 13</value>
@@ -766,7 +766,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>49</value>
+    <value>53</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -799,7 +799,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>35</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -811,16 +811,16 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 62</value>
+    <value>272, 62</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 20</value>
+    <value>50, 20</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>126</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Servo Limits</value>
+    <value>Servo</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -832,7 +832,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>36</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -862,7 +862,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>37</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -892,7 +892,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>38</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -901,7 +901,7 @@
     <value>NoControl</value>
   </data>
   <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 115</value>
+    <value>246, 143</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
     <value>27, 13</value>
@@ -922,7 +922,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>37</value>
+    <value>41</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -931,7 +931,7 @@
     <value>NoControl</value>
   </data>
   <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 87</value>
+    <value>246, 115</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
     <value>24, 13</value>
@@ -952,13 +952,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>38</value>
+    <value>42</value>
   </data>
   <data name="mavlinkComboBoxTilt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>90, 34</value>
+    <value>276, 87</value>
   </data>
   <data name="mavlinkComboBoxTilt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>73, 21</value>
   </data>
   <data name="mavlinkComboBoxTilt.TabIndex" type="System.Int32, mscorlib">
     <value>128</value>
@@ -973,13 +973,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxTilt.ZOrder" xml:space="preserve">
-    <value>30</value>
+    <value>34</value>
   </data>
   <data name="mavlinkComboBoxRoll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>90, 162</value>
+    <value>276, 212</value>
   </data>
   <data name="mavlinkComboBoxRoll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>73, 21</value>
   </data>
   <data name="mavlinkComboBoxRoll.TabIndex" type="System.Int32, mscorlib">
     <value>129</value>
@@ -994,13 +994,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxRoll.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>33</value>
   </data>
   <data name="mavlinkComboBoxPan.Location" type="System.Drawing.Point, System.Drawing">
-    <value>90, 286</value>
+    <value>276, 336</value>
   </data>
   <data name="mavlinkComboBoxPan.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>73, 21</value>
   </data>
   <data name="mavlinkComboBoxPan.TabIndex" type="System.Int32, mscorlib">
     <value>130</value>
@@ -1015,7 +1015,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxPan.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>32</value>
   </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1048,7 +1048,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>30</value>
   </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1081,7 +1081,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>28</value>
   </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1114,7 +1114,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>26</value>
   </data>
   <data name="label27.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1162,7 +1162,7 @@
     <value>NUD_RETRACT_z</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_z.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1216,7 +1216,7 @@
     <value>NUD_RETRACT_y</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_y.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1270,7 +1270,7 @@
     <value>NUD_RETRACT_x</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_x.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1300,7 +1300,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>25</value>
   </data>
   <data name="label28.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1348,7 +1348,7 @@
     <value>NUD_NEUTRAL_z</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_z.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1402,7 +1402,7 @@
     <value>NUD_NEUTRAL_y</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_y.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1456,7 +1456,7 @@
     <value>NUD_NEUTRAL_x</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_x.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1486,13 +1486,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>24</value>
   </data>
   <data name="CMB_shuttertype.Location" type="System.Drawing.Point, System.Drawing">
-    <value>90, 425</value>
+    <value>276, 477</value>
   </data>
   <data name="CMB_shuttertype.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>73, 21</value>
   </data>
   <data name="CMB_shuttertype.TabIndex" type="System.Int32, mscorlib">
     <value>156</value>
@@ -1507,7 +1507,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_shuttertype.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="label35.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1540,7 +1540,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label35.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="label36.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1552,16 +1552,16 @@
     <value>NoControl</value>
   </data>
   <data name="label36.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 452</value>
+    <value>272, 452</value>
   </data>
   <data name="label36.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 20</value>
+    <value>50, 20</value>
   </data>
   <data name="label36.TabIndex" type="System.Int32, mscorlib">
     <value>154</value>
   </data>
   <data name="label36.Text" xml:space="preserve">
-    <value>Servo Limits</value>
+    <value>Servo</value>
   </data>
   <data name="&gt;&gt;label36.Name" xml:space="preserve">
     <value>label36</value>
@@ -1573,7 +1573,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label36.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="label37.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1603,7 +1603,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label37.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
   <data name="label38.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1633,7 +1633,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label38.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>14</value>
   </data>
   <data name="label39.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1642,7 +1642,7 @@
     <value>NoControl</value>
   </data>
   <data name="label39.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 505</value>
+    <value>246, 531</value>
   </data>
   <data name="label39.Size" type="System.Drawing.Size, System.Drawing">
     <value>27, 13</value>
@@ -1663,7 +1663,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label39.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>17</value>
   </data>
   <data name="label40.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1672,7 +1672,7 @@
     <value>NoControl</value>
   </data>
   <data name="label40.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 477</value>
+    <value>246, 505</value>
   </data>
   <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
     <value>24, 13</value>
@@ -1693,7 +1693,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>18</value>
   </data>
   <data name="label41.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1705,16 +1705,16 @@
     <value>NoControl</value>
   </data>
   <data name="label41.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 426</value>
+    <value>20, 452</value>
   </data>
   <data name="label41.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 20</value>
+    <value>122, 20</value>
   </data>
   <data name="label41.TabIndex" type="System.Int32, mscorlib">
     <value>144</value>
   </data>
   <data name="label41.Text" xml:space="preserve">
-    <value>Shutter</value>
+    <value>Camera Shutter</value>
   </data>
   <data name="&gt;&gt;label41.Name" xml:space="preserve">
     <value>label41</value>
@@ -1726,7 +1726,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>21</value>
   </data>
   <data name="groupBox7.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 444</value>
@@ -1747,7 +1747,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox7.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>22</value>
   </data>
   <data name="pictureBox4.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -1756,10 +1756,10 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 435</value>
+    <value>72, 463</value>
   </data>
   <data name="pictureBox4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>203, 112</value>
+    <value>164, 84</value>
   </data>
   <data name="pictureBox4.TabIndex" type="System.Int32, mscorlib">
     <value>143</value>
@@ -1774,7 +1774,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox4.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>23</value>
   </data>
   <data name="label34.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1801,7 +1801,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="label42.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1834,7 +1834,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="label43.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1867,7 +1867,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label43.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="label44.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1897,7 +1897,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="CMB_mnt_type.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1915,13 +1915,13 @@
     <value>CMB_mnt_type</value>
   </data>
   <data name="&gt;&gt;CMB_mnt_type.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_mnt_type.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_mnt_type.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="mavlinkNumericUpDownshut_duration.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1939,13 +1939,13 @@
     <value>mavlinkNumericUpDownshut_duration</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="mavlinkNumericUpDownshut_pushed.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1963,13 +1963,13 @@
     <value>mavlinkNumericUpDownshut_pushed</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>15</value>
   </data>
   <data name="mavlinkNumericUpDownshut_notpushed.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1987,19 +1987,19 @@
     <value>mavlinkNumericUpDownshut_notpushed</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>16</value>
   </data>
   <data name="mavlinkNumericUpDownShutM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownShutM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 475</value>
+    <value>276, 503</value>
   </data>
   <data name="mavlinkNumericUpDownShutM.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2011,19 +2011,19 @@
     <value>mavlinkNumericUpDownShutM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutM.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>19</value>
   </data>
   <data name="mavlinkNumericUpDownShutMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownShutMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 501</value>
+    <value>276, 527</value>
   </data>
   <data name="mavlinkNumericUpDownShutMX.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2035,13 +2035,13 @@
     <value>mavlinkNumericUpDownShutMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutMX.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>20</value>
   </data>
   <data name="CMB_inputch_pan.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2059,13 +2059,13 @@
     <value>CMB_inputch_pan</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_pan.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_pan.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_pan.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>27</value>
   </data>
   <data name="CMB_inputch_roll.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2083,13 +2083,13 @@
     <value>CMB_inputch_roll</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_roll.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_roll.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_roll.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>29</value>
   </data>
   <data name="CMB_inputch_tilt.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2107,13 +2107,13 @@
     <value>CMB_inputch_tilt</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_tilt.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_tilt.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_tilt.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>31</value>
   </data>
   <data name="mavlinkNumericUpDownTAM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2131,13 +2131,13 @@
     <value>mavlinkNumericUpDownTAM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAM.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>39</value>
   </data>
   <data name="mavlinkNumericUpDownTAMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2155,19 +2155,19 @@
     <value>mavlinkNumericUpDownTAMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAMX.ZOrder" xml:space="preserve">
-    <value>36</value>
+    <value>40</value>
   </data>
   <data name="mavlinkNumericUpDownTSM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownTSM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 85</value>
+    <value>276, 113</value>
   </data>
   <data name="mavlinkNumericUpDownTSM.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2179,19 +2179,19 @@
     <value>mavlinkNumericUpDownTSM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSM.ZOrder" xml:space="preserve">
-    <value>39</value>
+    <value>43</value>
   </data>
   <data name="mavlinkNumericUpDownTSMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownTSMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 111</value>
+    <value>276, 139</value>
   </data>
   <data name="mavlinkNumericUpDownTSMX.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2203,13 +2203,13 @@
     <value>mavlinkNumericUpDownTSMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSMX.ZOrder" xml:space="preserve">
-    <value>40</value>
+    <value>44</value>
   </data>
   <data name="mavlinkCheckBoxTR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2221,7 +2221,7 @@
     <value>NoControl</value>
   </data>
   <data name="mavlinkCheckBoxTR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 137</value>
+    <value>267, 165</value>
   </data>
   <data name="mavlinkCheckBoxTR.Size" type="System.Drawing.Size, System.Drawing">
     <value>66, 17</value>
@@ -2236,13 +2236,13 @@
     <value>mavlinkCheckBoxTR</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxTR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxTR.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxTR.ZOrder" xml:space="preserve">
-    <value>41</value>
+    <value>45</value>
   </data>
   <data name="mavlinkNumericUpDownPAM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2260,13 +2260,13 @@
     <value>mavlinkNumericUpDownPAM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAM.ZOrder" xml:space="preserve">
-    <value>46</value>
+    <value>50</value>
   </data>
   <data name="mavlinkNumericUpDownPAMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2284,19 +2284,19 @@
     <value>mavlinkNumericUpDownPAMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAMX.ZOrder" xml:space="preserve">
-    <value>47</value>
+    <value>51</value>
   </data>
   <data name="mavlinkNumericUpDownPSM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownPSM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 336</value>
+    <value>276, 361</value>
   </data>
   <data name="mavlinkNumericUpDownPSM.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2308,19 +2308,19 @@
     <value>mavlinkNumericUpDownPSM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSM.ZOrder" xml:space="preserve">
-    <value>50</value>
+    <value>54</value>
   </data>
   <data name="mavlinkNumericUpDownPSMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownPSMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 362</value>
+    <value>276, 387</value>
   </data>
   <data name="mavlinkNumericUpDownPSMX.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2332,13 +2332,13 @@
     <value>mavlinkNumericUpDownPSMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSMX.ZOrder" xml:space="preserve">
-    <value>51</value>
+    <value>55</value>
   </data>
   <data name="mavlinkCheckBoxPR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2350,7 +2350,7 @@
     <value>NoControl</value>
   </data>
   <data name="mavlinkCheckBoxPR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 388</value>
+    <value>267, 413</value>
   </data>
   <data name="mavlinkCheckBoxPR.Size" type="System.Drawing.Size, System.Drawing">
     <value>66, 17</value>
@@ -2365,13 +2365,13 @@
     <value>mavlinkCheckBoxPR</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxPR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxPR.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxPR.ZOrder" xml:space="preserve">
-    <value>52</value>
+    <value>56</value>
   </data>
   <data name="mavlinkNumericUpDownRAM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2389,13 +2389,13 @@
     <value>mavlinkNumericUpDownRAM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAM.ZOrder" xml:space="preserve">
-    <value>57</value>
+    <value>61</value>
   </data>
   <data name="mavlinkNumericUpDownRAMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2413,19 +2413,19 @@
     <value>mavlinkNumericUpDownRAMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAMX.ZOrder" xml:space="preserve">
-    <value>58</value>
+    <value>62</value>
   </data>
   <data name="mavlinkNumericUpDownRSM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownRSM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 212</value>
+    <value>276, 237</value>
   </data>
   <data name="mavlinkNumericUpDownRSM.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2437,19 +2437,19 @@
     <value>mavlinkNumericUpDownRSM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSM.ZOrder" xml:space="preserve">
-    <value>61</value>
+    <value>65</value>
   </data>
   <data name="mavlinkNumericUpDownRSMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="mavlinkNumericUpDownRSMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 238</value>
+    <value>276, 263</value>
   </data>
   <data name="mavlinkNumericUpDownRSMX.Size" type="System.Drawing.Size, System.Drawing">
     <value>59, 20</value>
@@ -2461,13 +2461,13 @@
     <value>mavlinkNumericUpDownRSMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSMX.ZOrder" xml:space="preserve">
-    <value>62</value>
+    <value>66</value>
   </data>
   <data name="mavlinkCheckBoxRR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2479,7 +2479,7 @@
     <value>NoControl</value>
   </data>
   <data name="mavlinkCheckBoxRR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 264</value>
+    <value>267, 289</value>
   </data>
   <data name="mavlinkCheckBoxRR.Size" type="System.Drawing.Size, System.Drawing">
     <value>66, 17</value>
@@ -2494,13 +2494,133 @@
     <value>mavlinkCheckBoxRR</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxRR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.29603, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxRR.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxRR.ZOrder" xml:space="preserve">
-    <value>63</value>
+    <value>67</value>
+  </data>
+  <data name="label31.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label31.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label31.Location" type="System.Drawing.Point, System.Drawing">
+    <value>246, 90</value>
+  </data>
+  <data name="label31.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 13</value>
+  </data>
+  <data name="label31.TabIndex" type="System.Int32, mscorlib">
+    <value>162</value>
+  </data>
+  <data name="label31.Text" xml:space="preserve">
+    <value>Ch</value>
+  </data>
+  <data name="&gt;&gt;label31.Name" xml:space="preserve">
+    <value>label31</value>
+  </data>
+  <data name="&gt;&gt;label31.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label32.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label32.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label32.Location" type="System.Drawing.Point, System.Drawing">
+    <value>246, 214</value>
+  </data>
+  <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 13</value>
+  </data>
+  <data name="label32.TabIndex" type="System.Int32, mscorlib">
+    <value>163</value>
+  </data>
+  <data name="label32.Text" xml:space="preserve">
+    <value>Ch</value>
+  </data>
+  <data name="&gt;&gt;label32.Name" xml:space="preserve">
+    <value>label32</value>
+  </data>
+  <data name="&gt;&gt;label32.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label33.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label33.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
+    <value>246, 338</value>
+  </data>
+  <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 13</value>
+  </data>
+  <data name="label33.TabIndex" type="System.Int32, mscorlib">
+    <value>164</value>
+  </data>
+  <data name="label33.Text" xml:space="preserve">
+    <value>Ch</value>
+  </data>
+  <data name="&gt;&gt;label33.Name" xml:space="preserve">
+    <value>label33</value>
+  </data>
+  <data name="&gt;&gt;label33.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label45.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label45.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label45.Location" type="System.Drawing.Point, System.Drawing">
+    <value>246, 478</value>
+  </data>
+  <data name="label45.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 13</value>
+  </data>
+  <data name="label45.TabIndex" type="System.Int32, mscorlib">
+    <value>165</value>
+  </data>
+  <data name="label45.Text" xml:space="preserve">
+    <value>Ch</value>
+  </data>
+  <data name="&gt;&gt;label45.Name" xml:space="preserve">
+    <value>label45</value>
+  </data>
+  <data name="&gt;&gt;label45.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label45.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label45.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/GCSViews/ConfigurationView/ConfigMount.resx
+++ b/GCSViews/ConfigurationView/ConfigMount.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
-    <value>76</value>
+    <value>73</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 181</value>
@@ -166,7 +166,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>74</value>
+    <value>71</value>
   </data>
   <data name="pictureBox2.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -193,7 +193,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox2.ZOrder" xml:space="preserve">
-    <value>75</value>
+    <value>72</value>
   </data>
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 54</value>
@@ -214,7 +214,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>73</value>
+    <value>70</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -247,7 +247,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>72</value>
+    <value>69</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -280,7 +280,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>71</value>
+    <value>68</value>
   </data>
   <data name="LNK_wiki.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -313,7 +313,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;LNK_wiki.ZOrder" xml:space="preserve">
-    <value>70</value>
+    <value>67</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -346,7 +346,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>67</value>
+    <value>64</value>
   </data>
   <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 305</value>
@@ -367,7 +367,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
-    <value>68</value>
+    <value>65</value>
   </data>
   <data name="pictureBox3.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -394,7 +394,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox3.ZOrder" xml:space="preserve">
-    <value>69</value>
+    <value>66</value>
   </data>
   <data name="label9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,7 +427,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>56</value>
+    <value>53</value>
   </data>
   <data name="label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -460,7 +460,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>57</value>
+    <value>54</value>
   </data>
   <data name="label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -490,7 +490,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>58</value>
+    <value>55</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -520,7 +520,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>59</value>
+    <value>56</value>
   </data>
   <data name="label13.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -550,7 +550,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>62</value>
+    <value>59</value>
   </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -580,7 +580,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>63</value>
+    <value>60</value>
   </data>
   <data name="label16.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -613,7 +613,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>45</value>
+    <value>42</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -646,7 +646,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>46</value>
+    <value>43</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -676,7 +676,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>47</value>
+    <value>44</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -706,7 +706,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>48</value>
+    <value>45</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -736,7 +736,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>51</value>
+    <value>48</value>
   </data>
   <data name="label21.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -766,7 +766,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>52</value>
+    <value>49</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -799,7 +799,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>31</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -832,7 +832,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>32</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -862,7 +862,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>36</value>
+    <value>33</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -892,7 +892,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>37</value>
+    <value>34</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -922,7 +922,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>40</value>
+    <value>37</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -952,7 +952,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>41</value>
+    <value>38</value>
   </data>
   <data name="mavlinkComboBoxTilt.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 34</value>
@@ -973,7 +973,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxTilt.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>30</value>
   </data>
   <data name="mavlinkComboBoxRoll.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 162</value>
@@ -994,7 +994,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxRoll.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>29</value>
   </data>
   <data name="mavlinkComboBoxPan.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 286</value>
@@ -1015,7 +1015,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxPan.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>28</value>
   </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1048,7 +1048,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>26</value>
   </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1081,7 +1081,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>24</value>
   </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1114,466 +1114,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="CMB_inputch_pan.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CMB_inputch_pan.Location" type="System.Drawing.Point, System.Drawing">
-    <value>450, 336</value>
-  </data>
-  <data name="CMB_inputch_pan.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 21</value>
-  </data>
-  <data name="CMB_inputch_pan.TabIndex" type="System.Int32, mscorlib">
-    <value>135</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_pan.Name" xml:space="preserve">
-    <value>CMB_inputch_pan</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_pan.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_pan.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_pan.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="CMB_inputch_roll.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CMB_inputch_roll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>450, 212</value>
-  </data>
-  <data name="CMB_inputch_roll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 21</value>
-  </data>
-  <data name="CMB_inputch_roll.TabIndex" type="System.Int32, mscorlib">
-    <value>133</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_roll.Name" xml:space="preserve">
-    <value>CMB_inputch_roll</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_roll.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_roll.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_roll.ZOrder" xml:space="preserve">
-    <value>28</value>
-  </data>
-  <data name="CMB_inputch_tilt.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CMB_inputch_tilt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>450, 85</value>
-  </data>
-  <data name="CMB_inputch_tilt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 21</value>
-  </data>
-  <data name="CMB_inputch_tilt.TabIndex" type="System.Int32, mscorlib">
-    <value>131</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_tilt.Name" xml:space="preserve">
-    <value>CMB_inputch_tilt</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_tilt.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_tilt.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_inputch_tilt.ZOrder" xml:space="preserve">
-    <value>30</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>385, 85</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAM.TabIndex" type="System.Int32, mscorlib">
-    <value>123</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownTAM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAM.ZOrder" xml:space="preserve">
-    <value>38</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>385, 111</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownTAMX.TabIndex" type="System.Int32, mscorlib">
-    <value>122</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownTAMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.ZOrder" xml:space="preserve">
-    <value>39</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 85</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSM.TabIndex" type="System.Int32, mscorlib">
-    <value>119</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownTSM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSM.ZOrder" xml:space="preserve">
-    <value>42</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 111</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownTSMX.TabIndex" type="System.Int32, mscorlib">
-    <value>118</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownTSMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.ZOrder" xml:space="preserve">
-    <value>43</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 137</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 17</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.TabIndex" type="System.Int32, mscorlib">
-    <value>117</value>
-  </data>
-  <data name="mavlinkCheckBoxTR.Text" xml:space="preserve">
-    <value>Reverse</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxTR.Name" xml:space="preserve">
-    <value>mavlinkCheckBoxTR</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxTR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxTR.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxTR.ZOrder" xml:space="preserve">
-    <value>44</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>385, 336</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAM.TabIndex" type="System.Int32, mscorlib">
-    <value>112</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownPAM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAM.ZOrder" xml:space="preserve">
-    <value>49</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>385, 362</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownPAMX.TabIndex" type="System.Int32, mscorlib">
-    <value>111</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownPAMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.ZOrder" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 336</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSM.TabIndex" type="System.Int32, mscorlib">
-    <value>108</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownPSM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSM.ZOrder" xml:space="preserve">
-    <value>53</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 362</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownPSMX.TabIndex" type="System.Int32, mscorlib">
-    <value>107</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownPSMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.ZOrder" xml:space="preserve">
-    <value>54</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 388</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 17</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.TabIndex" type="System.Int32, mscorlib">
-    <value>106</value>
-  </data>
-  <data name="mavlinkCheckBoxPR.Text" xml:space="preserve">
-    <value>Reverse</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxPR.Name" xml:space="preserve">
-    <value>mavlinkCheckBoxPR</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxPR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxPR.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxPR.ZOrder" xml:space="preserve">
-    <value>55</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>385, 212</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAM.TabIndex" type="System.Int32, mscorlib">
-    <value>101</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownRAM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAM.ZOrder" xml:space="preserve">
-    <value>60</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>385, 238</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownRAMX.TabIndex" type="System.Int32, mscorlib">
-    <value>100</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownRAMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.ZOrder" xml:space="preserve">
-    <value>61</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 212</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSM.TabIndex" type="System.Int32, mscorlib">
-    <value>97</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownRSM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSM.ZOrder" xml:space="preserve">
-    <value>64</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 238</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownRSMX.TabIndex" type="System.Int32, mscorlib">
-    <value>96</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownRSMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.ZOrder" xml:space="preserve">
-    <value>65</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 264</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 17</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.TabIndex" type="System.Int32, mscorlib">
-    <value>95</value>
-  </data>
-  <data name="mavlinkCheckBoxRR.Text" xml:space="preserve">
-    <value>Reverse</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxRR.Name" xml:space="preserve">
-    <value>mavlinkCheckBoxRR</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxRR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxRR.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkCheckBoxRR.ZOrder" xml:space="preserve">
-    <value>66</value>
+    <value>22</value>
   </data>
   <data name="label27.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1621,7 +1162,7 @@
     <value>NUD_RETRACT_z</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_z.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1675,7 +1216,7 @@
     <value>NUD_RETRACT_y</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_y.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1685,6 +1226,9 @@
   </data>
   <data name="label25.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="label25.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="label25.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 21</value>
@@ -1726,7 +1270,7 @@
     <value>NUD_RETRACT_x</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_x.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1756,7 +1300,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>21</value>
   </data>
   <data name="label28.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1804,7 +1348,7 @@
     <value>NUD_NEUTRAL_z</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_z.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1858,7 +1402,7 @@
     <value>NUD_NEUTRAL_y</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_y.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1912,7 +1456,7 @@
     <value>NUD_NEUTRAL_x</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_x.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1942,102 +1486,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="CHK_stab_tilt.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_stab_tilt.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CHK_stab_tilt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 36</value>
-  </data>
-  <data name="CHK_stab_tilt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 17</value>
-  </data>
-  <data name="CHK_stab_tilt.TabIndex" type="System.Int32, mscorlib">
-    <value>139</value>
-  </data>
-  <data name="CHK_stab_tilt.Text" xml:space="preserve">
-    <value>Stabalise Tilt</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_tilt.Name" xml:space="preserve">
-    <value>CHK_stab_tilt</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_tilt.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_tilt.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_tilt.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="CHK_stab_roll.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_stab_roll.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CHK_stab_roll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_stab_roll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 164</value>
-  </data>
-  <data name="CHK_stab_roll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 17</value>
-  </data>
-  <data name="CHK_stab_roll.TabIndex" type="System.Int32, mscorlib">
-    <value>140</value>
-  </data>
-  <data name="CHK_stab_roll.Text" xml:space="preserve">
-    <value>Stabalise Roll</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_roll.Name" xml:space="preserve">
-    <value>CHK_stab_roll</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_roll.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_roll.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_roll.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="CHK_stab_pan.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_stab_pan.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CHK_stab_pan.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_stab_pan.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 288</value>
-  </data>
-  <data name="CHK_stab_pan.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
-  </data>
-  <data name="CHK_stab_pan.TabIndex" type="System.Int32, mscorlib">
-    <value>141</value>
-  </data>
-  <data name="CHK_stab_pan.Text" xml:space="preserve">
-    <value>Stabalise Pan</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_pan.Name" xml:space="preserve">
-    <value>CHK_stab_pan</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_pan.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_pan.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_stab_pan.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
   <data name="CMB_shuttertype.Location" type="System.Drawing.Point, System.Drawing">
@@ -2187,54 +1635,6 @@
   <data name="&gt;&gt;label38.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
-  <data name="mavlinkNumericUpDownshut_pushed.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_pushed.Location" type="System.Drawing.Point, System.Drawing">
-    <value>423, 475</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_pushed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_pushed.TabIndex" type="System.Int32, mscorlib">
-    <value>151</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownshut_pushed</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_notpushed.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_notpushed.Location" type="System.Drawing.Point, System.Drawing">
-    <value>423, 501</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_notpushed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_notpushed.TabIndex" type="System.Int32, mscorlib">
-    <value>150</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownshut_notpushed</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="label39.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2294,54 +1694,6 @@
   </data>
   <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
     <value>14</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutM.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 475</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutM.TabIndex" type="System.Int32, mscorlib">
-    <value>147</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutM.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownShutM</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutM.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutM.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutMX.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutMX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>276, 501</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutMX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownShutMX.TabIndex" type="System.Int32, mscorlib">
-    <value>146</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownShutMX</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.ZOrder" xml:space="preserve">
-    <value>16</value>
   </data>
   <data name="label41.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2451,30 +1803,6 @@
   <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="mavlinkNumericUpDownshut_duration.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_duration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>423, 527</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_duration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="mavlinkNumericUpDownshut_duration.TabIndex" type="System.Int32, mscorlib">
-    <value>157</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Name" xml:space="preserve">
-    <value>mavlinkNumericUpDownshut_duration</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="label42.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2507,30 +1835,6 @@
   </data>
   <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="CMB_mnt_type.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CMB_mnt_type.Location" type="System.Drawing.Point, System.Drawing">
-    <value>90, 7</value>
-  </data>
-  <data name="CMB_mnt_type.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
-  </data>
-  <data name="CMB_mnt_type.TabIndex" type="System.Int32, mscorlib">
-    <value>160</value>
-  </data>
-  <data name="&gt;&gt;CMB_mnt_type.Name" xml:space="preserve">
-    <value>CMB_mnt_type</value>
-  </data>
-  <data name="&gt;&gt;CMB_mnt_type.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CMB_mnt_type.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_mnt_type.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label43.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2594,6 +1898,609 @@
   </data>
   <data name="&gt;&gt;label44.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="CMB_mnt_type.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CMB_mnt_type.Location" type="System.Drawing.Point, System.Drawing">
+    <value>90, 7</value>
+  </data>
+  <data name="CMB_mnt_type.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="CMB_mnt_type.TabIndex" type="System.Int32, mscorlib">
+    <value>160</value>
+  </data>
+  <data name="&gt;&gt;CMB_mnt_type.Name" xml:space="preserve">
+    <value>CMB_mnt_type</value>
+  </data>
+  <data name="&gt;&gt;CMB_mnt_type.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CMB_mnt_type.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_mnt_type.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_duration.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_duration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>423, 527</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_duration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_duration.TabIndex" type="System.Int32, mscorlib">
+    <value>157</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownshut_duration</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_pushed.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_pushed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>423, 475</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_pushed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_pushed.TabIndex" type="System.Int32, mscorlib">
+    <value>151</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownshut_pushed</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_notpushed.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_notpushed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>423, 501</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_notpushed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownshut_notpushed.TabIndex" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownshut_notpushed</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 475</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutM.TabIndex" type="System.Int32, mscorlib">
+    <value>147</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownShutM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutM.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 501</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownShutMX.TabIndex" type="System.Int32, mscorlib">
+    <value>146</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownShutMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownShutMX.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="CMB_inputch_pan.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CMB_inputch_pan.Location" type="System.Drawing.Point, System.Drawing">
+    <value>450, 336</value>
+  </data>
+  <data name="CMB_inputch_pan.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 21</value>
+  </data>
+  <data name="CMB_inputch_pan.TabIndex" type="System.Int32, mscorlib">
+    <value>135</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_pan.Name" xml:space="preserve">
+    <value>CMB_inputch_pan</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_pan.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_pan.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_pan.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="CMB_inputch_roll.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CMB_inputch_roll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>450, 212</value>
+  </data>
+  <data name="CMB_inputch_roll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 21</value>
+  </data>
+  <data name="CMB_inputch_roll.TabIndex" type="System.Int32, mscorlib">
+    <value>133</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_roll.Name" xml:space="preserve">
+    <value>CMB_inputch_roll</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_roll.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_roll.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_roll.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="CMB_inputch_tilt.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CMB_inputch_tilt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>450, 85</value>
+  </data>
+  <data name="CMB_inputch_tilt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 21</value>
+  </data>
+  <data name="CMB_inputch_tilt.TabIndex" type="System.Int32, mscorlib">
+    <value>131</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_tilt.Name" xml:space="preserve">
+    <value>CMB_inputch_tilt</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_tilt.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_tilt.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_inputch_tilt.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 85</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAM.TabIndex" type="System.Int32, mscorlib">
+    <value>123</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownTAM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAM.ZOrder" xml:space="preserve">
+    <value>35</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 111</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownTAMX.TabIndex" type="System.Int32, mscorlib">
+    <value>122</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownTAMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTAMX.ZOrder" xml:space="preserve">
+    <value>36</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 85</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSM.TabIndex" type="System.Int32, mscorlib">
+    <value>119</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownTSM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSM.ZOrder" xml:space="preserve">
+    <value>39</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 111</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownTSMX.TabIndex" type="System.Int32, mscorlib">
+    <value>118</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownTSMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownTSMX.ZOrder" xml:space="preserve">
+    <value>40</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>267, 137</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 17</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.TabIndex" type="System.Int32, mscorlib">
+    <value>117</value>
+  </data>
+  <data name="mavlinkCheckBoxTR.Text" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxTR.Name" xml:space="preserve">
+    <value>mavlinkCheckBoxTR</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxTR.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxTR.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxTR.ZOrder" xml:space="preserve">
+    <value>41</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 336</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAM.TabIndex" type="System.Int32, mscorlib">
+    <value>112</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownPAM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAM.ZOrder" xml:space="preserve">
+    <value>46</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 362</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownPAMX.TabIndex" type="System.Int32, mscorlib">
+    <value>111</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownPAMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPAMX.ZOrder" xml:space="preserve">
+    <value>47</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 336</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSM.TabIndex" type="System.Int32, mscorlib">
+    <value>108</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownPSM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSM.ZOrder" xml:space="preserve">
+    <value>50</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 362</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownPSMX.TabIndex" type="System.Int32, mscorlib">
+    <value>107</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownPSMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownPSMX.ZOrder" xml:space="preserve">
+    <value>51</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>267, 388</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 17</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.TabIndex" type="System.Int32, mscorlib">
+    <value>106</value>
+  </data>
+  <data name="mavlinkCheckBoxPR.Text" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxPR.Name" xml:space="preserve">
+    <value>mavlinkCheckBoxPR</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxPR.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxPR.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxPR.ZOrder" xml:space="preserve">
+    <value>52</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 212</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAM.TabIndex" type="System.Int32, mscorlib">
+    <value>101</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownRAM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAM.ZOrder" xml:space="preserve">
+    <value>57</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>385, 238</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownRAMX.TabIndex" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownRAMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRAMX.ZOrder" xml:space="preserve">
+    <value>58</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSM.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 212</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSM.TabIndex" type="System.Int32, mscorlib">
+    <value>97</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSM.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownRSM</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSM.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSM.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSM.ZOrder" xml:space="preserve">
+    <value>61</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSMX.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSMX.Location" type="System.Drawing.Point, System.Drawing">
+    <value>276, 238</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSMX.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 20</value>
+  </data>
+  <data name="mavlinkNumericUpDownRSMX.TabIndex" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Name" xml:space="preserve">
+    <value>mavlinkNumericUpDownRSMX</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkNumericUpDownRSMX.ZOrder" xml:space="preserve">
+    <value>62</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>267, 264</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 17</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.TabIndex" type="System.Int32, mscorlib">
+    <value>95</value>
+  </data>
+  <data name="mavlinkCheckBoxRR.Text" xml:space="preserve">
+    <value>Reverse</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxRR.Name" xml:space="preserve">
+    <value>mavlinkCheckBoxRR</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxRR.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17541, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxRR.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;mavlinkCheckBoxRR.ZOrder" xml:space="preserve">
+    <value>63</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/GCSViews/ConfigurationView/ConfigMount.resx
+++ b/GCSViews/ConfigurationView/ConfigMount.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
-    <value>77</value>
+    <value>76</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 181</value>
@@ -166,7 +166,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>75</value>
+    <value>74</value>
   </data>
   <data name="pictureBox2.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -193,7 +193,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox2.ZOrder" xml:space="preserve">
-    <value>76</value>
+    <value>75</value>
   </data>
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 54</value>
@@ -214,7 +214,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>74</value>
+    <value>73</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -247,7 +247,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>73</value>
+    <value>72</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -280,7 +280,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>72</value>
+    <value>71</value>
   </data>
   <data name="LNK_wiki.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -313,7 +313,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;LNK_wiki.ZOrder" xml:space="preserve">
-    <value>71</value>
+    <value>70</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -346,7 +346,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>68</value>
+    <value>67</value>
   </data>
   <data name="groupBox3.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 305</value>
@@ -367,7 +367,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
-    <value>69</value>
+    <value>68</value>
   </data>
   <data name="pictureBox3.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Zoom</value>
@@ -394,7 +394,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureBox3.ZOrder" xml:space="preserve">
-    <value>70</value>
+    <value>69</value>
   </data>
   <data name="label9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,7 +427,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>57</value>
+    <value>56</value>
   </data>
   <data name="label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -460,7 +460,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>58</value>
+    <value>57</value>
   </data>
   <data name="label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -490,7 +490,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>59</value>
+    <value>58</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -520,7 +520,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>60</value>
+    <value>59</value>
   </data>
   <data name="label13.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -550,7 +550,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>63</value>
+    <value>62</value>
   </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -580,7 +580,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>64</value>
+    <value>63</value>
   </data>
   <data name="label16.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -613,7 +613,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>46</value>
+    <value>45</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -646,7 +646,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>47</value>
+    <value>46</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -676,7 +676,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>48</value>
+    <value>47</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -706,7 +706,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>49</value>
+    <value>48</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -736,7 +736,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>52</value>
+    <value>51</value>
   </data>
   <data name="label21.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -766,7 +766,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>53</value>
+    <value>52</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -799,7 +799,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>34</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -832,7 +832,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>36</value>
+    <value>35</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -862,7 +862,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>37</value>
+    <value>36</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -892,7 +892,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>38</value>
+    <value>37</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -922,7 +922,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>41</value>
+    <value>40</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -952,7 +952,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>42</value>
+    <value>41</value>
   </data>
   <data name="mavlinkComboBoxTilt.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 34</value>
@@ -973,7 +973,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxTilt.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>33</value>
   </data>
   <data name="mavlinkComboBoxRoll.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 162</value>
@@ -994,7 +994,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxRoll.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>32</value>
   </data>
   <data name="mavlinkComboBoxPan.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 286</value>
@@ -1015,7 +1015,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkComboBoxPan.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>31</value>
   </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1048,7 +1048,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>30</value>
+    <value>29</value>
   </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1081,7 +1081,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>27</value>
   </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1114,7 +1114,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>25</value>
   </data>
   <data name="CMB_inputch_pan.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1132,13 +1132,13 @@
     <value>CMB_inputch_pan</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_pan.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_pan.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_pan.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>26</value>
   </data>
   <data name="CMB_inputch_roll.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1156,13 +1156,13 @@
     <value>CMB_inputch_roll</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_roll.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_roll.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_roll.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>28</value>
   </data>
   <data name="CMB_inputch_tilt.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1180,13 +1180,13 @@
     <value>CMB_inputch_tilt</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_tilt.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_tilt.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_inputch_tilt.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>30</value>
   </data>
   <data name="mavlinkNumericUpDownTAM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1204,13 +1204,13 @@
     <value>mavlinkNumericUpDownTAM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAM.ZOrder" xml:space="preserve">
-    <value>39</value>
+    <value>38</value>
   </data>
   <data name="mavlinkNumericUpDownTAMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1228,13 +1228,13 @@
     <value>mavlinkNumericUpDownTAMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTAMX.ZOrder" xml:space="preserve">
-    <value>40</value>
+    <value>39</value>
   </data>
   <data name="mavlinkNumericUpDownTSM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1252,13 +1252,13 @@
     <value>mavlinkNumericUpDownTSM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSM.ZOrder" xml:space="preserve">
-    <value>43</value>
+    <value>42</value>
   </data>
   <data name="mavlinkNumericUpDownTSMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1276,13 +1276,13 @@
     <value>mavlinkNumericUpDownTSMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownTSMX.ZOrder" xml:space="preserve">
-    <value>44</value>
+    <value>43</value>
   </data>
   <data name="mavlinkCheckBoxTR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1309,13 +1309,13 @@
     <value>mavlinkCheckBoxTR</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxTR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxTR.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxTR.ZOrder" xml:space="preserve">
-    <value>45</value>
+    <value>44</value>
   </data>
   <data name="mavlinkNumericUpDownPAM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1333,13 +1333,13 @@
     <value>mavlinkNumericUpDownPAM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAM.ZOrder" xml:space="preserve">
-    <value>50</value>
+    <value>49</value>
   </data>
   <data name="mavlinkNumericUpDownPAMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1357,13 +1357,13 @@
     <value>mavlinkNumericUpDownPAMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPAMX.ZOrder" xml:space="preserve">
-    <value>51</value>
+    <value>50</value>
   </data>
   <data name="mavlinkNumericUpDownPSM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1381,13 +1381,13 @@
     <value>mavlinkNumericUpDownPSM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSM.ZOrder" xml:space="preserve">
-    <value>54</value>
+    <value>53</value>
   </data>
   <data name="mavlinkNumericUpDownPSMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1405,13 +1405,13 @@
     <value>mavlinkNumericUpDownPSMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownPSMX.ZOrder" xml:space="preserve">
-    <value>55</value>
+    <value>54</value>
   </data>
   <data name="mavlinkCheckBoxPR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1438,13 +1438,13 @@
     <value>mavlinkCheckBoxPR</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxPR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxPR.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxPR.ZOrder" xml:space="preserve">
-    <value>56</value>
+    <value>55</value>
   </data>
   <data name="mavlinkNumericUpDownRAM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1462,13 +1462,13 @@
     <value>mavlinkNumericUpDownRAM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAM.ZOrder" xml:space="preserve">
-    <value>61</value>
+    <value>60</value>
   </data>
   <data name="mavlinkNumericUpDownRAMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1486,13 +1486,13 @@
     <value>mavlinkNumericUpDownRAMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRAMX.ZOrder" xml:space="preserve">
-    <value>62</value>
+    <value>61</value>
   </data>
   <data name="mavlinkNumericUpDownRSM.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1510,13 +1510,13 @@
     <value>mavlinkNumericUpDownRSM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSM.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSM.ZOrder" xml:space="preserve">
-    <value>65</value>
+    <value>64</value>
   </data>
   <data name="mavlinkNumericUpDownRSMX.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1534,13 +1534,13 @@
     <value>mavlinkNumericUpDownRSMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSMX.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownRSMX.ZOrder" xml:space="preserve">
-    <value>66</value>
+    <value>65</value>
   </data>
   <data name="mavlinkCheckBoxRR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1567,13 +1567,13 @@
     <value>mavlinkCheckBoxRR</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxRR.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxRR.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;mavlinkCheckBoxRR.ZOrder" xml:space="preserve">
-    <value>67</value>
+    <value>66</value>
   </data>
   <data name="label27.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1621,7 +1621,7 @@
     <value>NUD_RETRACT_z</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_z.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1675,7 +1675,7 @@
     <value>NUD_RETRACT_y</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_y.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1726,7 +1726,7 @@
     <value>NUD_RETRACT_x</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_RETRACT_x.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -1756,7 +1756,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>24</value>
   </data>
   <data name="label28.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1804,7 +1804,7 @@
     <value>NUD_NEUTRAL_z</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_z.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1858,7 +1858,7 @@
     <value>NUD_NEUTRAL_y</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_y.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1912,7 +1912,7 @@
     <value>NUD_NEUTRAL_x</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;NUD_NEUTRAL_x.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -1942,192 +1942,6 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="label31.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label31.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label31.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 73</value>
-  </data>
-  <data name="label31.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
-  </data>
-  <data name="label31.TabIndex" type="System.Int32, mscorlib">
-    <value>129</value>
-  </data>
-  <data name="label31.Text" xml:space="preserve">
-    <value>Z</value>
-  </data>
-  <data name="&gt;&gt;label31.Name" xml:space="preserve">
-    <value>label31</value>
-  </data>
-  <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="NUD_CONTROL_z.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="NUD_CONTROL_z.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 71</value>
-  </data>
-  <data name="NUD_CONTROL_z.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="NUD_CONTROL_z.TabIndex" type="System.Int32, mscorlib">
-    <value>128</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_z.Name" xml:space="preserve">
-    <value>NUD_CONTROL_z</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_z.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_z.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_z.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label32.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label32.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label32.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 47</value>
-  </data>
-  <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
-  </data>
-  <data name="label32.TabIndex" type="System.Int32, mscorlib">
-    <value>127</value>
-  </data>
-  <data name="label32.Text" xml:space="preserve">
-    <value>Y</value>
-  </data>
-  <data name="&gt;&gt;label32.Name" xml:space="preserve">
-    <value>label32</value>
-  </data>
-  <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="NUD_CONTROL_y.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="NUD_CONTROL_y.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 45</value>
-  </data>
-  <data name="NUD_CONTROL_y.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="NUD_CONTROL_y.TabIndex" type="System.Int32, mscorlib">
-    <value>126</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_y.Name" xml:space="preserve">
-    <value>NUD_CONTROL_y</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_y.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_y.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_y.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="label33.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label33.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 21</value>
-  </data>
-  <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
-  </data>
-  <data name="label33.TabIndex" type="System.Int32, mscorlib">
-    <value>125</value>
-  </data>
-  <data name="label33.Text" xml:space="preserve">
-    <value>X</value>
-  </data>
-  <data name="&gt;&gt;label33.Name" xml:space="preserve">
-    <value>label33</value>
-  </data>
-  <data name="&gt;&gt;label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="NUD_CONTROL_x.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="NUD_CONTROL_x.Location" type="System.Drawing.Point, System.Drawing">
-    <value>54, 19</value>
-  </data>
-  <data name="NUD_CONTROL_x.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 20</value>
-  </data>
-  <data name="NUD_CONTROL_x.TabIndex" type="System.Int32, mscorlib">
-    <value>124</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_x.Name" xml:space="preserve">
-    <value>NUD_CONTROL_x</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_x.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_x.Parent" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;NUD_CONTROL_x.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="groupBox6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>551, 303</value>
-  </data>
-  <data name="groupBox6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 97</value>
-  </data>
-  <data name="groupBox6.TabIndex" type="System.Int32, mscorlib">
-    <value>138</value>
-  </data>
-  <data name="groupBox6.Text" xml:space="preserve">
-    <value>Control Angles</value>
-  </data>
-  <data name="&gt;&gt;groupBox6.Name" xml:space="preserve">
-    <value>groupBox6</value>
-  </data>
-  <data name="&gt;&gt;groupBox6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox6.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBox6.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
   <data name="CHK_stab_tilt.AutoSize" type="System.Boolean, mscorlib">
@@ -2152,7 +1966,7 @@
     <value>CHK_stab_tilt</value>
   </data>
   <data name="&gt;&gt;CHK_stab_tilt.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CHK_stab_tilt.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2185,7 +1999,7 @@
     <value>CHK_stab_roll</value>
   </data>
   <data name="&gt;&gt;CHK_stab_roll.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CHK_stab_roll.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2218,7 +2032,7 @@
     <value>CHK_stab_pan</value>
   </data>
   <data name="&gt;&gt;CHK_stab_pan.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkCheckBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CHK_stab_pan.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2389,7 +2203,7 @@
     <value>mavlinkNumericUpDownshut_pushed</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_pushed.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2413,7 +2227,7 @@
     <value>mavlinkNumericUpDownshut_notpushed</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_notpushed.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2497,7 +2311,7 @@
     <value>mavlinkNumericUpDownShutM</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutM.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutM.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2521,7 +2335,7 @@
     <value>mavlinkNumericUpDownShutMX</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownShutMX.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2653,7 +2467,7 @@
     <value>mavlinkNumericUpDownshut_duration</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownshut_duration.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2710,7 +2524,7 @@
     <value>CMB_mnt_type</value>
   </data>
   <data name="&gt;&gt;CMB_mnt_type.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.1.6252.20108, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.8370.17362, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CMB_mnt_type.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2791,6 +2605,6 @@
     <value>ConfigMount</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.MyUserControl, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
This updates the Camera Gimbal setup screen so that it works for AP 4.3 but also sadly makes it incompatible with 4.2 (and earlier).  I think it is more important that MP is compatible with our stable build but if you have advice on how to make it backwards compatible and I'll try to do that.

Changes included are:

1. remove the CONTROL_X/Y/Z section (these parameters haven't existed for years)
2. remove the STAB_TILT/ROLL/PAN parameters.  These were required previously to allow users to use the "Servo" gimbal type for both regular servo gimbals and brushless gimbals (that self stabilize).  In AP 4.3 the "Servo" gimbal type is really only for servo gimbals.  For brushless-self-stabilising gimbals users should use the "BrushlessPWM" type
3. rename parameter prefix from "MNT" to "MNT1"
4. rename angle limit parameters from "ANGMIN_TIL" to "PITCH_MIN", "ANGMIN_ROL" to "ROLL_MIN", "ANGMIN_PAN" to "YAW_MIN", and same for the corresponding MAX parameters
5. cosmetic changes including
    - renamed "Tilt" label to "Pitch", "Pan" to "Yaw", "Trigger" to "Camera Trigger"
    - renamed "Servo Limits" labels to just "Servo"
    - moved servo drop downs to just above servo limit fields
    - slightly shrunk all images
    - moved all section titles to just below section's top line

I'm happy for the last commit (the cosmetic changes) to be dropped if you'd prefer.  I think the screen looks better but I don't feel strongly about it.
![mp-gimbal-setup-PR-before-vs-after](https://user-images.githubusercontent.com/1498098/204998863-2e31676a-f33c-4b56-945f-786122c98829.png)


BTW, I could not figure out how to make the "Input Ch" drop-downs work.  Any advice on how to fix these is also greatly appreciated.

I tested this on my own machine and it seemed fine.  I also lightly tested it with Copter-4.2 and as expected it does not allow the gimbal to be setup but it also doesn't throw out any ugly errors.
![mp-gimbal-setup-PR-42-test](https://user-images.githubusercontent.com/1498098/204999928-22f5178d-56f3-4791-a634-d4b240d0bbd6.png)
