### PR TITLE
MAVFTP: use smaller read/write sizes to keep radios happier

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVFtp.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVFtp.cs
@@ -28,7 +28,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
         const byte kDirentSkip = (byte) 'S';
 
         /// max read/write size we will use - low to keep some radios happy
-        const uint16_t rwSize = 80;
+        const byte rwSize = 80;
 
         private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly byte _compid;

--- a/ExtLibs/ArduPilot/Mavlink/MAVFtp.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVFtp.cs
@@ -27,6 +27,9 @@ namespace MissionPlanner.ArduPilot.Mavlink
         /// Identifies Skipped entry from List command
         const byte kDirentSkip = (byte) 'S';
 
+        /// max read/write size we will use - low to keep some radios happy
+        const uint16_t rwSize = 80;
+
         private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly byte _compid;
         private readonly MAVLinkInterface _mavint;
@@ -547,7 +550,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
             kRspNak
         };
 
-        public MemoryStream GetFile(string file, CancellationTokenSource cancel, bool burst = true, byte readsize = 239)
+        public MemoryStream GetFile(string file, CancellationTokenSource cancel, bool burst = true, byte readsize = rwSize)
         {
             log.InfoFormat("GetFile {0}-{1} {2}", _sysid, _compid, file);
             Progress?.Invoke("Opening file " + file, -1);
@@ -681,7 +684,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
             return ans;
         }
 
-        public MemoryStream kCmdBurstReadFile(string file, int size, CancellationTokenSource cancel, byte readsize = 239)
+        public MemoryStream kCmdBurstReadFile(string file, int size, CancellationTokenSource cancel, byte readsize = rwSize)
         {
             RetryTimeout timeout = new RetryTimeout();
             fileTransferProtocol.target_system = _sysid;
@@ -1453,7 +1456,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
             return ans;
         }
 
-        public MemoryStream kCmdReadFile(string file, int size, CancellationTokenSource cancel, byte readsize = 239)
+        public MemoryStream kCmdReadFile(string file, int size, CancellationTokenSource cancel, byte readsize = rwSize)
         {
             RetryTimeout timeout = new RetryTimeout();
             var payload = new FTPPayloadHeader()
@@ -2074,7 +2077,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
 
                     // send next
                     payload.offset += (uint) payload.data.Length;
-                    payload.data = data.Skip((int) payload.offset - (int) destoffset).Take(239).ToArray();
+                    payload.data = data.Skip((int) payload.offset - (int) destoffset).Take(rwSize).ToArray();
                     bytes_read = payload.data.Length;
                     payload.size = (uint8_t) bytes_read;
                     payload.seq_number = seq_no++;
@@ -2087,7 +2090,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
                 }, _sysid, _compid);
                 // fill buffer
                 payload.offset = destoffset;
-                payload.data = data.Skip((int) payload.offset - (int) destoffset).Take(239).ToArray();
+                payload.data = data.Skip((int) payload.offset - (int) destoffset).Take(rwSize).ToArray();
                 bytes_read = payload.data.Length;
                 payload.size = (uint8_t) bytes_read;
                 //  package it
@@ -2205,7 +2208,7 @@ namespace MissionPlanner.ArduPilot.Mavlink
                 }, _sysid, _compid);
                 // fill buffer
                 payload.offset = (uint32_t) stream.Position;
-                payload.data = new byte[239];
+                payload.data = new byte[rwSize];
                 bytes_read = stream.Read(payload.data, 0, payload.data.Length);
                 Array.Resize(ref payload.data, bytes_read);
                 payload.size = (uint8_t) bytes_read;


### PR DESCRIPTION
the RFD900x with multipoint can't handle over 80 byte data size for FTP
this needs some testing before merge
fixes issue #3086