### PR TITLE
ConfigRawParam: handle range and value together

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -541,7 +541,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                                 ParameterMetaDataConstants.Units, MainV2.comPort.MAV.cs.firmware.ToString());
 
                             row.Cells[Units.Index].Value = units;
-                            row.Cells[Options.Index].Value = range + options.Replace(",", "\n");
+                            row.Cells[Options.Index].Value = (range + "\n" + options.Replace(",", "\n")).Trim();
                             if (options.Length > 0) row.Cells[Options.Index].ToolTipText = options.Replace(',', '\n');
                             int N = options.Count(c => c.Equals(','));
                             if (N > 50)


### PR DESCRIPTION
Parameters that have both of these need a character to break them up.

Before
![image](https://user-images.githubusercontent.com/14059190/233753328-8ff85b18-8570-4b86-b462-0f882558c19b.png)

After
![image](https://user-images.githubusercontent.com/14059190/233753317-d5cf4d89-421f-43c5-a654-9cab15e728fd.png)
