### PR TITLE
mavcmd: add image-start-capture command columns

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -121,9 +121,9 @@
       <Z>Alt</Z>
     </SPLINE_WAYPOINT>
     <IMAGE_START_CAPTURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
+      <P1>Id</P1>
+      <P2>Interval</P2>
+      <P3>Total Images</P3>
       <P4></P4>
       <X></X>
       <Y></Y>
@@ -520,9 +520,9 @@
       <Z></Z>
     </DO_VTOL_TRANSITION>
     <IMAGE_START_CAPTURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
+      <P1>Id</P1>
+      <P2>Interval</P2>
+      <P3>Total Images</P3>
       <P4></P4>
       <X></X>
       <Y></Y>
@@ -919,9 +919,9 @@
       <Z></Z>
     </SET_YAW_SPEED>
     <IMAGE_START_CAPTURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
+      <P1>Id</P1>
+      <P2>Interval</P2>
+      <P3>Total Images</P3>
       <P4></P4>
       <X></X>
       <Y></Y>


### PR DESCRIPTION
This is a minor fix so that the IMAGE_START_CAPTURE commands columns are filled in.

This has been lightly tested on my PC to confirm the command column headers appear

![mp-mavcmd-image-start-capture](https://github.com/ArduPilot/MissionPlanner/assets/1498098/9e540b40-7d08-43b3-9ab3-52f28aec56a0)

BTW, there's actually a fourth column, "Sequence Number", that we don't support so I've left that field out ([see command definition here](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1670)) 