### PR TITLE
ConfigFirmware: allow offline access to certain parts

### DIFF
--- a/GCSViews/ConfigurationView/ConfigFirmwareManifest.cs
+++ b/GCSViews/ConfigurationView/ConfigFirmwareManifest.cs
@@ -47,7 +47,18 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             MainV2.instance.DeviceChanged -= Instance_DeviceChanged;
             MainV2.instance.DeviceChanged += Instance_DeviceChanged;
 
-            this.Enabled = false;
+            // Until we connect to the internet, disable all controls that require it
+            // Disable all ImageLabels
+            foreach (Control c in this.Controls)
+            {
+                if (c is ImageLabel)
+                {
+                    c.Enabled = false;
+                }
+            }
+            // Disable "All Options" and "Beta Firmwares"
+            lbl_alloptions.Enabled = false;
+            lbl_devfw.Enabled = false;
 
             flashdone = false;
 
@@ -101,7 +112,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                    imageLabel.Text = first.VehicleType?.ToString() + " " + first.MavFirmwareVersionStr + " " +
                                      first.MavFirmwareVersionType.ToString();
 
-               this.Enabled = true;
+               // Re-enable this ImageLabel
+               imageLabel.Enabled = true;
+               // Re-enable the "All Options" and "Beta Firmwares" controls
+               // (only needs to be done once, but easier to do here)
+               lbl_alloptions.Enabled = true;
+               lbl_devfw.Enabled = true;
            });
         }
 


### PR DESCRIPTION
Fixes an issue that Alex/ARACE pointed out on Discord. There are circumstances where someone might want to upload custom firmware with a computer that has no internet access at the time.

![image](https://user-images.githubusercontent.com/14059190/215225195-ab58ec0a-0561-4c5c-886e-daad4a871360.png)
