### PR TITLE
MainV2: Fix console window hide in windows11

### DIFF
--- a/MainV2.cs
+++ b/MainV2.cs
@@ -879,8 +879,8 @@ namespace MissionPlanner
                 }
                 else
                 {
-                    int win = NativeMethods.FindWindow("ConsoleWindowClass", null);
-                    NativeMethods.ShowWindow(win, NativeMethods.SW_HIDE); // hide window
+                    NativeMethods.ShowWindow(NativeMethods.GetConsoleWindow(), NativeMethods.SW_HIDE);
+
                 }
 
                 // prevent system from sleeping while mp open

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -10,13 +10,17 @@ namespace MissionPlanner
         public static extern int FindWindow(string szClass, string szTitle);
 
         [DllImport("user32.dll")]
-        public static extern int ShowWindow(int Handle, int showState);
+        public static extern bool ShowWindow(IntPtr Handle, int showState);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern IntPtr RegisterDeviceNotification
         (IntPtr hRecipient,
             IntPtr NotificationFilter,
             Int32 Flags);
+
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetConsoleWindow();
 
         // Import SetThreadExecutionState Win32 API and necessary flags
 


### PR DESCRIPTION
Latest update in windows 11 breaks current implementation for hiding console window. 
This PR update the NativeMethods for using IntPtr and instead of find window, use GetConsoleWindow()