### PR TITLE
mavcmd: add image-stop-capture command

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -129,6 +129,15 @@
       <Y></Y>
       <Z></Z>
     </IMAGE_START_CAPTURE>
+    <IMAGE_STOP_CAPTURE>
+      <P1>Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_STOP_CAPTURE>
     <SET_CAMERA_ZOOM>
       <P1>Type</P1>
       <P2>Value</P2>
@@ -528,6 +537,15 @@
       <Y></Y>
       <Z></Z>
     </IMAGE_START_CAPTURE>
+    <IMAGE_STOP_CAPTURE>
+      <P1>Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_STOP_CAPTURE>
     <SET_CAMERA_ZOOM>
       <P1>Type</P1>
       <P2>Value</P2>
@@ -927,6 +945,15 @@
       <Y></Y>
       <Z></Z>
     </IMAGE_START_CAPTURE>
+    <IMAGE_STOP_CAPTURE>
+      <P1>Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_STOP_CAPTURE>
     <SET_CAMERA_ZOOM>
       <P1>Type</P1>
       <P2>Value</P2>


### PR DESCRIPTION
A follow-up to PR https://github.com/ArduPilot/MissionPlanner/pull/3175 this adds the [image-stop-capture command](https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/common.xml#L1693) which will be added to AP shortly (see https://github.com/ArduPilot/ardupilot/pull/24772).

This has been lightly tested and looks good.
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/31bd66ae-37ae-4c4e-97f2-30584a4b0595)
