### PR TITLE
param: fixed exclusions for change of GND_ params to BARO params

### DIFF
--- a/ExtLibs/Utilities/ParamFile.cs
+++ b/ExtLibs/Utilities/ParamFile.cs
@@ -60,6 +60,14 @@ namespace MissionPlanner.Utilities
                         continue;
                     if (name == "GND_TEMP")
                         continue;
+                    if (name == "BARO1_GND_PRESS")
+                        continue;
+                    if (name == "BARO2_GND_PRESS")
+                        continue;
+                    if (name == "BARO3_GND_PRESS")
+                        continue;
+                    if (name == "BARO_GND_TEMP")
+                        continue;
                     if (name == "CMD_INDEX")
                         continue;
                     if (name == "LOG_LASTFILE")


### PR DESCRIPTION
ensures users don't load old calibration values