### PR TITLE
Temp: Add sysid target to safety switch command

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1688,7 +1688,7 @@ namespace MissionPlanner.GCSViews
                     if (CMB_action.Text == actions.Toggle_Safety_Switch.ToString())
                     {
                         var custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u;
-                        var mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode };
+                        var mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode, target_system = (byte)MainV2.comPort.sysidcurrent };
                         MainV2.comPort.setMode(mode, MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
                         ((Control)sender).Enabled = true;
                         return;

--- a/temp.cs
+++ b/temp.cs
@@ -1187,8 +1187,11 @@ namespace MissionPlanner
         {
             if (CustomMessageBox.Show("Are you sure?", "", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
                 MainV2.comPort.setMode(
-                    new MAVLink.mavlink_set_mode_t() { custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control == true && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u },
-                    MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
+                    new MAVLink.mavlink_set_mode_t()
+                    {
+                        custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control == true && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u,
+                        target_system = (byte)MainV2.comPort.sysidcurrent
+                    }, MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
         }
 
         private void but_hwids_Click(object sender, EventArgs e)


### PR DESCRIPTION
Adds the target system id to the "safely switch" button.

Fixes issue when having multiple vehicles connected, pressing the "safety switch" button would not work.