### PR TITLE
ConfigRawParams: fix search slowdown

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRawParams.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.Designer.cs
@@ -1,4 +1,4 @@
-﻿using MissionPlanner.Controls;
+using MissionPlanner.Controls;
 
 namespace MissionPlanner.GCSViews.ConfigurationView
 {
@@ -241,6 +241,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             this.Params.AllowUserToAddRows = false;
             this.Params.AllowUserToDeleteRows = false;
+            this.Params.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.Color.Maroon;
             dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -287,7 +288,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // Command
             // 
-            this.Command.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.Command.FillWeight = 20F;
             resources.ApplyResources(this.Command, "Command");
             this.Command.Name = "Command";
@@ -295,12 +295,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // Value
             // 
+            this.Value.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Value.FillWeight = 11F;
             resources.ApplyResources(this.Value, "Value");
             this.Value.Name = "Value";
             // 
             // Default_value
             // 
+            this.Default_value.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Default_value.FillWeight = 11F;
             resources.ApplyResources(this.Default_value, "Default_value");
             this.Default_value.Name = "Default_value";
@@ -308,7 +310,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // Units
             // 
-            this.Units.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.Units.FillWeight = 9F;
             resources.ApplyResources(this.Units, "Units");
             this.Units.Name = "Units";
@@ -316,6 +317,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // Options
             // 
+            this.Options.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Options.FillWeight = 28F;
             resources.ApplyResources(this.Options, "Options");
             this.Options.Name = "Options";

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -1,4 +1,4 @@
-﻿using log4net;
+using log4net;
 using MissionPlanner.Controls;
 using MissionPlanner.Utilities;
 using System;
@@ -588,9 +588,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             log.Info("about to add all");
 
-            Params.SuspendLayout();
+            SuspendParamGridView();
             Params.Visible = false;
-            Params.Enabled = false;
 
             Params.Rows.AddRange(rowlist.ToArray());
 
@@ -600,9 +599,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             Params.Sort(Params.Columns[Command.Index], ListSortDirection.Ascending);
 
-            Params.Enabled = true;
             Params.Visible = true;
-            Params.ResumeLayout();
+            ResumeParamGridView();
 
             if (splitContainer1.Panel1Collapsed == false)
             {
@@ -712,8 +710,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         void filterList(string searchfor)
         {
             DateTime start = DateTime.Now;
-            Params.SuspendLayout();
-            Params.Enabled = false;
+            SuspendParamGridView();
             if (searchfor.Length >= 2 || searchfor.Length == 0)
             {
                 Regex filter = new Regex(searchfor.Replace("*", ".*").Replace("..*", ".*"), RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline);
@@ -762,8 +759,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 }
             }
 
-            Params.Enabled = true;
-            Params.ResumeLayout();
+            ResumeParamGridView();
 
             log.InfoFormat("Filter: {0}ms", (DateTime.Now - start).TotalMilliseconds);
         }
@@ -1170,6 +1166,20 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 optionsControlUpateBounds();
             }
+        }
+
+        void SuspendParamGridView()
+        {
+            Params.SuspendLayout();
+            Params.Enabled = false;
+            Params.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;
+        }
+
+        void ResumeParamGridView()
+        {
+            Params.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
+            Params.Enabled = true;
+            Params.ResumeLayout();
         }
     }
 


### PR DESCRIPTION
We unwittingly introduced a search slowdown in https://github.com/ArduPilot/MissionPlanner/pull/3130. The auto column width is terribly optimized reruns any time a row's visibility is changed, and `SuspendLayout` isn't helping like I'd think it would.

To fix this, I have the auto width turn on and off. I changed the default column width mode for the entire data grid to `AllCells`, and changed the `NotSet` columns to `None`, and changed the `AllCells` columns to `NotSet`. Anywhere where `SuspendLayout` was being called, I added `Params.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;`, and restored the auto size wherever `ResumeLayout` was called (I actually implemented this in a helper function instead of copy/pasting that all 4 places).

We could also probably just go to fixed widths, but I'm happy enough with this approach now.