### PR TITLE
FlightPlanner: display rally points menu even if fence is disabled

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -2663,12 +2663,10 @@ namespace MissionPlanner.GCSViews
                 if ((MainV2.comPort.MAV.cs.capabilities & (int) MAVLink.MAV_PROTOCOL_CAPABILITY.MISSION_FENCE) > 0)
                 {
                     geoFenceToolStripMenuItem.Visible = false;
-                    rallyPointsToolStripMenuItem.Visible = false;
                 }
                 else
                 {
                     geoFenceToolStripMenuItem.Visible = true;
-                    rallyPointsToolStripMenuItem.Visible = true;
                 }
             }
 


### PR DESCRIPTION
Rally points menu are not displayed after connecting to the vehicle if FENCE is disabled. 
![image](https://github.com/ArduPilot/MissionPlanner/assets/16643069/fe46a2bf-045d-4b4a-aeae-ae3b0e932c03)

I want to set Rally points anytime.