### PR TITLE
Revert "Settings: add GetDecimal() to Settings.Instance storage"

### DIFF
--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -254,17 +254,6 @@ namespace MissionPlanner.Utilities
             return defaultd;
         }
 
-        public decimal GetDecimal(string key, decimal defaultd = 0)
-        {
-            decimal result = defaultd;
-            string value = null;
-            if (config.TryGetValue(key, out value))
-            {
-                decimal.TryParse(value, out result);
-            }
-            return result;
-        }
-
         public byte GetByte(string key, byte defaultb = 0)
         {
             byte result;


### PR DESCRIPTION
This reverts commit 680f0715281f16ae34b2aa76e89ed6bae6d58deb.

PR https://github.com/ArduPilot/MissionPlanner/pull/3104 included a commit from https://github.com/ArduPilot/MissionPlanner/pull/3103 and when merged it did a duplicate commit to upstream. This reverts that extra one.