### PR TITLE
Improve/Fix SBS-1 ADS-B Parsing

### DIFF
--- a/ExtLibs/Utilities/adsb.cs
+++ b/ExtLibs/Utilities/adsb.cs
@@ -823,7 +823,14 @@ namespace MissionPlanner.Utilities
                                 continue;
 
                             if (UpdatePlanePosition != null && plane != null)
-                                UpdatePlanePosition(null, new PointLatLngAltHdg(lat, lon, altitude / 3.048, (float)plane.heading, -1 , hex_ident, DateTime.Now));
+                            {
+                                double METERS_PER_FOOT = 3.28;
+                                PointLatLngAltHdg plln = new PointLatLngAltHdg(lat, lon, altitude / METERS_PER_FOOT, (float)plane.heading, plane.ground_speed, hex_ident, DateTime.Now)
+                                {
+                                    CallSign = plane.CallSign
+                                };
+                                UpdatePlanePosition(null, plln);
+                            }
                         }
                         else if (strArray[1] == "4")
                         {

--- a/ExtLibs/Utilities/adsb.cs
+++ b/ExtLibs/Utilities/adsb.cs
@@ -812,6 +812,13 @@ namespace MissionPlanner.Utilities
                             }
                             catch { }
 
+                            ushort squawk = 0;
+                            try
+                            {
+                                squawk = ushort.Parse(strArray[17]); // Squawk transponder code
+                            }
+                            catch { }
+
                             bool is_on_ground = strArray[21] != "0";//Boolean. Flag to indicate ground squat switch is active. 
 
                             if (Planes[hex_ident] == null)
@@ -827,7 +834,8 @@ namespace MissionPlanner.Utilities
                                 double METERS_PER_FOOT = 3.28;
                                 PointLatLngAltHdg plln = new PointLatLngAltHdg(lat, lon, altitude / METERS_PER_FOOT, (float)plane.heading, plane.ground_speed, hex_ident, DateTime.Now)
                                 {
-                                    CallSign = plane.CallSign
+                                    CallSign = plane.CallSign,
+                                    Squawk = squawk
                                 };
                                 UpdatePlanePosition(null, plln);
                             }


### PR DESCRIPTION
tl;dr: add ground track, speed, callsign, squawk codes, fix math error causing altitude discrepancy.

While writing https://github.com/MUSTARDTIGERFPV/MavADSB I discovered a few quirks about the ADS-B SBS-1 processing in Mission Planner. This PR addresses those quirks.

1. Ground track, speed, callsign, are parsed in SBS-1 message types one and four, but UpdatePlanePosition is called only in type 3. Its ground speed was fixed to -1, and the callsign wasn't set at all. This changes that behavior so all fields get updated as soon as a type 3 is seen using the values stored from the type 1 and type 4 messages.
2. Squawk codes were not interpreted at all - they've been added.
3. Previously, the altitude value sent OTA was divided by a factor which represents the number of meters in 10ft. Given that ADS-B Mode C altitudes are given in feet, and the PointLatLngAltHdg's internal representation is in meters, the correct conversion factor is approximately 3.28, the number of feet in a meter. This change makes Mission Planner's altitudes match those of https://globe.adsb-exchange.com and https://globe.adsb.one. The previous math would look correct for lower altitudes, but would skew more and more the higher a plane got. For example, at 32000 ft, it's a difference between 9753m and 10499m, 746m off.

There's a chance other protocols will need their altitude math looked at also, but I've not taken a look at it just yet.