### PR TITLE
Flightdata, Payload Control tab fixes

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4491,28 +4491,18 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
 
         public void setMountControl(byte sysid, byte compid, double pa, double pb, double pc, bool islatlng)
         {
-            mavlink_mount_control_t req = new mavlink_mount_control_t
-            {
-                target_system = sysid,
-                target_component = compid
-            };
-
             if (!islatlng)
             {
-                req.input_a = (int) pa;
-                req.input_b = (int) pb;
-                req.input_c = (int) pc;
+                // pa is pitch, pb is roll, pc is yaw in centi-degrees.  convert to degrees
+                doCommand(sysid, compid, MAV_CMD.DO_MOUNT_CONTROL, (float)(pa * 0.01), (float)(pb * 0.01), (float)(pc * 0.01), 0, 0, 0, (float)MAV_MOUNT_MODE.MAVLINK_TARGETING, false);
             }
             else
             {
-                req.input_a = (int) (pa * 10000000.0);
-                req.input_b = (int) (pb * 10000000.0);
-                req.input_c = (int) (pc * 100.0);
+                // pa is lat in degrees, placed in param5 in deg * 10e7
+                // pb is lon in degrees, placed in param6 in deg * 10e7
+                // pc is alt in meters, placed in param5 in meters
+                doCommand(sysid, compid, MAV_CMD.DO_MOUNT_CONTROL, 0, 0, 0, (float)pc, (float)(pa * 10000000.0f), (float)(pb * 10000000.0f), (float)MAV_MOUNT_MODE.MAVLINK_TARGETING, false);
             }
-
-            generatePacket((byte) MAVLINK_MSG_ID.MOUNT_CONTROL, req);
-            Thread.Sleep(20);
-            generatePacket((byte) MAVLINK_MSG_ID.MOUNT_CONTROL, req);
         }
 
         [Obsolete]

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -703,35 +703,6 @@ namespace MissionPlanner.GCSViews
             ThemeManager.ApplyThemeTo(tabControlactions);
         }
 
-        //Updates the visibility of the payload control tab based on whether the payload target is available or not
-        public void updatePayloadTabVisible()
-        {
-            bool gimbalPresent = false;
-
-            //if the currently connected target is a flight controller check if there is an associated mavlink gimbal
-            if (MainV2.comPort.compidcurrent == 1)
-            {
-                foreach (var mav in MainV2.comPort.MAVlist)
-                {
-                    if (mav.sysid == MainV2.comPort.sysidcurrent &&
-                        mav.compid == (int) MAVLink.MAV_COMPONENT.MAV_COMP_ID_GIMBAL)
-                    {
-                        gimbalPresent = true;
-                        break;
-                    }
-                }
-            }
-
-            if (tabControlactions.TabPages.Contains(tabPayload) == true && gimbalPresent == false)
-            {
-                tabControlactions.TabPages.Remove(tabPayload);
-            }
-            else if (tabControlactions.TabPages.Contains(tabPayload) == false && gimbalPresent == true)
-            {
-                tabControlactions.TabPages.Add(tabPayload);
-            }
-        }
-
         internal void BUT_run_script_Click(object sender, EventArgs e)
         {
             if (File.Exists(selectedscript))

--- a/GCSViews/FlightData.resx
+++ b/GCSViews/FlightData.resx
@@ -3983,7 +3983,7 @@
     <value>63, 19</value>
   </data>
   <data name="trackBarRoll.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>Yes</value>
+    <value>No</value>
   </data>
   <data name="trackBarRoll.RightToLeftLayout" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -1179,34 +1179,6 @@ namespace MissionPlanner
                     return;
                 }
             }
-
-            if (this.InvokeRequired)
-            {
-                this.BeginInvoke((MethodInvoker) delegate
-                {
-                    //enable the payload control page if a mavlink gimbal is detected
-                    if (instance.FlightData != null)
-                    {
-                        instance.FlightData.updatePayloadTabVisible();
-                    }
-
-                    instance.MyView.Reload();
-
-                    _connectionControl.UpdateSysIDS();
-                });
-            }
-            else
-            {
-                //enable the payload control page if a mavlink gimbal is detected
-                if (instance.FlightData != null)
-                {
-                    instance.FlightData.updatePayloadTabVisible();
-                }
-
-                instance.MyView.Reload();
-
-                _connectionControl.UpdateSysIDS();
-            }
         }
 #if !NETSTANDARD2_0
 #if !NETCOREAPP2_0


### PR DESCRIPTION
This fixes three issues I've found with the Payload Control tab

- The tab appears/disappears based on whether a MAVLink enabled gimbal has been seen or not but most gimbals are not mavlink enabled meaning this tab is normally invisible at first.  I've removed the logic to show/hide this tab and instead it is left to the user to use the Customise checkboxes.
- The Roll scroll bar direction was reversed meaning a gimbal would roll in the opposite direction to what the user would expect
- MOUNT_CONTROL messages have been replaced by MAV_CMD_MOUNT_CONTROL commands.  This command has been accepted since 4.0 (perhaps much earlier).

This has been tested on my PC with a DJI RS2 gimbal ([see AP user wiki here](https://ardupilot.org/copter/docs/common-djirs2-gimbal.html)) running latest ArduPilot.  I have not tested with older versions of AP but I think it should all work.

The only thing I was not able to test was the case where the GCS sends lat,lon,alt commands to the gimbal.  I think what I've done is correct though and from what I can see though this feature is never used in any case.