### PR TITLE
HUD: Don't override user setting to show BATT, add BATT2 option

### DIFF
--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -213,6 +213,7 @@ namespace MissionPlanner.Controls
 
         [System.ComponentModel.Browsable(true), DefaultValue(true)]
         public bool batteryon { get; set; }
+        public bool batteryon2 { get; set; }
 
         [System.ComponentModel.Browsable(true), DefaultValue(true)]
         public bool displayekf { get; set; }
@@ -251,7 +252,7 @@ namespace MissionPlanner.Controls
                                     displayalt =
                                         displayconninfo =
                                             displayxtrack =
-                                                displayrollpitch = displaygps = bgon = hudon = batteryon = true;
+                                                displayrollpitch = displaygps = bgon = hudon = batteryon = batteryon2 = true;
 
             displayAOASSA = false;
 
@@ -2813,7 +2814,7 @@ namespace MissionPlanner.Controls
 
                         if (displayCellVoltage & (_batterycellcount != 0))
                             drawstring(HUDT.Cell + " " + (_batterylevel / _batterycellcount).ToString("0.00v"), font, fontsize + 2, textcolor, xPos, yPos[1]);
-                        else if (_batterylevel2 > 0)
+                        else if (_batterylevel2 > 0 && batteryon2)
                         {
                             text = HUDT.Bat + "2 " + _batterylevel2.ToString("0.00v") + " " + _current2.ToString("0.0 A") + " " +
                                    (_batteryremaining2) + "%";

--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -568,7 +568,6 @@ namespace MissionPlanner.Controls
                 {
                     _current2 = value;
                     this.Invalidate();
-                    if (_current2 > 0) batteryon = true;
                 }
             }
         }
@@ -611,7 +610,6 @@ namespace MissionPlanner.Controls
                 {
                     _current = value;
                     this.Invalidate();
-                    if (_current > 0) batteryon = true;
                 }
             }
         }

--- a/ExtLibs/wasm/Controls/HUD.cs
+++ b/ExtLibs/wasm/Controls/HUD.cs
@@ -298,7 +298,6 @@ namespace MissionPlanner.Controls
                 {
                     _current = value;
                     this.Invalidate();
-                    if (_current > 0) batteryon = true;
                 }
             }
         }

--- a/ExtLibs/wasm/Controls/HUD.cs
+++ b/ExtLibs/wasm/Controls/HUD.cs
@@ -143,7 +143,7 @@ namespace MissionPlanner.Controls
                             displayspeed =
                                 displayalt =
                                     displayconninfo =
-                                        displayxtrack = displayrollpitch = displaygps = bgon = hudon = batteryon = true;
+                                        displayxtrack = displayrollpitch = displaygps = bgon = hudon = batteryon = batteryon2 = true;
 
             displayAOASSA = false;
 
@@ -217,6 +217,7 @@ namespace MissionPlanner.Controls
 
         [System.ComponentModel.Browsable(true), DefaultValue(true)]
         public bool batteryon { get; set; }
+        public bool batteryon2 { get; set; }
 
         [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Values")]
         public float batteryremaining

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -569,17 +569,6 @@ namespace MissionPlanner.GCSViews
 
         public void CheckBatteryShow()
         {
-            // ensure battery display is on - also set in hud if current is updated
-            if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
-                (float) MainV2.comPort.MAV.param["BATT_MONITOR"] != 0)
-            {
-                hud1.batteryon = true;
-            }
-            else
-            {
-                hud1.batteryon = false;
-            }
-
             //Check if we want to display calculated battery cell voltage
             hud1.displayCellVoltage = Settings.Instance.GetBoolean("HUD_showbatterycell", false);
             hud1.batterycellcount = Settings.Instance.GetInt32("HUD_batterycellcount", 0);

--- a/plugins/example9-hudonoff.cs
+++ b/plugins/example9-hudonoff.cs
@@ -57,6 +57,7 @@ namespace hudonoff
                 {"displayrollpitch", "Roll/Pitch"},
                 {"displaygps", "GPS"},
                 {"batteryon", "Battery"},
+                {"batteryon2", "Battery2"},
                 {"displayekf", "EKF"},
                 {"displayvibe", "Vibe"},
                 {"displayprearm", "Prearm Status"},


### PR DESCRIPTION
Three things:
- Don't always show HUD BATT2 if HUD BATT1 is shown.
- Don't override user setting to show HUD BATT. Respect the HUD user setting
- Allow HUD BATT2 a separate show enable

![image](https://user-images.githubusercontent.com/4782875/234654517-08cf6933-5bcc-4397-949e-fd2a5ad7667a.png)
