### PR TITLE
HUD: use nofix icon for "no fix" instead of nogps

### DIFF
--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -2833,7 +2833,7 @@ namespace MissionPlanner.Controls
                         {
                             gps = (HUDT.GPS1);
                             col = (SolidBrush) Brushes.Red;
-                            icon = HUDT.nogps_wide;
+                            icon = HUDT.nofix_wide;
                         }
                         else if (_fix == 2)
                         {


### PR DESCRIPTION
Someone pointed out this behavior on Discord.