### PR TITLE
Adding Legacy, UTM Basic and UTM Ready display

### DIFF
--- a/ExtLibs/AltitudeAngelWings.Plugin/Resources/MapInfoDockPanel.html
+++ b/ExtLibs/AltitudeAngelWings.Plugin/Resources/MapInfoDockPanel.html
@@ -72,17 +72,34 @@
             text-transform: capitalize;
         }
 
-        div.utmStatus {
+        div.utmReadyStatus {
             border: 1px solid #3dbb4e;
             margin-top: 10px;
             padding: 0 10px;
         }
 
-        div.utmStatus div.section div.title {
-            display: block;
-            text-align: center;
-            font-size: 18px;
-            padding: 5px;
+        div.utmBasicStatus {
+            border: 1px solid darkorange;
+            margin-top: 10px;
+            padding: 0 10px;
+        }
+
+        div.utmReadyTitle {
+            background-color: #edf8ed;
+            margin: 8px 0;
+            padding: 8px;
+        }
+
+        div.utmBasicTitle {
+            background-color: #fcebb4;
+            margin: 8px 0;
+            padding: 8px;
+        }
+
+        div.utmLegacyTitle {
+            background-color: #fde5ee;
+            margin: 8px 0;
+            padding: 8px;
         }
 
         div.noUtm {
@@ -91,8 +108,17 @@
             padding: 0 10px;
         }
 
-        div.utmStatus div.button {
+        div.utmReadyStatus div.button {
             background-color: #3dbb4e;
+            text-align: center;
+            margin: 0 50px 10px;
+            padding: 10px 10px;
+            font-weight: bold;
+            font-size: 14px;
+        }
+
+        div.utmBasicStatus div.button {
+            background-color: #fb0;
             text-align: center;
             margin: 0 50px 10px;
             padding: 10px 10px;

--- a/ExtLibs/AltitudeAngelWings/AltitudeAngelWings.csproj
+++ b/ExtLibs/AltitudeAngelWings/AltitudeAngelWings.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MarkdownSharp" Version="2.0.5" />
+    <PackageReference Include="Markdig" Version="0.32.0" />
     <PackageReference Include="NetTopologySuite" Version="2.4.0" />
     <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.1" />
     <PackageReference Include="Flurl" Version="3.0.2" />

--- a/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
@@ -30,22 +30,8 @@ namespace AltitudeAngelWings.Clients.Api.Model
             IDictionary<string, RateCardDetail> rateCardDetails)
         {
             var settings = ServiceLocator.GetService<ISettings>();
+            var pipeline = ServiceLocator.GetService<MarkdownPipeline>();
             var builder = new StringBuilder();
-            var pipeline = new MarkdownPipelineBuilder()
-                .UseAbbreviations()
-                .UseAutoIdentifiers()
-                .UseCitations()
-                .UseDefinitionLists()
-                .UseEmphasisExtras()
-                .UseFooters()
-                .UseFootnotes()
-                .UseGridTables()
-                .UsePipeTables()
-                .UseListExtras()
-                .UseTaskLists()
-                .DisableHtml()
-                .UseSmartyPants()
-                .Build();
             builder.Append("<div class=\"feature\">");
             builder.Append($"<div class=\"highlight\" style=\"background-color: {featureProperties.FillColor}\"></div>");
             builder.Append("<div class=\"header\">");

--- a/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using MarkdownSharp;
+using Markdig;
 
 namespace AltitudeAngelWings.Clients.Api.Model
 {
@@ -31,13 +31,21 @@ namespace AltitudeAngelWings.Clients.Api.Model
         {
             var settings = ServiceLocator.GetService<ISettings>();
             var builder = new StringBuilder();
-            var markdown = new Markdown(new MarkdownOptions
-            {
-                AutoNewlines = false,
-                AutoHyperlink = false,
-                LinkEmails = false,
-                EmptyElementSuffix = "/>"
-            });
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAbbreviations()
+                .UseAutoIdentifiers()
+                .UseCitations()
+                .UseDefinitionLists()
+                .UseEmphasisExtras()
+                .UseFooters()
+                .UseFootnotes()
+                .UseGridTables()
+                .UsePipeTables()
+                .UseListExtras()
+                .UseTaskLists()
+                .DisableHtml()
+                .UseSmartyPants()
+                .Build();
             builder.Append("<div class=\"feature\">");
             builder.Append($"<div class=\"highlight\" style=\"background-color: {featureProperties.FillColor}\"></div>");
             builder.Append("<div class=\"header\">");
@@ -91,14 +99,14 @@ namespace AltitudeAngelWings.Clients.Api.Model
 
                     if (!string.IsNullOrWhiteSpace(featureProperties.UtmStatus.Title))
                     {
-                        builder.Append($"<div class=\"title\">{markdown.Transform(featureProperties.UtmStatus.Title)}</div>");
+                        builder.Append($"<div class=\"title\">{Markdown.ToHtml(featureProperties.UtmStatus.Title, pipeline)}</div>");
                     }
 
                     builder.Append($"<div class=\"displayTitle\">{(isReady ? "FACILITY IS UTM CONNECTED" : "NOTIFY FACILITY")}</div>");
 
                     if (!string.IsNullOrWhiteSpace(featureProperties.UtmStatus.Description))
                     {
-                        builder.Append($"<div class=\"text\">{markdown.Transform(featureProperties.UtmStatus.Description)}</div>");
+                        builder.Append($"<div class=\"text\">{Markdown.ToHtml(featureProperties.UtmStatus.Description, pipeline)}</div>");
                     }
                     else if (!isReady)
                     {
@@ -125,7 +133,7 @@ namespace AltitudeAngelWings.Clients.Api.Model
                         builder.Append($"<div class=\"displayTitle\">{MapRateTypeToText(rateType)}</div>");
                         builder.Append("<div class=\"rateCard\">");
                         builder.Append($"<p>{featureProperties.DisplayInfo.Title.ToUpper()}</p>");
-                        builder.Append($"<p>{rateCard.ExplanatoryText}</p>");
+                        builder.Append($"<p>{Markdown.ToHtml(rateCard.ExplanatoryText, pipeline)}</p>");
                         builder.Append("<ul>");
                         foreach (var rate in rateCard.Rates.OrderBy(r => r.Ordinal))
                         {
@@ -199,12 +207,12 @@ namespace AltitudeAngelWings.Clients.Api.Model
 
                 if (!string.IsNullOrWhiteSpace(section.Text))
                 {
-                    builder.Append($"<div class=\"text\">{markdown.Transform(section.Text)}</div>");
+                    builder.Append($"<div class=\"text\">{Markdown.ToHtml(section.Text, pipeline)}</div>");
                 }
 
                 if (!string.IsNullOrWhiteSpace(section.Disclaimer))
                 {
-                    builder.Append($"<div class=\"disclaimer\">{markdown.Transform(section.Disclaimer)}</div>");
+                    builder.Append($"<div class=\"disclaimer\">{Markdown.ToHtml(section.Disclaimer, pipeline)}</div>");
                 }
                 builder.Append("</div>");
             }

--- a/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
@@ -39,16 +39,31 @@ namespace AltitudeAngelWings.Clients.Api.Model
             });
             builder.Append("<div class=\"feature\">");
             builder.Append($"<div class=\"highlight\" style=\"background-color: {featureProperties.FillColor}\"></div>");
-            builder.Append($"<div class=\"header\">");
+            builder.Append("<div class=\"header\">");
             builder.Append($"<div class=\"category\">{featureProperties.DisplayInfo.Category}</div>");
             builder.Append($"<div class=\"detailedCategory\"> : {featureProperties.DisplayInfo.DetailedCategory}</div>");
             builder.Append($"<div class=\"displayTitle\">{featureProperties.DisplayInfo.Title.ToUpper()}</div>");
+            if (featureProperties.HasUtmStatus())
+            {
+                // TODO: Get base URL from domain suffix
+                builder.Append("<div class=\"utmBadge\"><img src=\"https://dronesafetymap.com/images/icons/");
+                if (featureProperties.IsUtmReady())
+                {
+                    builder.Append("utm-ready.png");
+                }
+                else if (featureProperties.IsUtmBasic())
+                {
+                    builder.Append("utm-basic.png");
+                }
+                else
+                {
+                    builder.Append("utm-legacy.png");
+                }
+                builder.Append("\"/></div>");
+            }
             builder.Append("</div>");
-            /*
-             3 Star UTM Ready: utmStatus != null && utmStatus.enabled == true && utmStatus.utm != null && utmStatus.utm.id == "AA_GUARDIAN_UTM"
-             2 Star UTM Basic: utmStatus != null && utmStatus.enabled == true && utmStatus.utm != null && utmStatus.utm.id == "AA_UTM_READY"
-             1 Star Legacy: utmStatus != null && utmStatus.enabled == false
-            */
+
+            // TODO: UTM Legacy/Basic/Ready display
             if (featureProperties.UtmStatus?.UtmDetails != null && featureProperties.UtmStatus.Enabled)
             {
                 builder.Append("<div class=\"utmStatus\">");

--- a/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
@@ -44,6 +44,11 @@ namespace AltitudeAngelWings.Clients.Api.Model
             builder.Append($"<div class=\"detailedCategory\"> : {featureProperties.DisplayInfo.DetailedCategory}</div>");
             builder.Append($"<div class=\"displayTitle\">{featureProperties.DisplayInfo.Title.ToUpper()}</div>");
             builder.Append("</div>");
+            /*
+             3 Star UTM Ready: utmStatus != null && utmStatus.enabled == true && utmStatus.utm != null && utmStatus.utm.id == "AA_GUARDIAN_UTM"
+             2 Star UTM Basic: utmStatus != null && utmStatus.enabled == true && utmStatus.utm != null && utmStatus.utm.id == "AA_UTM_READY"
+             1 Star Legacy: utmStatus != null && utmStatus.enabled == false
+            */
             if (featureProperties.UtmStatus?.UtmDetails != null && featureProperties.UtmStatus.Enabled)
             {
                 builder.Append("<div class=\"utmStatus\">");

--- a/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/Clients/Api/Model/DisplayInfoExtensions.cs
@@ -29,6 +29,7 @@ namespace AltitudeAngelWings.Clients.Api.Model
         public static string FormatAsHtml(this FeatureProperties featureProperties,
             IDictionary<string, RateCardDetail> rateCardDetails)
         {
+            var settings = ServiceLocator.GetService<ISettings>();
             var builder = new StringBuilder();
             var markdown = new Markdown(new MarkdownOptions
             {
@@ -45,8 +46,7 @@ namespace AltitudeAngelWings.Clients.Api.Model
             builder.Append($"<div class=\"displayTitle\">{featureProperties.DisplayInfo.Title.ToUpper()}</div>");
             if (featureProperties.HasUtmStatus())
             {
-                // TODO: Get base URL from domain suffix
-                builder.Append("<div class=\"utmBadge\"><img src=\"https://dronesafetymap.com/images/icons/");
+                builder.Append($"<div class=\"utmBadge\"><img src=\"{settings.CdnUrl}/images/icons/");
                 if (featureProperties.IsUtmReady())
                 {
                     builder.Append("utm-ready.png");
@@ -110,8 +110,8 @@ namespace AltitudeAngelWings.Clients.Api.Model
                         builder.Append(" (");
                         var total = rate.Rate + rateCard.StandingCharge;
                         total += rateCard.TaxRate / 100 * total;
-                        builder.Append(CurrencyLookup.ContainsKey(rateCard.Currency)
-                            ? total.ToString("C", CurrencyLookup[rateCard.Currency])
+                        builder.Append(CurrencyLookup.TryGetValue(rateCard.Currency, out var value)
+                            ? total.ToString("C", value)
                             : $"{total} {rateCard.Currency}");
 
                         builder.Append(")</li>");

--- a/ExtLibs/AltitudeAngelWings/Clients/Api/Model/FeaturePropertiesExtensions.cs
+++ b/ExtLibs/AltitudeAngelWings/Clients/Api/Model/FeaturePropertiesExtensions.cs
@@ -5,6 +5,52 @@ namespace AltitudeAngelWings.Clients.Api.Model
 {
     public static class FeaturePropertiesExtensions
     {
+        public static bool HasUtmStatus(this FeatureProperties properties)
+            => properties?.UtmStatus != null;
+
+        public static bool IsUtmEnabled(this FeatureProperties properties)
+            => properties?.UtmStatus != null && properties.UtmStatus.Enabled;
+
+        public static bool IsUtmLegacy(this FeatureProperties properties)
+        {
+            if (!properties.HasUtmStatus())
+            {
+                return false;
+            }
+
+            return !properties.IsUtmEnabled();
+        }
+
+        public static bool IsUtmBasic(this FeatureProperties properties)
+        {
+            if (!properties.IsUtmEnabled())
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(properties.UtmStatus.UtmDetails?.Id))
+            {
+                return false;
+            }
+
+            return properties.UtmStatus.UtmDetails.Id == "AA_UTM_READY";
+        }
+
+        public static bool IsUtmReady(this FeatureProperties properties)
+        {
+            if (!properties.IsUtmEnabled())
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(properties.UtmStatus.UtmDetails?.Id))
+            {
+                return false;
+            }
+
+            return properties.UtmStatus.UtmDetails.Id == "AA_GUARDIAN_UTM";
+        }
+
         public static ColorInfo ToColorInfo(this FeatureProperties properties, float opacityAdjust = 1f)
         {
             var fillColor = ToARGB(properties.FillColor, properties.FillOpacity, opacityAdjust);

--- a/ExtLibs/AltitudeAngelWings/ISettings.cs
+++ b/ExtLibs/AltitudeAngelWings/ISettings.cs
@@ -56,5 +56,6 @@ namespace AltitudeAngelWings
         string FlightIdentifierSerialNumber { get; set; }
         int AltitudeFilter { get; set; }
         string SurveillanceUrl { get; }
+        string CdnUrl { get; }
     }
 }

--- a/ExtLibs/AltitudeAngelWings/ServiceLocatorConfiguration.cs
+++ b/ExtLibs/AltitudeAngelWings/ServiceLocatorConfiguration.cs
@@ -20,6 +20,7 @@ using AltitudeAngelWings.Service.Messaging;
 using AltitudeAngelWings.Service.OutboundNotifications;
 using Flurl.Http;
 using Flurl.Http.Configuration;
+using Markdig;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NodaTime;
@@ -144,6 +145,21 @@ namespace AltitudeAngelWings
                     l.Resolve<IApiClient>(),
                 l.Resolve<ITelemetryService>(),
                 l.Resolve<IFlightService>()));
+            ServiceLocator.Register(l => new MarkdownPipelineBuilder()
+                    .UseAbbreviations()
+                    .UseAutoIdentifiers()
+                    .UseCitations()
+                    .UseDefinitionLists()
+                    .UseEmphasisExtras()
+                    .UseFooters()
+                    .UseFootnotes()
+                    .UseGridTables()
+                    .UsePipeTables()
+                    .UseListExtras()
+                    .UseTaskLists()
+                    .DisableHtml()
+                    .UseSmartyPants()
+                    .Build());
         }
 
         private static void ResetAccessToken(ISettings settings)

--- a/ExtLibs/AltitudeAngelWings/Settings.cs
+++ b/ExtLibs/AltitudeAngelWings/Settings.cs
@@ -69,7 +69,13 @@ namespace AltitudeAngelWings
 
         public string SurveillanceUrl => $"https://surveillance-api.{UrlDomainSuffix}";
 
-        public string UrlDomainSuffix => OverrideClientUrlSettings ? OverrideUrlDomainSuffix : "altitudeangel.com";
+        public string CdnUrl => UrlDomainSuffix == DefaultDomainSuffix
+            ? "https://dronesafetymap.com"
+            : $"https://map.{UrlDomainSuffix}";
+
+        private const string DefaultDomainSuffix = "altitudeangel.com";
+
+        public string UrlDomainSuffix => OverrideClientUrlSettings ? OverrideUrlDomainSuffix : DefaultDomainSuffix;
 
         public bool OverrideClientUrlSettings
         {


### PR DESCRIPTION
Adding the display of Legacy, UTM Basic (notify), and UTM Ready (connected) airspaces. This enables a better understanding of when approval is needed for the use of airspace and if that approval is fully electronic, simple electronic notification, or legacy phone contact based. See https://www.altitudeangel.com/news/altitude-angel-platform-launch-hailed-as-a-key-step-for-uk-aviation.

Legacy:
![image](https://github.com/ArduPilot/MissionPlanner/assets/1358821/283eb884-f0b3-48e8-8e7e-dbee62263a4a)

UTM Basic (notify):
![image](https://github.com/ArduPilot/MissionPlanner/assets/1358821/40ef1e40-af20-4c57-a407-2329dcfb41e3)

UTM Ready (connected):
![image](https://github.com/ArduPilot/MissionPlanner/assets/1358821/3bc3792b-872c-4253-82b7-512dbcc1e963)
