### PR TITLE
ExtLibs: setMountConfigure uses mav-cmd-do-mount-configure

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4469,18 +4469,15 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
         [Obsolete]
         public void setMountConfigure(MAV_MOUNT_MODE mountmode, bool stabroll, bool stabpitch, bool stabyaw)
         {
-            mavlink_mount_configure_t req = new mavlink_mount_configure_t();
+            byte stab_roll = (stabroll == true) ? (byte) 1 : (byte) 0;
+            byte stab_pitch = (stabpitch == true) ? (byte) 1 : (byte) 0;
+            byte stab_yaw = (stabyaw == true) ? (byte) 1 : (byte) 0;
 
-            req.target_system = MAV.sysid;
-            req.target_component = MAV.compid;
-            req.mount_mode = (byte) mountmode;
-            req.stab_pitch = (stabpitch == true) ? (byte) 1 : (byte) 0;
-            req.stab_roll = (stabroll == true) ? (byte) 1 : (byte) 0;
-            req.stab_yaw = (stabyaw == true) ? (byte) 1 : (byte) 0;
-
-            generatePacket((byte) MAVLINK_MSG_ID.MOUNT_CONFIGURE, req);
-            Thread.Sleep(20);
-            generatePacket((byte) MAVLINK_MSG_ID.MOUNT_CONFIGURE, req);
+            // p1 : mount mode
+            // p2, p3, p4 : stabilize roll, pitch, yaw
+            // p5, p6, p7 : empty
+            // no ack required
+            doCommand(MAV.sysid, MAV.compid, MAV_CMD.DO_MOUNT_CONFIGURE, (byte)mountmode, stab_roll, stab_pitch, stab_yaw, 0, 0, 0, false);
         }
 
         [Obsolete]


### PR DESCRIPTION
This changes the SetMountConfigure method so that it uses the [MAV_CMD_DO_MOUNT_CONFIGURE mavlink command](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1274) instead of the deprecated ardupilot specific [MOUNT_CONFIGURE message](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml#L1237).

This method is only used by the Payload Control tab's "Reset Position" button.
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/c9b50dcf-efe5-4dd2-be61-38dcadb903de)

By the way, ArduPilot has consumed the do-mount-configure command since before ver 4.0 (I didn't look back any further than this).  Ardupilot stopped consuming the roll_stab, pitch_stab and yaw_stab values in version 4.3 but this PR doesn't change how these fields are set anyway.

This has been lightly tested on a real autopilot using a Xacti gimbal.  The only difference in behaviour noted was that the flight code no longer displays the deprecated message.  Below are before and after screen shots taken during testing.
![mp-do-mount-configure-cmd-before-vs-after](https://github.com/ArduPilot/MissionPlanner/assets/1498098/91c79836-6f9a-4577-93bb-8f16b09b506d)