### PR TITLE
GMapProvider: add Empty check for RefererUrl

### DIFF
--- a/ExtLibs/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
+++ b/ExtLibs/GMap.NET.Core/GMap.NET.MapProviders/GMapProvider.cs
@@ -402,7 +402,8 @@ namespace GMap.NET.MapProviders
             {
                 request.Headers.Add("User-Agent", UserAgent);
                 request.Headers.Add("Accept", requestAccept);
-                request.Headers.Add("Referer", RefererUrl);
+                if (!string.IsNullOrEmpty(RefererUrl))
+                    request.Headers.Add("Referer", RefererUrl);
 
                 MemoryStream data = Task.Run(async () =>
                 {


### PR DESCRIPTION
I got System.FormatException when using Mapbox service.
I confirmed it worked after adding this condition.