### PR TITLE
ConfigRawParams: manual absolute column sizing

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRawParams.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.Designer.cs
@@ -241,7 +241,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             this.Params.AllowUserToAddRows = false;
             this.Params.AllowUserToDeleteRows = false;
-            this.Params.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.Color.Maroon;
             dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -295,14 +294,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // Value
             // 
-            this.Value.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Value.FillWeight = 11F;
             resources.ApplyResources(this.Value, "Value");
             this.Value.Name = "Value";
             // 
             // Default_value
             // 
-            this.Default_value.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Default_value.FillWeight = 11F;
             resources.ApplyResources(this.Default_value, "Default_value");
             this.Default_value.Name = "Default_value";
@@ -317,7 +314,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // Options
             // 
-            this.Options.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Options.FillWeight = 28F;
             resources.ApplyResources(this.Options, "Options");
             this.Options.Name = "Options";
@@ -339,7 +335,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Fav.FillWeight = 4F;
             resources.ApplyResources(this.Fav, "Fav");
             this.Fav.Name = "Fav";
-            this.Fav.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.Fav.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             // 
             // ConfigRawParams
             // 

--- a/GCSViews/ConfigurationView/ConfigRawParams.resx
+++ b/GCSViews/ConfigurationView/ConfigRawParams.resx
@@ -638,7 +638,7 @@ format with no scaling</value>
     <value>50</value>
   </data>
   <data name="Command.Width" type="System.Int32, mscorlib">
-    <value>126</value>
+    <value>130</value>
   </data>
   <metadata name="Value.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -650,7 +650,7 @@ format with no scaling</value>
     <value>50</value>
   </data>
   <data name="Value.Width" type="System.Int32, mscorlib">
-    <value>69</value>
+    <value>70</value>
   </data>
   <metadata name="Default_value.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -665,7 +665,7 @@ format with no scaling</value>
     <value>False</value>
   </data>
   <data name="Default_value.Width" type="System.Int32, mscorlib">
-    <value>69</value>
+    <value>70</value>
   </data>
   <metadata name="Units.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -677,7 +677,7 @@ format with no scaling</value>
     <value>50</value>
   </data>
   <data name="Units.Width" type="System.Int32, mscorlib">
-    <value>56</value>
+    <value>60</value>
   </data>
   <metadata name="Options.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -689,7 +689,7 @@ format with no scaling</value>
     <value>50</value>
   </data>
   <data name="Options.Width" type="System.Int32, mscorlib">
-    <value>175</value>
+    <value>150</value>
   </data>
   <metadata name="Desc.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -728,7 +728,7 @@ format with no scaling</value>
     <value>Params</value>
   </data>
   <data name="&gt;&gt;Params.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyDataGridView, MissionPlanner, Version=1.3.8474.23142, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MyDataGridView, MissionPlanner, Version=1.3.8674.15835, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;Params.Parent" xml:space="preserve">
     <value>splitContainer1.Panel2</value>


### PR DESCRIPTION
This commit does 2 things:
1. Makes all columns but Desc and Fav manually sizeable (no more autosizing)
2. Stores and retrieves column widths from config.xml in absolute widths instead of percentages.

It actually makes more sense for most columns to remain a fixed size for various window sizes, and let the Desc column fill to take up any extra space. This PR solves multiple issues, from the autosize not working correctly cross-platform, to the tendency for the FAV column to accidentally getting larger and larger with each restart. Once the user has tuned the widths to taste, they never have to touch it again.

I also tweaked the default widths to what I think are sensible values.