### PR TITLE
ADSB: fix deadlock issue

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -1300,35 +1300,35 @@ namespace MissionPlanner
                                 DateTime.Now)
                             {CallSign = adsb.CallSign, Squawk = adsb.Squawk, Raw = adsb.Raw};
                 }
+            }
 
-                try
-                {
-                    // dont rebroadcast something that came from the drone
-                    if (sender != null && sender is MAVLinkInterface)
-                        return;
+            try
+            {
+                // dont rebroadcast something that came from the drone
+                if (sender != null && sender is MAVLinkInterface)
+                    return;
 
-                    MAVLink.mavlink_adsb_vehicle_t packet = new MAVLink.mavlink_adsb_vehicle_t();
+                MAVLink.mavlink_adsb_vehicle_t packet = new MAVLink.mavlink_adsb_vehicle_t();
 
-                    packet.altitude = (int) (MainV2.instance.adsbPlanes[id].Alt * 1000);
-                    packet.altitude_type = (byte) MAVLink.ADSB_ALTITUDE_TYPE.GEOMETRIC;
-                    packet.callsign = adsb.CallSign.MakeBytes();
-                    packet.squawk = adsb.Squawk;
-                    packet.emitter_type = (byte) MAVLink.ADSB_EMITTER_TYPE.NO_INFO;
-                    packet.heading = (ushort) (MainV2.instance.adsbPlanes[id].Heading * 100);
-                    packet.lat = (int) (MainV2.instance.adsbPlanes[id].Lat * 1e7);
-                    packet.lon = (int) (MainV2.instance.adsbPlanes[id].Lng * 1e7);
-                    packet.ICAO_address = uint.Parse(id, NumberStyles.HexNumber);
+                packet.altitude = (int) (adsb.Alt * 1000);
+                packet.altitude_type = (byte) MAVLink.ADSB_ALTITUDE_TYPE.GEOMETRIC;
+                packet.callsign = adsb.CallSign.MakeBytes();
+                packet.squawk = adsb.Squawk;
+                packet.emitter_type = (byte) MAVLink.ADSB_EMITTER_TYPE.NO_INFO;
+                packet.heading = (ushort) (adsb.Heading * 100);
+                packet.lat = (int) (adsb.Lat * 1e7);
+                packet.lon = (int) (adsb.Lng * 1e7);
+                packet.ICAO_address = uint.Parse(adsb.Tag, NumberStyles.HexNumber);
 
-                    packet.flags = (ushort) (MAVLink.ADSB_FLAGS.VALID_ALTITUDE | MAVLink.ADSB_FLAGS.VALID_COORDS |
-                                             MAVLink.ADSB_FLAGS.VALID_HEADING | MAVLink.ADSB_FLAGS.VALID_CALLSIGN);
+                packet.flags = (ushort) (MAVLink.ADSB_FLAGS.VALID_ALTITUDE | MAVLink.ADSB_FLAGS.VALID_COORDS |
+                                            MAVLink.ADSB_FLAGS.VALID_HEADING | MAVLink.ADSB_FLAGS.VALID_CALLSIGN);
 
-                    //send to current connected
-                    MainV2.comPort.sendPacket(packet, MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid);
-                }
-                catch
-                {
+                //send to current connected
+                MainV2.comPort.sendPacket(packet, MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid);
+            }
+            catch
+            {
 
-                }
             }
         }
 


### PR DESCRIPTION
The call to MainV2.comPort.sendPacket waits for MAVLinkInterface.objlock to release. This can cause a deadlock if the MAVLinkInterface thread has also called adsb_UpdatePlanePosition, and is waiting on this thread to release adsblock. adsblock is only needed for accessing the adsbPlanes list, so this commit restricts the lock to only where it is needed.

When constructing the mavlink packet, adsbPlanes and adsb are used a bit randomly. I changed those all to read from adsb, and moved them out of the locked section as well.