### PR TITLE
DFLog: Fix messages show as System.byte[]

### DIFF
--- a/ExtLibs/Utilities/DFLog.cs
+++ b/ExtLibs/Utilities/DFLog.cs
@@ -88,7 +88,8 @@ namespace MissionPlanner.Utilities
                             if (a.IsNumber())
                                 return (((IConvertible)a).ToString(CultureInfo.InvariantCulture));
                             else
-                                return a?.ToString();
+                                if (a is System.Byte[]) return (System.Text.Encoding.ASCII.GetString(a as byte[]).Trim('\0'));
+                                else return a?.ToString();
                         }).ToArray();
                     }
                     return _items;


### PR DESCRIPTION
Commit #bb7d061 (BinaryLog: fix raw data extraction aka FILE)  broke messages display, it fixes it and keeps changes in the commit mentioned above.