### PR TITLE
SRTM: migrate to terrain.ardupilot.org

### DIFF
--- a/ExtLibs/Utilities/srtm.cs
+++ b/ExtLibs/Utilities/srtm.cs
@@ -598,7 +598,7 @@ namespace MissionPlanner.Utilities
             List<string> list = new List<string>();
 
             // load 1 arc seconds first
-            list.AddRange(await getListing(baseurl1sec).ConfigureAwait(false));
+            list.Add(baseurl1sec);
             log.Info("srtm1sec " + list.Count);
             // load 3 arc second
             list.AddRange(await getListing(baseurl).ConfigureAwait(false));
@@ -623,18 +623,18 @@ namespace MissionPlanner.Utilities
                 }
             }
 
-            // if there are no http exceptions, and the list is >= 20, then everything above is valid
-            // 15760 is all srtm3 and srtm1
-            if (list.Count >= 21 && checkednames > 15000 && !oceantile.Contains((string) name))
+            // if there are no http exceptions, and the list is >= 9, then everything above is valid
+            // 38581 is all srtm3 and srtm1
+            if (list.Count >= 9 && checkednames > 38000 && !oceantile.Contains((string) name))
             {
                 // we must be an ocean tile - no matchs
                 oceantile.Add((string) name);
             }
         }
 
-        public static string baseurl1sec { get; set; }= "https://firmware.ardupilot.org/SRTM/USGS/SRTM1/version2_1/SRTM1/";
+        public static string baseurl1sec { get; set; }= "https://terrain.ardupilot.org/SRTM1/";
 
-        public static string baseurl { get; set; }= "https://firmware.ardupilot.org/SRTM/";
+        public static string baseurl { get; set; }= "https://terrain.ardupilot.org/SRTM3/";
 
         static HttpClient client = new HttpClient();
 


### PR DESCRIPTION
The 1-arcsec SRTM data on firmware.ardupilot.org is copied from the old usgs.gov dataset, which has some [large holes](https://www.usgs.gov/media/images/data-voids-srtm-coverage-conterminous-united-states) in coverage. The problem with these is that Mission Planner can't fall back to the 3-arcsec data, because it merely checks for the existence of a .hgt file for that region, and if it does, assumes there is 1-arcsec coverage for the whole area in that file.

The 1-arcsec data on firmware.ardupilot.org is from JAXA's ALOS dataset, and does not have these invalid regions (at least, not that I can find). Another benefit is that it covers most of the world, and not just the US.

To reproduce this set your map on the plan page to 29.844, -82.040 (in Florida). Everything in the immediate area is "Invalid". After applying the changes in this PR, it comes through.

The only thing I'm not sure of is whether it's okay to use the terrain.ardupilot.org server for this, from a number-of-requests standpoint. Hopefully @tridge could chime in on that.