### PR TITLE
Switched to AsyncKeyedLock

### DIFF
--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -582,6 +582,9 @@
     <PackageReference Include="Asyncify">
       <Version>0.9.7</Version>
     </PackageReference>
+    <PackageReference Include="AsyncKeyedLock">
+      <Version>6.2.0</Version>
+    </PackageReference>    
     <PackageReference Include="BouncyCastle.Cryptography">
       <Version>2.0.0</Version>
     </PackageReference>


### PR DESCRIPTION
This helps clean up from the dictionary and reduces memory allocations. However I'm not sure if `urlcacheSem` should be static. It feels like it should, but the existing code keeps the dictionaries separate.