### PR TITLE
Fix getting settings default result

### DIFF
--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -243,6 +243,17 @@ namespace MissionPlanner.Utilities
             return result;
         }
 
+        public decimal GetDecimal(string key, decimal defaultd = 0)
+        {
+            decimal result = defaultd;
+            string value = null;
+            if (config.TryGetValue(key, out value))
+            {
+                decimal.TryParse(value, out result);
+            }
+            return result;
+        }
+
         public byte GetByte(string key, byte defaultb = 0)
         {
             byte result = defaultb;

--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -190,79 +190,79 @@ namespace MissionPlanner.Utilities
 
         public int GetInt32(string key, int defaulti = 0)
         {
-            int result = defaulti;
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            int result;
+            string value;
+            if (config.TryGetValue(key, out value) && int.TryParse(value, out result))
             {
-                int.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return defaulti;
         }
 
         public DisplayView GetDisplayView(string key)
         {
-            DisplayView result = new DisplayView();
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            DisplayView result;
+            string value;
+            if (config.TryGetValue(key, out value) && DisplayViewExtensions.TryParse(value, out result))
             {
-                DisplayViewExtensions.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return new DisplayView();
         }
 
         public bool GetBoolean(string key, bool defaultb = false)
         {
-            bool result = defaultb;
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            bool result;
+            string value;
+            if (config.TryGetValue(key, out value) && bool.TryParse(value, out result))
             {
-                bool.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return defaultb;
         }
 
         public float GetFloat(string key, float defaultv = 0)
         {
-            float result = defaultv;
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            float result;
+            string value;
+            if (config.TryGetValue(key, out value) && float.TryParse(value, out result))
             {
-                float.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return defaultv;
         }
 
         public double GetDouble(string key, double defaultd = 0)
         {
-            double result = defaultd;
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            double result;
+            string value;
+            if (config.TryGetValue(key, out value) && double.TryParse(value, out result))
             {
-                double.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return defaultd;
         }
 
         public decimal GetDecimal(string key, decimal defaultd = 0)
         {
-            decimal result = defaultd;
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            decimal result;
+            string value;
+            if (config.TryGetValue(key, out value) && decimal.TryParse(value, out result))
             {
-                decimal.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return defaultd;
         }
 
         public byte GetByte(string key, byte defaultb = 0)
         {
-            byte result = defaultb;
-            string value = null;
-            if (config.TryGetValue(key, out value))
+            byte result;
+            string value;
+            if (config.TryGetValue(key, out value) && byte.TryParse(value, out result))
             {
-                byte.TryParse(value, out result);
+                return result;
             }
-            return result;
+            return defaultb;
         }
 
         private static string _GetRunningDirectory = "";


### PR DESCRIPTION
This adds a new GetDecimal() helper but also it ensures the default value is returned when a TryParse() fails in the various helpers.

Current code assumes ```TryParse(string, result)==false``` does not touch result because we are initially setting the result with the default value and then always return the value without checking the return boolean. However, the docs say it will trample on result when returning false. Here's the docs for Int32.TryParse()

```
       //   result:
        //     When this method returns, contains the 32-bit signed integer value equivalent
        //     of the number contained in s, if the conversion succeeded, or zero if the conversion
        //     failed. The conversion fails if the s parameter is null or System.String.Empty,
        //     is not of the correct format, or represents a number less than System.Int32.MinValue
        //     or greater than System.Int32.MaxValue. This parameter is passed uninitialized;
        //     any value originally supplied in result will be overwritten.
        //
        //  public static bool TryParse(string s, out Int32 result);
```
