### PR TITLE
Comm Stats: reset button to clear all the fields better

### DIFF
--- a/Controls/ConnectionStats.cs
+++ b/Controls/ConnectionStats.cs
@@ -36,6 +36,16 @@ namespace MissionPlanner.Controls
         {
             _subscriptionsDisposable = new CompositeDisposable();
 
+            txt_BytesPerSecondRx.Text = "";
+            txt_BytesPerSecondSent.Text = "";
+            txt_BytesReceived.Text = "";
+            txt_BytesSent.Text = "";
+            txt_LinkQuality.Text = "";
+            txt_MaxPacketInterval.Text = "";
+            txt_PacketsLost.Text = "";
+            txt_PacketsPerSecond.Text = "";
+            txt_PacketsRx.Text = "";
+
             var packetsReceivedCount = _mavlink.WhenPacketReceived.Scan(0, (x, y) => x + y);
             var packetsLostCount = _mavlink.WhenPacketLost.Scan(0, (x, y) => x + y);
 


### PR DESCRIPTION
Comm Stats: reset button to clear all the fields better

Before this, they would actually just stop updating and another mavlink packet would show the new initial value.. but the old ones would still show if you were actually disconnected or lost link