### PR TITLE
WPOverlay: change the condition for rally point

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -321,7 +321,7 @@ namespace MissionPlanner.ArduPilot
                     addpolygonmarker((a + 1).ToString(), item.lng, item.lat,
                         null, Color.Orange, 0, MAVLink.MAV_MISSION_TYPE.FENCE);
                 }
-                else if (command >= (ushort)MAVLink.MAV_CMD.RALLY_POINT) // rally
+                else if (command == (ushort)MAVLink.MAV_CMD.RALLY_POINT) // rally
                 {
                     pointlist.Add(new PointLatLngAlt(item.lat, item.lng, 0, (a + 1).ToString()));
                     addpolygonmarker((a + 1).ToString(), item.lng, item.lat,


### PR DESCRIPTION
I noticed to display DO_WINCH command as RALLY point of lat/lon=0,0.
I changed to equals because I feel that the greater is not necessary.
![image](https://github.com/ArduPilot/MissionPlanner/assets/16643069/9b3ac97c-f1e8-4c7e-bdff-4ef147e39497)
