### PR TITLE
CommsUDPSerialConnect multicast to allow address reuse

### DIFF
--- a/Controls/SerialOutputCoT.cs
+++ b/Controls/SerialOutputCoT.cs
@@ -171,7 +171,7 @@ namespace MissionPlanner.Controls
 
                             if (CoTStream != null && CoTStream.IsOpen)
                             {
-                                CoTStream.WriteLine(xmlStr.Replace("\r", ""));
+                                CoTStream.Write(xmlStr.Replace("\r", ""));
                             }
                         });
                     });

--- a/ExtLibs/Comms/CommsUDPSerialConnect.cs
+++ b/ExtLibs/Comms/CommsUDPSerialConnect.cs
@@ -92,7 +92,11 @@ namespace MissionPlanner.Comms
             if (IsInRange("224.0.0.0", "239.255.255.255", hostEndPoint.Address.ToString()))
             {
                 log.Info($"UdpSerialConnect bind to port {Port}");
-                client = new UdpClient(int.Parse(Port), hostEndPoint.AddressFamily);
+
+                client = new UdpClient();
+                client.ExclusiveAddressUse = false;
+                client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                client.Connect(hostEndPoint.Address, hostEndPoint.Port);
 
                 IsOpen = true;
 


### PR DESCRIPTION
When sending to a multicast port, such as 234.2.3.1:6969 for TAK, other apps on the same computer can't use that same multicast IP. Example: using WinTAK to test TAK messages from Mission Planner. There's an option in WinTAK networking settings to allow this, but for Mission Planner I think it's fine to always allow it