### PR TITLE
FlightData HUD Update:  Positioning HUD Buttons

### DIFF
--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -2852,7 +2852,7 @@ namespace MissionPlanner.Controls
                     if (displayicons)
                     {
                         var bottomsize = ((fontsize + 2) * 3) + fontoffset - 2;
-                        DrawImage(icon, 3, this.Height - bottomsize, bottomsize / 2, bottomsize);
+                        DrawImage(icon, 2, this.Height - bottomsize, bottomsize / 2, bottomsize);
 
                         text = _batterylevel.ToString("0.00v") + " " + _current.ToString("0.0 A") + " " + (_batteryremaining) + "%";
                         drawstring(text, font, fontsize + 1, textcolor, bottomsize / 2 + 6, yPos[1]);
@@ -3108,8 +3108,16 @@ namespace MissionPlanner.Controls
                     if (displayicons)
                     {
                         var width = (fontsize + 8) * 3;
-                        vibehitzone = new Rectangle(this.Width - (width * 4) + width / 2 - 5, this.Height - (fontsize + 13), (fontsize + 8) * 3, fontsize + 8);
-
+                        //When the width is greater or equal to 325, the vibe button must be placed at half of the HUD's width
+                        if (this.Width >= 325)
+                        {
+                            vibehitzone = new Rectangle((int)(this.Width * 0.5), this.Height - (fontsize + 13), width, fontsize + 8);
+                        }
+                        //When the width is less than 325, the vibe button must be placed just passed half of the HUD's width
+                        else if (this.Width < 325)
+                        {
+                            vibehitzone = new Rectangle((int)(this.Width * 0.535), this.Height - (fontsize + 13), width, fontsize + 8);
+                        }
                     }
                     else
                     {
@@ -3161,10 +3169,15 @@ namespace MissionPlanner.Controls
 
                 if (displayekf)
                 {
+                    //Set the starting Position for the EKF button based off of the VIBE Button
+                    //Variable for the Vibe width
+                    var vibeWidth = vibehitzone.Width;
+                    //Variable for the start position of EKF
+                    var eKFLocationX = vibehitzone.X - vibeWidth - 2;
                     if (displayicons)
                     {
                         var width = (fontsize + 8) * 3;
-                        ekfhitzone = new Rectangle(this.Width - width * 5 + width / 2 - 10 , this.Height - (fontsize + 13), (fontsize + 8) * 3, fontsize + 8);
+                        ekfhitzone = new Rectangle((int)(eKFLocationX), this.Height - (fontsize + 13), width, fontsize + 8);
                     }
                     else
                     {
@@ -3211,10 +3224,12 @@ namespace MissionPlanner.Controls
 
                 if (displayprearm && status == false) // not armed
                 {
+                    //Set the starting Position for the PreArm button - Variable for the start position of PreArm button                    
+                    var readyToArmLocationX = ekfhitzone.X;
                     if (displayicons)
                     {
                         var width = (fontsize + 8) * 3;
-                        prearmhitzone = new Rectangle(this.Width - width * 5 + width / 2 - 7, this.Height - (fontsize*2 + 25), width * 2, fontsize + 8);
+                        prearmhitzone = new Rectangle(readyToArmLocationX, this.Height - (fontsize*2 + 25), width * 2, fontsize + 8);
                     }
                     else
                     {


### PR DESCRIPTION
Update: The three buttons on the HUD, namely: 'VIBE', 'EKF', 'PreArm', placed towards the center bottom section of the HUD have now been centered with the HUD. The VIBE and EKF buttons are now on either side of the center of the HUD with the PreArm button directly in line with the EKF button.
(See screenshots attached for the updated display)
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/6c9278c2-6f41-4e41-a719-469e01bb2a47)
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/0442bba1-b6e7-440d-a35c-36afef02e6ab)
