### PR TITLE
Xamarin: change http handler

### DIFF
--- a/ExtLibs/Xamarin/Xamarin.Android/Xamarin.Android.csproj
+++ b/ExtLibs/Xamarin/Xamarin.Android/Xamarin.Android.csproj
@@ -77,7 +77,7 @@
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
-    <AndroidHttpClientHandlerType>System.Net.Http.HttpClientHandler</AndroidHttpClientHandlerType>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidKeyStore>false</AndroidKeyStore>
     <AndroidPackageFormat>aab</AndroidPackageFormat>
     <AndroidUseAapt2>true</AndroidUseAapt2>


### PR DESCRIPTION
Fixes Android build

I am not sure why the action for this only recently started failing, but this fixes it.