### PR TITLE
Log review: support bitmask fields from metadata

### DIFF
--- a/ExtLibs/ArduPilot/LogMetaData.cs
+++ b/ExtLibs/ArduPilot/LogMetaData.cs
@@ -25,7 +25,19 @@ namespace MissionPlanner.ArduPilot
 
         static string url = "https://autotest.ardupilot.org/LogMessages/{0}/LogMessages.xml.xz";
 
-        public static  Dictionary<string, Dictionary<string, string>> MetaData { get; } = new Dictionary<string, Dictionary<string, string>>();
+        public struct LogItemFeild
+        {
+            public string description;
+            public struct LogItemFeildBitmask
+            {
+                public string name;
+                public uint mask;
+                public string description;
+            }
+            public List<LogItemFeildBitmask> bitmask;
+        };
+
+        public static  Dictionary<string, Dictionary<string, LogItemFeild>> MetaData { get; } = new Dictionary<string, Dictionary<string, LogItemFeild>>();
 
         public static async Task GetMetaData()
         {
@@ -107,16 +119,38 @@ namespace MissionPlanner.ArduPilot
                         var typedesc = b.Descendants("description").FirstOrDefault();
 
                         if (!MetaData.ContainsKey(type.Value))
-                            MetaData[type.Value] = new Dictionary<string, string>();
+                            MetaData[type.Value] = new Dictionary<string, LogItemFeild>();
 
-                        MetaData[type.Value]["description"] = typedesc.Value;
+                        LogItemFeild log_type = new LogItemFeild();
+                        log_type.description = typedesc.Value;
+                        MetaData[type.Value]["description"] = log_type;
 
                         b.Descendants("fields").Descendants("field").ForEach(c =>
                         {
                             var name = c.Attribute("name");
                             var desc = c.Descendants("description").FirstOrDefault();
+                            var bits = c.Descendants("bitmask").FirstOrDefault();
 
-                            MetaData[type.Value][name.Value] = desc.Value;
+                            LogItemFeild log_feild = new LogItemFeild();
+                            log_feild.description = desc.Value;
+
+                            if (bits != null)
+                            {
+                                if (log_feild.bitmask == null)
+                                {
+                                    log_feild.bitmask = new List<LogItemFeild.LogItemFeildBitmask>();
+                                }
+
+                                bits.Descendants("bit").ForEach(d =>
+                                {
+                                    LogItemFeild.LogItemFeildBitmask log_mask = new LogItemFeild.LogItemFeildBitmask();
+                                    log_mask.name = (string)d.Attribute("name");
+                                    log_mask.mask = (uint)d.Descendants("value").FirstOrDefault();
+                                    log_mask.description = (string)d.Descendants("description").FirstOrDefault();
+                                    log_feild.bitmask.Add(log_mask);
+                                });
+                            }
+                            MetaData[type.Value][name.Value] = log_feild;
                         });
                     });
                 }   

--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -72,6 +72,8 @@ namespace MissionPlanner.Log
             public double offset = 0;
             public double scalar = 1;
             public bool doOffsetFirst = false;
+            public bool isMask = false;
+            public uint mask = 0;
 
             public DataModifer()
             {
@@ -81,8 +83,16 @@ namespace MissionPlanner.Log
 
             public DataModifer(string _commandString)
             {
-                this.commandString = _commandString;
+                this.commandString = _commandString.Trim();
                 this.isValid = ParseCommandString(_commandString);
+            }
+
+            public DataModifer(uint _mask)
+            {
+                this.commandString = "";
+                this.isValid = true;
+                this.isMask = true;
+                this.mask = _mask;
             }
 
             private bool ParseCommandString(string _commandString)
@@ -138,6 +148,15 @@ namespace MissionPlanner.Log
                         case '-':
                             this.doOffsetFirst = (i == 0);
                             this.offset = -value;
+                            break;
+
+                        case '&':
+                            if (value < 0)
+                            {
+                                return false;
+                            }
+                            this.isMask = true;
+                            this.mask = (uint)value;
                             break;
 
                         default:
@@ -619,6 +638,23 @@ namespace MissionPlanner.Log
             return "";
         }
 
+        private void add_field_node(ref TreeNode root_node, string LogMSG, string instance, string VehicleType)
+        {
+            var new_node = root_node.Nodes.Add(instance);
+            new_node.ToolTipText = get_extra_info(LogMSG, instance, VehicleType);
+
+            // if bitmask add sub nodes, look up in metadata
+            if (LogMetaData.MetaData.ContainsKey(LogMSG) && LogMetaData.MetaData[LogMSG].ContainsKey(instance) && LogMetaData.MetaData[LogMSG][instance].bitmask != null)
+            {
+                foreach(var bit in LogMetaData.MetaData[LogMSG][instance].bitmask)
+                {
+                    var new_bit_node = new_node.Nodes.Add(bit.name);
+                    new_bit_node.ToolTipText = bit.description;
+                    new_bit_node.Tag = "bitmask";
+                }
+            }
+        }
+
         private void ResetTreeView(List<string> seenmessagetypes, string VehicleType)
         {
             treeView1.Nodes.Clear();
@@ -649,8 +685,7 @@ namespace MissionPlanner.Log
                             instNode.ToolTipText = get_instance_info(item.Name, instanceinfo, VehicleType);
                             foreach (var item1 in item.FieldNames)
                             {
-                                var new_node = instNode.Nodes.Add(item1);
-                                new_node.ToolTipText = get_extra_info(item.Name, item1, VehicleType);
+                                add_field_node(ref instNode, item.Name, item1, VehicleType);
                             }
                         }
                     }
@@ -659,8 +694,7 @@ namespace MissionPlanner.Log
                         // no instance add the fields
                         foreach (var item1 in item.FieldNames)
                         {
-                            var new_node = msgNode.Nodes.Add(item1);
-                            new_node.ToolTipText = get_extra_info(item.Name, item1, VehicleType);
+                            add_field_node(ref msgNode, item.Name, item1, VehicleType);
                         }
                     }
                     treeView1.Nodes.Add(msgNode);
@@ -1032,7 +1066,7 @@ namespace MissionPlanner.Log
         }
 
         void GraphItem(string type, string fieldname, bool left = true, bool displayerror = true,
-            bool isexpression = false, string instance = "")
+            bool isexpression = false, string instance = "", string bitmask = null)
         {
             log.InfoFormat("GraphItem: {0} {1} {2}", type, fieldname, instance);
             DataModifer dataModifier = new DataModifer();
@@ -1050,7 +1084,7 @@ namespace MissionPlanner.Log
                     return;
             }
 
-            if (dataModifierHash.ContainsKey(nodeName))
+            if (dataModifierHash.ContainsKey(nodeName) && (bitmask == null))
             {
                 dataModifier = (DataModifer)dataModifierHash[nodeName];
             }
@@ -1071,6 +1105,54 @@ namespace MissionPlanner.Log
                                 {
                                     if (subsubnode.Text == fieldname)
                                     {
+                                        if (bitmask == null)
+                                        {
+                                            if (subsubnode.Checked != true)
+                                            {
+                                                subsubnode.Checked = true;
+                                            }
+                                            extra_label = " " + subsubnode.ToolTipText;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            foreach (TreeNode subsubsubnode in subsubnode.Nodes)
+                                            {
+                                                if (subsubsubnode.Text == bitmask)
+                                                {
+                                                    if (subsubsubnode.Checked != true)
+                                                    {
+                                                        subsubsubnode.Checked = true;
+                                                    }
+                                                    extra_label = " " + subsubsubnode.ToolTipText;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (bitmask == null)
+                            {
+                                if (subnode.Text == fieldname)
+                                {
+                                    if (subnode.Checked != true)
+                                    {
+                                        subnode.Checked = true;
+                                    }
+                                    extra_label = " " + subnode.ToolTipText;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                foreach (TreeNode subsubnode in subnode.Nodes)
+                                {
+                                    if (subsubnode.Text == bitmask)
+                                    {
                                         if (subsubnode.Checked != true)
                                         {
                                             subsubnode.Checked = true;
@@ -1081,18 +1163,24 @@ namespace MissionPlanner.Log
                                 }
                             }
                         }
-                        else
-                        {
-                            if (subnode.Text == fieldname)
-                            {
-                                if (subnode.Checked != true)
-                                {
-                                    subnode.Checked = true;
-                                }
-                                extra_label = " " + subnode.ToolTipText;
-                                break;
-                            }
-                        }
+                    }
+                }
+            }
+
+            if (dataModifier.IsValid())
+            {
+                extra_label = dataModifier.commandString + extra_label;
+            }
+
+            if (bitmask != null)
+            {
+                foreach (var bitmask_item in LogMetaData.MetaData[type][fieldname].bitmask)
+                {
+                    if (bitmask_item.name == bitmask)
+                    {
+                        extra_label = "." + bitmask + extra_label;
+                        dataModifier = new DataModifer(bitmask_item.mask);
+                        break;
                     }
                 }
             }
@@ -1354,7 +1442,6 @@ main()
             double a = 0; // row counter
             double b = 0;
             DateTime screenupdate = DateTime.MinValue;
-            double value_prev = 0;
 
             foreach (var item in logdata.GetEnumeratorType(type))
             {
@@ -1374,24 +1461,20 @@ main()
                         double value = double.Parse(item.items[col],
                             System.Globalization.CultureInfo.InvariantCulture);
 
-                        // abandon realy bad data
-                        if (Math.Abs(value) > 9.15e8)
-                        {
-                            a++;
-                            continue;
-                        }
-
                         if (dataModifier.IsValid())
                         {
-                            if ((a != 0) && Math.Abs(value - value_prev) > 1e5)
+                            if (dataModifier.isMask)
                             {
-                                // there is a glitch in the data, reject it by replacing it with the previous value
-                                value = value_prev;
+                                int shift;
+                                for (shift = 0; shift < 32; shift++)
+                                { 
+                                    if (((dataModifier.mask >> shift) & 1) != 0) {
+                                        break;
+                                    }
+                                }
+                                value = ((uint)value & dataModifier.mask) >> shift;
                             }
-
-                            value_prev = value;
-
-                            if (dataModifier.doOffsetFirst)
+                            else if (dataModifier.doOffsetFirst)
                             {
                                 value += dataModifier.offset;
                                 value *= dataModifier.scalar;
@@ -2942,28 +3025,32 @@ main()
 
                 if (e.Node.Checked)
                 {
-                    if (wasrightclick)
-                    {
-                        if (parts.Length == 3)
-                            GraphItem(parts[0], parts[2], false, true, false, parts[1]);
+                    if (parts.Length == 4)
+                        GraphItem(parts[0], parts[2], !wasrightclick, true, false, parts[1], parts[3]);
+
+                    else if (parts.Length == 3)
+                        if ((e.Node.Tag != null) && (e.Node.Tag.ToString() == "bitmask"))
+                            GraphItem(parts[0], parts[1], !wasrightclick, true, false, "", parts[2]);
                         else
-                            GraphItem(parts[0], parts[1], false);
-                    }
-                    else
-                    {
-                        if (parts.Length == 3)
-                            GraphItem(parts[0], parts[2], true, true, false, parts[1]);
-                        else
-                            GraphItem(parts[0], parts[1], true);
-                    }
+                            GraphItem(parts[0], parts[2], !wasrightclick, true, false, parts[1]);
+                     else
+                        GraphItem(parts[0], parts[1], !wasrightclick, true, false, "");
                 }
                 else
                 {
                     List<CurveItem> removeitems = new List<CurveItem>();
 
-                    var name = parts.Length == 3
-                        ? parts[0] + "[" + parts[1] + "]." + parts[2]
-                        : parts[0] + "." + parts[1];
+                    string name;
+                    if (parts.Length == 4)
+                        name = parts[0] + "[" + parts[1] + "]." + parts[2] + "." + parts[3];
+
+                    else if (parts.Length == 3)
+                        if ((e.Node.Tag != null) && (e.Node.Tag.ToString() == "bitmask"))
+                            name = parts[0] + "." + parts[1] + "." + parts[2];
+                        else
+                            name = parts[0] + "[" + parts[1] + "]." + parts[2];
+                    else
+                        name = parts[0] + "." + parts[1];
 
                     foreach (var item in zg1.GraphPane.CurveList)
                     {
@@ -3626,18 +3713,18 @@ main()
                 if (items.Length >= 2 && LogMetaData.MetaData.ContainsKey(items[0]) &&
                     LogMetaData.MetaData[items[0]].ContainsKey(items[items.Length - 1]))
                 {
-                    var desc = LogMetaData.MetaData[items[0]][items[items.Length - 1]];
+                    var feild = LogMetaData.MetaData[items[0]][items[items.Length - 1]];
                     pos.Y -= 30;
                     pos.X += 30;
-                    txt_info.Text = desc;
+                    txt_info.Text = feild.description;
                     //toolTip1.Show(desc, treeView1, pos, 2000);
                 } else if (items.Length == 1 && LogMetaData.MetaData.ContainsKey(items[0]) &&
                            LogMetaData.MetaData[items[0]].ContainsKey("description"))
                 {
-                    var desc = LogMetaData.MetaData[items[0]]["description"];
+                    var feild = LogMetaData.MetaData[items[0]]["description"];
                     pos.Y -= 30;
                     pos.X += 30;
-                    txt_info.Text = desc;
+                    txt_info.Text = feild.description;
                     //toolTip1.Show(desc, treeView1, pos, 2000);
                 }
             }


### PR DESCRIPTION
This adds support for parsing bitmask masks from the logmetadata xml and applying them to values. So you can plot each bit field individualy. Currenlly the TECS message is the only example in the xml, because of this I have not tested instance with bitmask, but it should work.

![image](https://user-images.githubusercontent.com/33176108/213830102-5b4764e9-7666-432a-bd5d-01e13b93fd5c.png)

![image](https://user-images.githubusercontent.com/33176108/213829866-75824887-a4e2-4673-be75-574137195e6f.png)

As a byproduct we also now get mask with `&` as a manual modifier too. The modifiers also are included in the label, for example:

![image](https://user-images.githubusercontent.com/33176108/213830543-c7e1fcf0-b765-47ea-9ef4-13c6a3d3627a.png)

We need to update the log meta data a little to give a name and description for each bit. I would also like to give a mask rather than a bit so we can do multiple bit values (there are some in the EKF I think). Maybe we should do that metadata rework before merging this, @peterbarker any thoughts?
