### PR TITLE
PreFlight tab: Resizing fix

### DIFF
--- a/Controls/PreFlight/CheckListControl.Designer.cs
+++ b/Controls/PreFlight/CheckListControl.Designer.cs
@@ -42,6 +42,7 @@
             this.BUT_edit.Size = new System.Drawing.Size(34, 23);
             this.BUT_edit.TabIndex = 0;
             this.BUT_edit.Text = "Edit";
+            this.BUT_edit.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_edit.UseVisualStyleBackColor = true;
             this.BUT_edit.Click += new System.EventHandler(this.BUT_edit_Click);
             // 
@@ -68,6 +69,7 @@
             this.DoubleBuffered = true;
             this.Name = "CheckListControl";
             this.Size = new System.Drawing.Size(268, 179);
+            this.Load += new System.EventHandler(this.CheckListControl_Load);
             this.ResumeLayout(false);
 
         }

--- a/Controls/PreFlight/CheckListControl.cs
+++ b/Controls/PreFlight/CheckListControl.cs
@@ -17,6 +17,16 @@ namespace MissionPlanner.Controls.PreFlight
 
         int rowcount = 0;
 
+        //Controls and the lists for the controls
+        private GroupBox gb = new GroupBox();
+        private Label desc = new Label();
+        private Label text = new Label();
+        private CheckBox tickbox = new CheckBox();
+        private List<GroupBox> groupboxes = new List<GroupBox>();
+        private List<Label> descLabels = new List<Label>();
+        private List<Label> labels = new List<Label>();
+        private List<CheckBox> checkboxes = new List<CheckBox>();
+
         internal struct internaldata
         {
             internal Label desc;
@@ -57,7 +67,10 @@ namespace MissionPlanner.Controls.PreFlight
                 int y = 0;
 
                 rowcount = 0;
-
+                groupboxes.Clear();
+                descLabels.Clear();
+                labels.Clear();
+                checkboxes.Clear();
                 foreach (var item in this.CheckListItems)
                 {
                     var wrnctl = addwarningcontrol(5, y, item);
@@ -114,24 +127,49 @@ namespace MissionPlanner.Controls.PreFlight
 
             var height = TextRenderer.MeasureText(desctext, this.Font).Height;
 
-            var x0 = (int)(Width * 0.95);
-            var x1 = (int)(x0 * 0.5);
-            var x2 = (int)(x0 * 0.4);
-            var x3 = (int)(x0 * 0.1);
+            var x0 = (int)(panel1.Width * 0.94);
+            var x1 = (int)(x0 * 0.66);
+            var x2 = (int)(x0 * 0.26);
+            var x3 = (int)(x0 * 0.08);
 
-            GroupBox gb = new GroupBox() { Text = "", Location = new Point(x, y), Size = new Size(x0, 17 + height), Name = "gb" + y };
+            gb = new GroupBox() { Text = "", Location = new Point(x, y), Size = new Size(x0, 17 + height), Name = "gb" + y };
 
-            Label desc = new Label() { Text = desctext, Location = new Point(5, 9), Size = new Size(x1, height), Name = "udesc" + y };
-            Label text = new Label() { Text = texttext, Location = new Point(desc.Right, 9), Size = new Size(x2, height), Name = "utext" + y };
-            CheckBox tickbox = new CheckBox() { Checked = item.checkCond(item), Location = new Point(text.Right, 7), Size = new Size(21, 21), Name = "utickbox" + y };
+            desc = new Label() { Text = desctext, Location = new Point(5, 9), Size = new Size(x1, height), Name = "udesc" + y };
+            text = new Label() { Text = texttext, Location = new Point(desc.Right, 9), Size = new Size(x2, height), Name = "utext" + y };
+            tickbox = new CheckBox() { Checked = item.checkCond(item), Location = new Point((text.Right), 7), Size = new Size(21, 21), Name = "utickbox" + y };
 
             desc.Tag = text.Tag = tickbox.Tag = new internaldata { CLItem = item, desc = desc, text = text, tickbox = tickbox };
 
+            //Changing the font size of the desc labels text according to amount of characters contained in the label
+            desc.TextAlign = ContentAlignment.MiddleLeft;
+            if (desc.Text.ToCharArray().Length > 35)
+            {
+                if (desc.Text.ToCharArray().Length > 35 && desc.Text.ToCharArray().Length < 40)
+                {
+                    desc.Font = new Font(desc.Font.FontFamily, desc.Font.Size - 0.7f, desc.Font.Style);
+                }
+                else if (desc.Text.ToCharArray().Length >= 40)
+                {
+                    desc.Font = new Font(desc.Font.FontFamily, desc.Font.Size - 1.35f, desc.Font.Style);
+                }
+            }
+            else if (desc.Text.ToCharArray().Length <= 35)
+            {
+                desc.Font = new Font(desc.Font.FontFamily, desc.Font.Size - 0.4f, desc.Font.Style);
+            }
+
+            //Add the controls to the main control
             gb.Controls.Add(desc);
             gb.Controls.Add(text);
             gb.Controls.Add(tickbox);
 
             panel1.Controls.Add(gb);
+
+            //Add controls to relevant control lists
+            groupboxes.Add(gb);
+            descLabels.Add(desc);
+            labels.Add(text);
+            checkboxes.Add(tickbox);
 
             y = gb.Bottom;
 
@@ -216,6 +254,107 @@ namespace MissionPlanner.Controls.PreFlight
             {
                 timer1.Enabled = false;
             }
+        }
+
+        public void Controls_Resize(object sender, EventArgs e)
+        {
+            //initialize controls x and y
+            int gbsX = 0;
+            int gbsY = 0;
+            int lblsOneX = 0;
+            int lblsOneY = 0;
+            int lblsTwoX = 0;
+            int lblsTwoY = 0;
+            int cbxsX = 0;
+            int cbxsY = 0;
+
+            //Width of the controls
+            //Panel1 variable width
+            var panelOneWidth = panel1.Width;
+            //Group boxes variable width
+            var gbsWidth = groupboxes[0].Width = (int)(panelOneWidth * 0.9);
+            //Desc label variable width
+            var descLabelWidth = descLabels[0].Width = (int)(gbsWidth * 0.6204);
+            //Second label variable width
+            var labeTwolWidth = labels[0].Width = (int)(gbsWidth * 0.2444);
+            //Checkbox variable width
+            var checkboxWidth = checkboxes[0].Width = (int)(gbsWidth * 0.0752);
+
+            //Setting Locations
+            //Set the first groupboxes location
+            groupboxes[0].Location = new Point(groupboxes[0].Location.X, groupboxes[0].Location.Y);
+            gbsX = groupboxes[0].Location.X;
+            gbsY = groupboxes[0].Location.Y;
+
+            //location of the desc Label
+            descLabels[0].Location = new Point(descLabels[0].Location.X, descLabels[0].Location.Y);
+            lblsOneX = descLabels[0].Location.X;
+            lblsOneY = descLabels[0].Location.Y;
+            //set the second labels location
+            var labelTwo = labels[0].Location = new Point(labels[0].Location.X, labels[0].Location.Y);
+            lblsTwoX = descLabels[0].Width + (int)(gbsWidth * 0.02);
+            lblsTwoY = labels[0].Location.Y;
+            //set the first checkboxes location
+            var checkboxOne = checkboxes[0].Location = new Point(checkboxes[0].Location.X, checkboxes[0].Location.Y);
+            cbxsX = labels[0].Location.X + labels[0].Width + (int)(gbsWidth * 0.02);
+            cbxsY = checkboxes[0].Location.Y;
+
+            for (int i = 0; i < groupboxes.Count; i++)
+            {
+                if (groupboxes.Count > 0 && labels.Count > 0 && checkboxes.Count > 0)
+                {
+                    //Set the group box Y Location
+                    gbsY = groupboxes[i].Bottom;
+                    //Set the width of the desc labels
+                    descLabelWidth = descLabels[i].Width;
+
+                    if (i == 0)
+                    {
+                        //check the height of the panel1 = not to do with the change
+                        var panelOneHeight = panel1.Height;
+
+                        //ratio needs to be rechecked
+                        if (this.panel1.Width > 0)
+                        {
+                            //set the width of the group boxes
+                            groupboxes[i].Width = (int)(panelOneWidth * 0.9);
+
+                            //desc Label X Location
+                            lblsOneX = descLabels[i].Location.X;
+
+                            //Second label X Location
+                            lblsTwoX = labelTwo.X = (int)(groupboxes[i].Width * 0.66);
+
+                            labels[i].Width = (int)(groupboxes[i].Width * 0.3);
+
+                            //checkbox location
+                            cbxsX = checkboxOne.X = (int)(groupboxes[i].Width * 0.9);
+                        }
+                    }
+                    else if (i > 0)
+                    {
+                        //setting the groupboxes width
+                        groupboxes[i].Width = (int)(panelOneWidth * 0.9);
+                    }
+
+                    //set the location in the group box for labels
+                    descLabels[i].Location = new Point(lblsOneX, lblsOneY);
+                    //set the location in the group box for the second labels
+                    labels[i].Location = new Point(lblsTwoX, lblsTwoY);
+                    //set the location in the group box for the checkboxes
+                    checkboxes[i].Location = new Point(cbxsX, cbxsY);
+
+                    //Bring controls to the front
+                    groupboxes[i].BringToFront();
+                    labels[i].BringToFront();
+                    checkboxes[i].BringToFront();
+                }
+            }
+        }
+
+        private void CheckListControl_Load(object sender, EventArgs e)
+        {
+            this.Resize += new EventHandler(Controls_Resize);
         }
     }
 }

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -113,6 +113,9 @@
     <EmbeddedResource Include="Controls\PrearmStatus.resx">
       <DependentUpon>PrearmStatus.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Controls\PreFlight\CheckListControl.resx">
+      <DependentUpon>CheckListControl.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Controls\PropagationSettings.uk.resx">
       <DependentUpon>PropagationSettings.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
Issue: In the PreFlight tab on the Data screen in Mission Planner, the Preflight group boxes do not change their size when resizing the panel.

Fix: The Preflight group boxes and their components will now resize according to the size of the panel. A Resize Event Handler has been added into the CheckListControl file, as well as a function to resize the desc label text to fit the text better onto the screen for checks containing longer strings.
