### PR TITLE
mavcmd: add image start capture

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -120,6 +120,51 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </SPLINE_WAYPOINT>
+    <IMAGE_START_CAPTURE>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_START_CAPTURE>
+    <SET_CAMERA_ZOOM>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_ZOOM>
+    <SET_CAMERA_FOCUS>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_FOCUS>
+    <VIDEO_START_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_START_CAPTURE>
+    <VIDEO_STOP_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_STOP_CAPTURE>
     <DO_AUX_FUNCTION>
       <P1>AuxFunction</P1>
       <P2>SwitchPosition</P2>
@@ -456,6 +501,51 @@
       <Y></Y>
       <Z></Z>
     </DO_VTOL_TRANSITION>
+    <IMAGE_START_CAPTURE>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_START_CAPTURE>
+    <SET_CAMERA_ZOOM>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_ZOOM>
+    <SET_CAMERA_FOCUS>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_FOCUS>
+    <VIDEO_START_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_START_CAPTURE>
+    <VIDEO_STOP_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_STOP_CAPTURE>
     <DO_AUX_FUNCTION>
       <P1>AuxFunction</P1>
       <P2>SwitchPosition</P2>
@@ -774,6 +864,51 @@
       <Y></Y>
       <Z></Z>
     </SET_YAW_SPEED>
+    <IMAGE_START_CAPTURE>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_START_CAPTURE>
+    <SET_CAMERA_ZOOM>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_ZOOM>
+    <SET_CAMERA_FOCUS>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_FOCUS>
+    <VIDEO_START_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_START_CAPTURE>
+    <VIDEO_STOP_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_STOP_CAPTURE>
     <DO_AUX_FUNCTION>
       <P1>AuxFunction</P1>
       <P2>SwitchPosition</P2>


### PR DESCRIPTION
This adds 5 commands to the mission list for Plane, Copter and Rover.  Support for these commands will be added in AP 4.4 (see https://github.com/ArduPilot/ardupilot/pull/23147).

- [MAV_CMD_SET_CAMERA_ZOOM](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1507) <-- only continuous type (not step or position yet)
- [MAV_CMD_SET_CAMERA_FOCUS](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1515) <-- only continuous type (not step or distance yet)
- [MAV_CMD_IMAGE_START_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1544) <-- only takes 1 picture
- [MAV_CMD_VIDEO_START_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1584)
- [MAV_CMD_VIDEO_STOP_CAPTURE](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1594)

This relies on MP being updated to use the latest ArduPilot mavlink which includes PR https://github.com/ArduPilot/mavlink/pull/304

This has been lightly tested and we can see the new commands appear correctly although I also see, "A invalid entry has been detected, Invalid number on row 2" but this should be cleared if MP uses the latest mavlink repo.
![image](https://user-images.githubusercontent.com/1498098/223895582-d5fbae36-ae12-40dd-b02c-7a541a9cdcc0.png)
![image](https://user-images.githubusercontent.com/1498098/223895712-f4932ebc-7c1c-49a6-b922-0e3bfdcfc8d0.png)


Developer wiki documentation PR is here: https://github.com/ArduPilot/ardupilot_wiki/pull/5002

