### PR TITLE
LogBrowse: use int.TryParse instead of int.Parse

### DIFF
--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -1036,7 +1036,8 @@ namespace MissionPlanner.Log
         {
             log.InfoFormat("GraphItem: {0} {1} {2}", type, fieldname, instance);
             DataModifer dataModifier = new DataModifer();
-            string nodeName = DataModifer.GetNodeName(type, instance != "" ? int.Parse(instance) : -1, fieldname);
+            int instance_int;
+            string nodeName = DataModifer.GetNodeName(type, int.TryParse(instance, out instance_int) ? instance_int : -1, fieldname);
 
             foreach (var curve in zg1.GraphPane.CurveList)
             {


### PR DESCRIPTION
If log's instance is not integer, exception happens.
So I change to use int.TryParse instead of int.Parse.

Before
![image](https://user-images.githubusercontent.com/16643069/208219079-d4273a59-8857-4eae-82e0-670bcabb97e9.png)

After
![image](https://user-images.githubusercontent.com/16643069/208219103-e3394d5b-4bf0-4440-be23-b255f6e3bee4.png)

The log output here will have a char type in the instance.
https://github.com/ArduPilot/ardupilot/blob/Copter-4.3/libraries/GCS_MAVLink/GCS_Common.cpp#L3179