### PR TITLE
MapTool: use OpenStreetMap to zoom to locations

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -7911,7 +7911,14 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
             string place = "Perth Airport, Australia";
             if (DialogResult.OK == InputBox.Show("Location", "Enter your location", ref place))
             {
+                // Create a backup of the map provider
+                var provider = MainMap.MapProvider;
+                // Set map provider to OpenStreetMap
+                MainMap.MapProvider = GMapProviders.OpenStreetMap;
+                // Zoom to the region specified
                 GeoCoderStatusCode status = MainMap.SetPositionByKeywords(place);
+                // Restore the map provider
+                MainMap.MapProvider = provider;
                 if (status != GeoCoderStatusCode.G_GEO_SUCCESS)
                 {
                     CustomMessageBox.Show("Google Maps Geocoder can't find: '" + place + "', reason: " + status,


### PR DESCRIPTION
The "Zoom To" search function in the Map Tool menu on the Flight Planner page does not work with Bing or Google map providers. I'd try others, but I don't know which providers work and which don't.

OpenStreetMap _does_ work though for these search requests ([despite not working for map tiles](https://operations.osmfoundation.org/policies/tiles/)). This temporarily switches the provider to OpenStreetMap, does the search, then switches back.

Alternatively, I'd support deleting this clearly rarely used feature, but now that I know it exists, and that it works now, I really like it.