### PR TITLE
mavcmd: update do-digicam-control fields

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -193,7 +193,7 @@
       <Z></Z>
     </DO_DIGICAM_CONFIGURE>
     <DO_DIGICAM_CONTROL>
-      <P1>On/Off</P1>
+      <P1>Session Control</P1>
       <P2>Zoom Position</P2>
       <P3>Zoom Step</P3>
       <P4>Focus Lock</P4>
@@ -754,7 +754,7 @@
       <Z></Z>
     </DO_DIGICAM_CONFIGURE>
     <DO_DIGICAM_CONTROL>
-      <P1>On/Off</P1>
+      <P1>Session Control</P1>
       <P2>Zoom Position</P2>
       <P3>Zoom Step</P3>
       <P4>Focus Lock</P4>
@@ -991,7 +991,7 @@
       <Z></Z>
     </DO_DIGICAM_CONFIGURE>
     <DO_DIGICAM_CONTROL>
-      <P1>On/Off</P1>
+      <P1>Session Control</P1>
       <P2>Zoom Position</P2>
       <P3>Zoom Step</P3>
       <P4>Focus Lock</P4>


### PR DESCRIPTION
This renames the "On/Off" field of the DO_DIGICAM_CONTROL command to "Session Control" which better matches [the mavlink spec](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1226) and, I hope, will reduce confusion with the "Shutter Control" field which is what most users actually need to set.

This has been lightly tested on my desktop and the before and after shots are shown below.

BEFORE:
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/0bba53df-a1c6-4ba5-b3ba-2fd42ad70b20)


AFTER:
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/0200aac3-d2f8-4dfa-bd33-cb012cca54f9)


Thanks to @CraigElder for reporting this issue.