### PR TITLE
GCSViews: ConfigRawParams: look up param type for bitmask helper

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -996,8 +996,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 {
                     var mcb = new MavlinkCheckBoxBitMask();
                     var list = new MAVLink.MAVLinkParamList();
+
+                    // Try and get type so the correct bitmask to value convertion is done
+                    var type = MAVLink.MAV_PARAM_TYPE.INT32;
+                    if (MainV2.comPort.MAV.param.ContainsKey(param_name))
+                    {
+                        type = MainV2.comPort.MAV.param[param_name].TypeAP;
+                    }
+
                     list.Add(new MAVLink.MAVLinkParam(param_name, double.Parse(Params[Value.Index, e.RowIndex].Value.ToString(), CultureInfo.InvariantCulture),
-                        MAVLink.MAV_PARAM_TYPE.INT32));
+                        type));
                     mcb.setup(param_name, list);
                     mcb.ValueChanged += (o, x, value) =>
                     {


### PR DESCRIPTION
Currently the bitmask helper assumes int32, this means the sign bit in smaller masks cannot be set. `INS_HNTCH_HMNCS` is a example of a `int8` param. 

Currently the 8th bit will set the value to 128:
![image](https://github.com/ArduPilot/MissionPlanner/assets/33176108/be65b703-a46f-4a39-b307-1a178ff1be89)

This is out of range for a int8, so when you write and read back you get a constrained down value of 127 which is a completely different bitmask. 

![image](https://github.com/ArduPilot/MissionPlanner/assets/33176108/29e600d2-5a2f-40b2-952c-37126ca23ab8)

With this patch when setting the 8th bit:

![image](https://github.com/ArduPilot/MissionPlanner/assets/33176108/5d070b76-6499-4587-bb08-fba790124313)

We now get -128 which is the correct in range value for the int8 param type.





