### PR TITLE
mavcmd: rover command list gets LOITER_TURNS

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -882,6 +882,15 @@
       <Y>Long</Y>
       <Z>Alt</Z>
     </LOITER_UNLIM>
+    <LOITER_TURNS>
+      <P1>Turns</P1>
+      <P2></P2>
+      <P3>Radius</P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z>Alt</Z>
+    </LOITER_TURNS>
     <LOITER_TIME>
       <P1>Time s</P1>
       <P2></P2>


### PR DESCRIPTION
This adds LOITER_TURNS to the rover command list.

The AP Rover flight code added support for LOITER_TURNS command as part of PR https://github.com/ArduPilot/ardupilot/pull/23890.

This has been tested on my local machine.
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/2a151138-f8c7-417f-a133-8a507bc6efdf)
