### PR TITLE
mavcmd: add jump-tag commands for plane, copter, rover

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -246,6 +246,24 @@
       <Y></Y>
       <Z></Z>
     </DO_JUMP>
+    <JUMP_TAG>
+      <P1>Tag</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </JUMP_TAG>
+    <DO_JUMP_TAG>
+      <P1>Tag</P1>
+      <P2>Repeat</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP_TAG>
     <DO_LAND_START>
       <P1></P1>
       <P2></P2>
@@ -654,6 +672,24 @@
       <Y></Y>
       <Z></Z>
     </DO_JUMP>
+    <JUMP_TAG>
+      <P1>Tag</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </JUMP_TAG>
+    <DO_JUMP_TAG>
+      <P1>Tag</P1>
+      <P2>Repeat</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP_TAG>
     <DO_CHANGE_SPEED>
       <P1>Type (0=as 1=gs)</P1>
       <P2>Speed (m/s)</P2>
@@ -981,6 +1017,24 @@
       <Y></Y>
       <Z></Z>
     </DO_JUMP>
+    <JUMP_TAG>
+      <P1>Tag</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </JUMP_TAG>
+    <DO_JUMP_TAG>
+      <P1>Tag</P1>
+      <P2>Repeat</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP_TAG>
     <DO_GUIDED_LIMITS>
       <P1>timeout S</P1>
       <P2></P2>


### PR DESCRIPTION
AP 4.4.0 (and higher) includes support for the [JUMP_TAG](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1523) and [DO_JUMP_TAG](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1527) commands.

This PR adds these commands to the Plan screen's command list for Plane, Copter and Rover.  This has been tested in SITL for all three vehicles. 

I've placed the two commands just below the existing "DO_JUMP" command for all three vehicles.
![image](https://user-images.githubusercontent.com/1498098/233271191-030584ab-eed5-4a7b-b5b3-60bca20f0fe3.png)

Here's a screen shot of a Copter in SITL exercising the new commands.

![image](https://user-images.githubusercontent.com/1498098/233270510-e00eca4b-914b-4d9d-a5b3-701e861d2acb.png)

FYI @magicrub 