### PR TITLE
ConfigRawParams: fix typecast exception

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -391,7 +391,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 double min = 0;
                 double max = 0;
 
-                var value = (string)Params[e.ColumnIndex, e.RowIndex].Value;
+                var value = Params[e.ColumnIndex, e.RowIndex].Value.ToString();
                 value = value.Replace(',', '.');
 
                 var newvalue = (double) new Expression(value).calculate();
@@ -443,7 +443,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 _changes[Params[Command.Index, e.RowIndex].Value] = newvalue;
 
                 Params.CellValueChanged -= Params_CellValueChanged;
-                Params[e.ColumnIndex, e.RowIndex].Value = newvalue;
+                Params[e.ColumnIndex, e.RowIndex].Value = newvalue.ToString();
                 Params.CellValueChanged += Params_CellValueChanged;
             }
             catch (Exception)
@@ -758,7 +758,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 foreach (DataGridViewRow row in Params.Rows)
                 {
-                    row.Visible = (string)row.Cells[Default_value.Index].Value != (string)row.Cells[Value.Index].Value;
+                    row.Visible = row.Cells[Default_value.Index].Value.ToString() != row.Cells[Value.Index].Value.ToString();
                 }
             }
 


### PR DESCRIPTION
When editing a float param, the cell gets set to a double, instead of a string, which throws a typecase exception if the cell is edited and then "None Default" is clicked. I fix this on both ends, setting the cell to a string, and using `ToString` everywhere instead of typecasting.

The only part of this PR that is truly needed is the `ToString` on line 446, but it's too easy to make a similar mistake in the future and have it go unnoticed.