### PR TITLE
FlightData HUD: Fuel Gauge feature

### DIFF
--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -201,6 +201,7 @@ namespace MissionPlanner.GCSViews
             this.setHomeHereToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.takeOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.onOffCameraOverlapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.jumpToTagToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.but_disablejoystick = new MissionPlanner.Controls.MyButton();
             this.distanceBar1 = new MissionPlanner.Controls.DistanceBar();
             this.windDir1 = new MissionPlanner.Controls.WindDir();
@@ -225,7 +226,7 @@ namespace MissionPlanner.GCSViews
             this.scriptChecker = new System.Windows.Forms.Timer(this.components);
             this.Messagetabtimer = new System.Windows.Forms.Timer(this.components);
             this.bindingSourceStatusTab = new System.Windows.Forms.BindingSource(this.components);
-            this.jumpToTagToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.FuelGaugeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.MainH)).BeginInit();
             this.MainH.Panel1.SuspendLayout();
             this.MainH.Panel2.SuspendLayout();
@@ -323,6 +324,7 @@ namespace MissionPlanner.GCSViews
             this.hud1.batterycellcount = 4;
             this.hud1.batterylevel = 0F;
             this.hud1.batterylevel2 = 0F;
+            this.hud1.batteryon2 = true;
             this.hud1.batteryremaining = 0F;
             this.hud1.batteryremaining2 = 0F;
             this.hud1.bgimage = null;
@@ -333,52 +335,52 @@ namespace MissionPlanner.GCSViews
             this.hud1.critSSA = 30F;
             this.hud1.current = 0F;
             this.hud1.current2 = 0F;
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("airspeed", this.bindingSourceHud, "airspeed", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("alt", this.bindingSourceHud, "alt", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("load", this.bindingSourceHud, "load", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batterylevel", this.bindingSourceHud, "battery_voltage", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batteryremaining", this.bindingSourceHud, "battery_remaining", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("connected", this.bindingSourceHud, "connected", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("current", this.bindingSourceHud, "current", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batterylevel2", this.bindingSourceHud, "battery_voltage2", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batteryremaining2", this.bindingSourceHud, "battery_remaining2", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("current2", this.bindingSourceHud, "current2", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("datetime", this.bindingSourceHud, "datetime", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("disttowp", this.bindingSourceHud, "wp_dist", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("ekfstatus", this.bindingSourceHud, "ekfstatus", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("failsafe", this.bindingSourceHud, "failsafe", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpsfix", this.bindingSourceHud, "gpsstatus", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpsfix2", this.bindingSourceHud, "gpsstatus2", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpshdop", this.bindingSourceHud, "gpshdop", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpshdop2", this.bindingSourceHud, "gpshdop2", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("groundalt", this.bindingSourceHud, "HomeAlt", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("groundcourse", this.bindingSourceHud, "groundcourse", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("groundspeed", this.bindingSourceHud, "groundspeed", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("heading", this.bindingSourceHud, "yaw", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("linkqualitygcs", this.bindingSourceHud, "linkqualitygcs", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("message", this.bindingSourceHud, "messageHigh", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("messageSeverity", this.bindingSourceHud, "messageHighSeverity", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("mode", this.bindingSourceHud, "mode", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("navpitch", this.bindingSourceHud, "nav_pitch", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("navroll", this.bindingSourceHud, "nav_roll", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("pitch", this.bindingSourceHud, "pitch", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("prearmstatus", this.bindingSourceHud, "prearmstatus", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("roll", this.bindingSourceHud, "roll", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("safetyactive", this.bindingSourceHud, "safetyactive", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("status", this.bindingSourceHud, "armed", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("targetalt", this.bindingSourceHud, "targetalt", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("targetheading", this.bindingSourceHud, "nav_bearing", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("targetspeed", this.bindingSourceHud, "targetairspeed", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("turnrate", this.bindingSourceHud, "turnrate", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("verticalspeed", this.bindingSourceHud, "verticalspeed", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibex", this.bindingSourceHud, "vibex", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibey", this.bindingSourceHud, "vibey", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibez", this.bindingSourceHud, "vibez", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("wpno", this.bindingSourceHud, "wpno", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("xtrack_error", this.bindingSourceHud, "xtrack_error", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("AOA", this.bindingSourceHud, "AOA", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("SSA", this.bindingSourceHud, "SSA", false));
-            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("critAOA", this.bindingSourceHud, "crit_AOA", false));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("airspeed", this.bindingSourceHud, "airspeed", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("alt", this.bindingSourceHud, "alt", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("load", this.bindingSourceHud, "load", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batterylevel", this.bindingSourceHud, "battery_voltage", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batteryremaining", this.bindingSourceHud, "battery_remaining", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("connected", this.bindingSourceHud, "connected", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("current", this.bindingSourceHud, "current", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batterylevel2", this.bindingSourceHud, "battery_voltage2", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("batteryremaining2", this.bindingSourceHud, "battery_remaining2", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("current2", this.bindingSourceHud, "current2", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("datetime", this.bindingSourceHud, "datetime", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("disttowp", this.bindingSourceHud, "wp_dist", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("ekfstatus", this.bindingSourceHud, "ekfstatus", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("failsafe", this.bindingSourceHud, "failsafe", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpsfix", this.bindingSourceHud, "gpsstatus", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpsfix2", this.bindingSourceHud, "gpsstatus2", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpshdop", this.bindingSourceHud, "gpshdop", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("gpshdop2", this.bindingSourceHud, "gpshdop2", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("groundalt", this.bindingSourceHud, "HomeAlt", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("groundcourse", this.bindingSourceHud, "groundcourse", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("groundspeed", this.bindingSourceHud, "groundspeed", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("heading", this.bindingSourceHud, "yaw", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("linkqualitygcs", this.bindingSourceHud, "linkqualitygcs", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("message", this.bindingSourceHud, "messageHigh", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("messageSeverity", this.bindingSourceHud, "messageHighSeverity", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("mode", this.bindingSourceHud, "mode", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("navpitch", this.bindingSourceHud, "nav_pitch", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("navroll", this.bindingSourceHud, "nav_roll", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("pitch", this.bindingSourceHud, "pitch", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("prearmstatus", this.bindingSourceHud, "prearmstatus", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("roll", this.bindingSourceHud, "roll", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("safetyactive", this.bindingSourceHud, "safetyactive", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("status", this.bindingSourceHud, "armed", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("targetalt", this.bindingSourceHud, "targetalt", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("targetheading", this.bindingSourceHud, "nav_bearing", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("targetspeed", this.bindingSourceHud, "targetairspeed", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("turnrate", this.bindingSourceHud, "turnrate", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("verticalspeed", this.bindingSourceHud, "verticalspeed", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibex", this.bindingSourceHud, "vibex", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibey", this.bindingSourceHud, "vibey", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("vibez", this.bindingSourceHud, "vibez", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("wpno", this.bindingSourceHud, "wpno", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("xtrack_error", this.bindingSourceHud, "xtrack_error", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("AOA", this.bindingSourceHud, "AOA", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("SSA", this.bindingSourceHud, "SSA", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("critAOA", this.bindingSourceHud, "crit_AOA", true));
             this.hud1.datetime = new System.DateTime(((long)(0)));
             this.hud1.displayAOASSA = false;
             this.hud1.displayCellVoltage = false;
@@ -398,6 +400,7 @@ namespace MissionPlanner.GCSViews
             this.hud1.heading = 0F;
             this.hud1.hudcolor = System.Drawing.Color.LightGray;
             this.hud1.linkqualitygcs = 0F;
+            this.hud1.load = 0F;
             this.hud1.lowairspeed = false;
             this.hud1.lowgroundspeed = false;
             this.hud1.lowvoltagealert = false;
@@ -411,6 +414,7 @@ namespace MissionPlanner.GCSViews
             this.hud1.prearmstatus = false;
             this.hud1.roll = 0F;
             this.hud1.Russian = false;
+            this.hud1.safetyactive = false;
             this.hud1.skyColor1 = System.Drawing.Color.Blue;
             this.hud1.skyColor2 = System.Drawing.Color.LightBlue;
             this.hud1.speedunit = null;
@@ -436,6 +440,7 @@ namespace MissionPlanner.GCSViews
             // 
             // contextMenuStripHud
             // 
+            this.contextMenuStripHud.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStripHud.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.videoToolStripMenuItem,
             this.setAspectRatioToolStripMenuItem,
@@ -444,7 +449,8 @@ namespace MissionPlanner.GCSViews
             this.swapWithMapToolStripMenuItem,
             this.groundColorToolStripMenuItem,
             this.setBatteryCellCountToolStripMenuItem,
-            this.showIconsToolStripMenuItem});
+            this.showIconsToolStripMenuItem,
+            this.FuelGaugeToolStripMenuItem});
             this.contextMenuStripHud.Name = "contextMenuStrip2";
             resources.ApplyResources(this.contextMenuStripHud, "contextMenuStripHud");
             // 
@@ -575,6 +581,7 @@ namespace MissionPlanner.GCSViews
             // 
             // contextMenuStripactionstab
             // 
+            this.contextMenuStripactionstab.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStripactionstab.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.customizeToolStripMenuItem,
             this.multiLineToolStripMenuItem});
@@ -627,6 +634,7 @@ namespace MissionPlanner.GCSViews
             // 
             // contextMenuStripQuickView
             // 
+            this.contextMenuStripQuickView.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStripQuickView.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.setViewCountToolStripMenuItem,
             this.undockToolStripMenuItem});
@@ -757,6 +765,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_SendMSG.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_SendMSG, "BUT_SendMSG");
             this.BUT_SendMSG.Name = "BUT_SendMSG";
+            this.BUT_SendMSG.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_SendMSG, resources.GetString("BUT_SendMSG.ToolTip"));
             this.BUT_SendMSG.UseVisualStyleBackColor = true;
             this.BUT_SendMSG.Click += new System.EventHandler(this.BUT_SendMSG_Click);
@@ -768,6 +777,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_abortland.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_abortland, "BUT_abortland");
             this.BUT_abortland.Name = "BUT_abortland";
+            this.BUT_abortland.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_abortland, resources.GetString("BUT_abortland.ToolTip"));
             this.BUT_abortland.UseVisualStyleBackColor = true;
             this.BUT_abortland.Click += new System.EventHandler(this.BUT_abortland_Click);
@@ -807,6 +817,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_clear_track.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_clear_track, "BUT_clear_track");
             this.BUT_clear_track.Name = "BUT_clear_track";
+            this.BUT_clear_track.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_clear_track, resources.GetString("BUT_clear_track.ToolTip"));
             this.BUT_clear_track.UseVisualStyleBackColor = true;
             this.BUT_clear_track.Click += new System.EventHandler(this.BUT_clear_track_Click);
@@ -826,6 +837,7 @@ namespace MissionPlanner.GCSViews
             this.BUTactiondo.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUTactiondo, "BUTactiondo");
             this.BUTactiondo.Name = "BUTactiondo";
+            this.BUTactiondo.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUTactiondo, resources.GetString("BUTactiondo.ToolTip"));
             this.BUTactiondo.UseVisualStyleBackColor = true;
             this.BUTactiondo.Click += new System.EventHandler(this.BUTactiondo_Click);
@@ -837,6 +849,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_resumemis.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_resumemis, "BUT_resumemis");
             this.BUT_resumemis.Name = "BUT_resumemis";
+            this.BUT_resumemis.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_resumemis.UseVisualStyleBackColor = true;
             this.BUT_resumemis.Click += new System.EventHandler(this.BUT_resumemis_Click);
             // 
@@ -915,6 +928,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_ARM.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_ARM, "BUT_ARM");
             this.BUT_ARM.Name = "BUT_ARM";
+            this.BUT_ARM.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_ARM, resources.GetString("BUT_ARM.ToolTip"));
             this.BUT_ARM.UseVisualStyleBackColor = true;
             this.BUT_ARM.Click += new System.EventHandler(this.BUT_ARM_Click);
@@ -926,6 +940,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_mountmode.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_mountmode, "BUT_mountmode");
             this.BUT_mountmode.Name = "BUT_mountmode";
+            this.BUT_mountmode.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_mountmode, resources.GetString("BUT_mountmode.ToolTip"));
             this.BUT_mountmode.UseVisualStyleBackColor = true;
             this.BUT_mountmode.Click += new System.EventHandler(this.BUT_mountmode_Click);
@@ -937,6 +952,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_joystick.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_joystick, "BUT_joystick");
             this.BUT_joystick.Name = "BUT_joystick";
+            this.BUT_joystick.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_joystick, resources.GetString("BUT_joystick.ToolTip"));
             this.BUT_joystick.UseVisualStyleBackColor = true;
             this.BUT_joystick.Click += new System.EventHandler(this.BUT_joystick_Click);
@@ -948,6 +964,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_RAWSensor.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_RAWSensor, "BUT_RAWSensor");
             this.BUT_RAWSensor.Name = "BUT_RAWSensor";
+            this.BUT_RAWSensor.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_RAWSensor, resources.GetString("BUT_RAWSensor.ToolTip"));
             this.BUT_RAWSensor.UseVisualStyleBackColor = true;
             this.BUT_RAWSensor.Click += new System.EventHandler(this.BUT_RAWSensor_Click);
@@ -959,6 +976,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_Homealt.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_Homealt, "BUT_Homealt");
             this.BUT_Homealt.Name = "BUT_Homealt";
+            this.BUT_Homealt.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_Homealt, resources.GetString("BUT_Homealt.ToolTip"));
             this.BUT_Homealt.UseVisualStyleBackColor = true;
             this.BUT_Homealt.Click += new System.EventHandler(this.BUT_Homealt_Click);
@@ -970,6 +988,7 @@ namespace MissionPlanner.GCSViews
             this.BUTrestartmission.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUTrestartmission, "BUTrestartmission");
             this.BUTrestartmission.Name = "BUTrestartmission";
+            this.BUTrestartmission.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUTrestartmission, resources.GetString("BUTrestartmission.ToolTip"));
             this.BUTrestartmission.UseVisualStyleBackColor = true;
             this.BUTrestartmission.Click += new System.EventHandler(this.BUTrestartmission_Click);
@@ -989,6 +1008,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_quickrtl.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_quickrtl, "BUT_quickrtl");
             this.BUT_quickrtl.Name = "BUT_quickrtl";
+            this.BUT_quickrtl.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_quickrtl, resources.GetString("BUT_quickrtl.ToolTip"));
             this.BUT_quickrtl.UseVisualStyleBackColor = true;
             this.BUT_quickrtl.Click += new System.EventHandler(this.BUT_quickrtl_Click);
@@ -1000,6 +1020,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_quickmanual.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_quickmanual, "BUT_quickmanual");
             this.BUT_quickmanual.Name = "BUT_quickmanual";
+            this.BUT_quickmanual.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_quickmanual, resources.GetString("BUT_quickmanual.ToolTip"));
             this.BUT_quickmanual.UseVisualStyleBackColor = true;
             this.BUT_quickmanual.Click += new System.EventHandler(this.BUT_quickmanual_Click);
@@ -1011,6 +1032,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_setwp.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_setwp, "BUT_setwp");
             this.BUT_setwp.Name = "BUT_setwp";
+            this.BUT_setwp.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_setwp, resources.GetString("BUT_setwp.ToolTip"));
             this.BUT_setwp.UseVisualStyleBackColor = true;
             this.BUT_setwp.Click += new System.EventHandler(this.BUT_setwp_Click);
@@ -1031,6 +1053,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_quickauto.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_quickauto, "BUT_quickauto");
             this.BUT_quickauto.Name = "BUT_quickauto";
+            this.BUT_quickauto.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_quickauto, resources.GetString("BUT_quickauto.ToolTip"));
             this.BUT_quickauto.UseVisualStyleBackColor = true;
             this.BUT_quickauto.Click += new System.EventHandler(this.BUT_quickauto_Click);
@@ -1042,6 +1065,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_setmode.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_setmode, "BUT_setmode");
             this.BUT_setmode.Name = "BUT_setmode";
+            this.BUT_setmode.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_setmode, resources.GetString("BUT_setmode.ToolTip"));
             this.BUT_setmode.UseVisualStyleBackColor = true;
             this.BUT_setmode.Click += new System.EventHandler(this.BUT_setmode_Click);
@@ -1074,6 +1098,7 @@ namespace MissionPlanner.GCSViews
             this.myButton1.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.myButton1, "myButton1");
             this.myButton1.Name = "myButton1";
+            this.myButton1.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.myButton1, resources.GetString("myButton1.ToolTip"));
             this.myButton1.UseVisualStyleBackColor = true;
             this.myButton1.Click += new System.EventHandler(this.BUT_quickmanual_Click);
@@ -1085,6 +1110,7 @@ namespace MissionPlanner.GCSViews
             this.myButton2.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.myButton2, "myButton2");
             this.myButton2.Name = "myButton2";
+            this.myButton2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.myButton2, resources.GetString("myButton2.ToolTip"));
             this.myButton2.UseVisualStyleBackColor = true;
             this.myButton2.Click += new System.EventHandler(this.BUT_quickrtl_Click);
@@ -1096,6 +1122,7 @@ namespace MissionPlanner.GCSViews
             this.myButton3.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.myButton3, "myButton3");
             this.myButton3.Name = "myButton3";
+            this.myButton3.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.myButton3, resources.GetString("myButton3.ToolTip"));
             this.myButton3.UseVisualStyleBackColor = true;
             this.myButton3.Click += new System.EventHandler(this.BUT_quickauto_Click);
@@ -1931,6 +1958,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_edit_selected.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_edit_selected, "BUT_edit_selected");
             this.BUT_edit_selected.Name = "BUT_edit_selected";
+            this.BUT_edit_selected.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_edit_selected.UseVisualStyleBackColor = true;
             this.BUT_edit_selected.Click += new System.EventHandler(this.BUT_edit_selected_Click);
             // 
@@ -1946,6 +1974,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_run_script.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_run_script, "BUT_run_script");
             this.BUT_run_script.Name = "BUT_run_script";
+            this.BUT_run_script.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_run_script.UseVisualStyleBackColor = true;
             this.BUT_run_script.Click += new System.EventHandler(this.BUT_run_script_Click);
             // 
@@ -1956,6 +1985,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_abort_script.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_abort_script, "BUT_abort_script");
             this.BUT_abort_script.Name = "BUT_abort_script";
+            this.BUT_abort_script.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_abort_script.UseVisualStyleBackColor = true;
             this.BUT_abort_script.Click += new System.EventHandler(this.BUT_abort_script_Click);
             // 
@@ -1971,6 +2001,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_select_script.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_select_script, "BUT_select_script");
             this.BUT_select_script.Name = "BUT_select_script";
+            this.BUT_select_script.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_select_script.UseVisualStyleBackColor = true;
             this.BUT_select_script.Click += new System.EventHandler(this.BUT_select_script_Click);
             // 
@@ -1989,6 +2020,7 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_PayloadFolder, "BUT_PayloadFolder");
             this.BUT_PayloadFolder.Name = "BUT_PayloadFolder";
+            this.BUT_PayloadFolder.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_PayloadFolder.UseVisualStyleBackColor = true;
             // 
             // groupBoxRoll
@@ -2047,6 +2079,7 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_resetGimbalPos, "BUT_resetGimbalPos");
             this.BUT_resetGimbalPos.Name = "BUT_resetGimbalPos";
+            this.BUT_resetGimbalPos.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_resetGimbalPos.UseVisualStyleBackColor = true;
             this.BUT_resetGimbalPos.Click += new System.EventHandler(this.BUT_resetGimbalPos_Click);
             // 
@@ -2121,6 +2154,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed10, "BUT_speed10");
             this.BUT_speed10.Name = "BUT_speed10";
             this.BUT_speed10.Tag = "10";
+            this.BUT_speed10.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed10.UseVisualStyleBackColor = true;
             this.BUT_speed10.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2132,6 +2166,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed5, "BUT_speed5");
             this.BUT_speed5.Name = "BUT_speed5";
             this.BUT_speed5.Tag = "5";
+            this.BUT_speed5.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed5.UseVisualStyleBackColor = true;
             this.BUT_speed5.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2143,6 +2178,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed2, "BUT_speed2");
             this.BUT_speed2.Name = "BUT_speed2";
             this.BUT_speed2.Tag = "2";
+            this.BUT_speed2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed2.UseVisualStyleBackColor = true;
             this.BUT_speed2.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2154,6 +2190,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1, "BUT_speed1");
             this.BUT_speed1.Name = "BUT_speed1";
             this.BUT_speed1.Tag = "1";
+            this.BUT_speed1.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1.UseVisualStyleBackColor = true;
             this.BUT_speed1.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2165,6 +2202,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1_2, "BUT_speed1_2");
             this.BUT_speed1_2.Name = "BUT_speed1_2";
             this.BUT_speed1_2.Tag = "0.5";
+            this.BUT_speed1_2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1_2.UseVisualStyleBackColor = true;
             this.BUT_speed1_2.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2176,6 +2214,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1_4, "BUT_speed1_4");
             this.BUT_speed1_4.Name = "BUT_speed1_4";
             this.BUT_speed1_4.Tag = "0.25";
+            this.BUT_speed1_4.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1_4.UseVisualStyleBackColor = true;
             this.BUT_speed1_4.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2187,6 +2226,7 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1_10, "BUT_speed1_10");
             this.BUT_speed1_10.Name = "BUT_speed1_10";
             this.BUT_speed1_10.Tag = "0.1";
+            this.BUT_speed1_10.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1_10.UseVisualStyleBackColor = true;
             this.BUT_speed1_10.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2197,6 +2237,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_loadtelem.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_loadtelem, "BUT_loadtelem");
             this.BUT_loadtelem.Name = "BUT_loadtelem";
+            this.BUT_loadtelem.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_loadtelem.UseVisualStyleBackColor = true;
             this.BUT_loadtelem.Click += new System.EventHandler(this.BUT_loadtelem_Click);
             // 
@@ -2223,6 +2264,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_log2kml.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_log2kml, "BUT_log2kml");
             this.BUT_log2kml.Name = "BUT_log2kml";
+            this.BUT_log2kml.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_log2kml.UseVisualStyleBackColor = true;
             this.BUT_log2kml.Click += new System.EventHandler(this.BUT_log2kml_Click);
             // 
@@ -2233,6 +2275,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_playlog.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_playlog, "BUT_playlog");
             this.BUT_playlog.Name = "BUT_playlog";
+            this.BUT_playlog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_playlog.UseVisualStyleBackColor = true;
             this.BUT_playlog.Click += new System.EventHandler(this.BUT_playlog_Click);
             // 
@@ -2270,6 +2313,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_DFMavlink.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_DFMavlink, "BUT_DFMavlink");
             this.BUT_DFMavlink.Name = "BUT_DFMavlink";
+            this.BUT_DFMavlink.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_DFMavlink.UseVisualStyleBackColor = true;
             this.BUT_DFMavlink.Click += new System.EventHandler(this.BUT_DFMavlink_Click);
             // 
@@ -2277,6 +2321,7 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_georefimage, "BUT_georefimage");
             this.BUT_georefimage.Name = "BUT_georefimage";
+            this.BUT_georefimage.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_georefimage.Click += new System.EventHandler(this.BUT_georefimage_Click);
             // 
             // BUT_logbrowse
@@ -2286,6 +2331,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_logbrowse.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_logbrowse, "BUT_logbrowse");
             this.BUT_logbrowse.Name = "BUT_logbrowse";
+            this.BUT_logbrowse.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_logbrowse.UseVisualStyleBackColor = true;
             this.BUT_logbrowse.Click += new System.EventHandler(this.BUT_logbrowse_Click);
             // 
@@ -2296,6 +2342,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_matlab.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_matlab, "BUT_matlab");
             this.BUT_matlab.Name = "BUT_matlab";
+            this.BUT_matlab.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_matlab.UseVisualStyleBackColor = true;
             this.BUT_matlab.Click += new System.EventHandler(this.BUT_matlab_Click);
             // 
@@ -2306,6 +2353,7 @@ namespace MissionPlanner.GCSViews
             this.but_bintolog.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.but_bintolog, "but_bintolog");
             this.but_bintolog.Name = "but_bintolog";
+            this.but_bintolog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_bintolog.UseVisualStyleBackColor = true;
             this.but_bintolog.Click += new System.EventHandler(this.but_bintolog_Click);
             // 
@@ -2316,6 +2364,7 @@ namespace MissionPlanner.GCSViews
             this.but_dflogtokml.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.but_dflogtokml, "but_dflogtokml");
             this.but_dflogtokml.Name = "but_dflogtokml";
+            this.but_dflogtokml.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_dflogtokml.UseVisualStyleBackColor = true;
             this.but_dflogtokml.Click += new System.EventHandler(this.but_dflogtokml_Click);
             // 
@@ -2326,6 +2375,7 @@ namespace MissionPlanner.GCSViews
             this.BUT_loganalysis.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_loganalysis, "BUT_loganalysis");
             this.BUT_loganalysis.Name = "BUT_loganalysis";
+            this.BUT_loganalysis.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_loganalysis.UseVisualStyleBackColor = true;
             this.BUT_loganalysis.Click += new System.EventHandler(this.BUT_loganalysis_Click);
             // 
@@ -2380,6 +2430,7 @@ namespace MissionPlanner.GCSViews
             // 
             // contextMenuStripMap
             // 
+            this.contextMenuStripMap.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStripMap.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.goHereToolStripMenuItem,
             this.flyToHereAltToolStripMenuItem,
@@ -2506,6 +2557,12 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.onOffCameraOverlapToolStripMenuItem, "onOffCameraOverlapToolStripMenuItem");
             this.onOffCameraOverlapToolStripMenuItem.Click += new System.EventHandler(this.onOffCameraOverlapToolStripMenuItem_Click);
             // 
+            // jumpToTagToolStripMenuItem
+            // 
+            this.jumpToTagToolStripMenuItem.Name = "jumpToTagToolStripMenuItem";
+            resources.ApplyResources(this.jumpToTagToolStripMenuItem, "jumpToTagToolStripMenuItem");
+            this.jumpToTagToolStripMenuItem.Click += new System.EventHandler(this.jumpToTagToolStripMenuItem_Click);
+            // 
             // but_disablejoystick
             // 
             this.but_disablejoystick.ColorMouseDown = System.Drawing.Color.Empty;
@@ -2513,6 +2570,7 @@ namespace MissionPlanner.GCSViews
             this.but_disablejoystick.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.but_disablejoystick, "but_disablejoystick");
             this.but_disablejoystick.Name = "but_disablejoystick";
+            this.but_disablejoystick.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_disablejoystick.UseVisualStyleBackColor = true;
             this.but_disablejoystick.Click += new System.EventHandler(this.but_disablejoystick_Click);
             // 
@@ -2527,9 +2585,9 @@ namespace MissionPlanner.GCSViews
             // windDir1
             // 
             this.windDir1.BackColor = System.Drawing.Color.Transparent;
-            this.windDir1.DataBindings.Add(new System.Windows.Forms.Binding("Direction", this.bindingSource1, "wind_dir", false, System.Windows.Forms.DataSourceUpdateMode.Never));
-            this.windDir1.DataBindings.Add(new System.Windows.Forms.Binding("Speed", this.bindingSource1, "wind_vel", false, System.Windows.Forms.DataSourceUpdateMode.Never));
-            this.windDir1.Direction = 180D;
+            this.windDir1.DataBindings.Add(new System.Windows.Forms.Binding("Direction", this.bindingSource1, "wind_dir", true, System.Windows.Forms.DataSourceUpdateMode.Never));
+            this.windDir1.DataBindings.Add(new System.Windows.Forms.Binding("Speed", this.bindingSource1, "wind_vel", true, System.Windows.Forms.DataSourceUpdateMode.Never));
+            this.windDir1.Direction = 360D;
             resources.ApplyResources(this.windDir1, "windDir1");
             this.windDir1.Name = "windDir1";
             this.windDir1.Speed = 0D;
@@ -2643,9 +2701,9 @@ namespace MissionPlanner.GCSViews
             this.coords1.Alt = 0D;
             this.coords1.AltSource = "";
             this.coords1.AltUnit = "m";
-            this.coords1.DataBindings.Add(new System.Windows.Forms.Binding("Alt", this.bindingSource1, "alt", false));
-            this.coords1.DataBindings.Add(new System.Windows.Forms.Binding("Lat", this.bindingSource1, "lat", false));
-            this.coords1.DataBindings.Add(new System.Windows.Forms.Binding("Lng", this.bindingSource1, "lng", false));
+            this.coords1.DataBindings.Add(new System.Windows.Forms.Binding("Alt", this.bindingSource1, "alt", true));
+            this.coords1.DataBindings.Add(new System.Windows.Forms.Binding("Lat", this.bindingSource1, "lat", true));
+            this.coords1.DataBindings.Add(new System.Windows.Forms.Binding("Lng", this.bindingSource1, "lng", true));
             this.coords1.Lat = 0D;
             this.coords1.Lng = 0D;
             resources.ApplyResources(this.coords1, "coords1");
@@ -2730,11 +2788,10 @@ namespace MissionPlanner.GCSViews
             // 
             this.bindingSourceStatusTab.DataSource = typeof(MissionPlanner.CurrentState);
             // 
-            // jumpToTagToolStripMenuItem
+            // FuelGaugeToolStripMenuItem
             // 
-            this.jumpToTagToolStripMenuItem.Name = "jumpToTagToolStripMenuItem";
-            resources.ApplyResources(this.jumpToTagToolStripMenuItem, "jumpToTagToolStripMenuItem");
-            this.jumpToTagToolStripMenuItem.Click += new System.EventHandler(this.jumpToTagToolStripMenuItem_Click);
+            this.FuelGaugeToolStripMenuItem.Name = "FuelGaugeToolStripMenuItem";
+            resources.ApplyResources(this.FuelGaugeToolStripMenuItem, "FuelGaugeToolStripMenuItem");
             // 
             // FlightData
             // 
@@ -3036,5 +3093,6 @@ namespace MissionPlanner.GCSViews
         private Controls.AuxOptions auxOptions6;
         private Controls.AuxOptions auxOptions7;
         private ToolStripMenuItem jumpToTagToolStripMenuItem;
+        private ToolStripMenuItem FuelGaugeToolStripMenuItem;
     }
 }

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -54,6 +54,41 @@ namespace MissionPlanner.GCSViews
 
         internal PointLatLng MouseDownStart;
 
+        //Fuel Gauge
+        //Input field for amount of fuel added into fuel tank
+        NumericUpDown FuelInTank = new NumericUpDown { Visible = false };
+        //Button to add/hide the fuel gauge to the screen
+        MyButton FuelGaugeButton = new MyButton { Visible = false };
+        //Input field for setting the size of the fuel tank
+        NumericUpDown FuelTankSize = new NumericUpDown { Visible = false };
+        //Button to set the fuel tank size
+        MyButton FuelTankSizeButton = new MyButton { Visible = false };
+        //Vertical progress bar used for the fuel gauge
+        VerticalProgressBar2 FuelGaugeBar = new VerticalProgressBar2 { Visible = false, Enabled = false, BackgroundColor = Color.DarkSlateGray, Text = string.Empty, ValueColor = Color.DarkSlateGray };
+        //Tooltip for Fuel Gauge
+        ToolTip FuelGaugeToolTip = new ToolTip();
+        //Initialize timers
+        //Fuel Gauge Timer
+        System.Windows.Forms.Timer FuelGaugeTimer = new System.Windows.Forms.Timer();
+        //Fuel Gauge MessageBox Timer
+        System.Windows.Forms.Timer FuelGaugeMessageBoxTimer = new System.Windows.Forms.Timer();
+        //Arm/disarm status timer
+        System.Windows.Forms.Timer ArmStatusTimer = new System.Windows.Forms.Timer();
+        //Variables for displaying Message boxes for zero and 15 percent fuel remaining in tank 
+        int ZeroPercentFuelCount = 0;
+        int FifteenPercentFuelCount = 0;
+        //Variable for displaying and hiding the fuel gauge controls
+        int displayFuelGaugeControls = 0;
+        //Variable for 10 percnt of fuel in tank - used with the colours of the fuel gauge
+        int TenPercentFuelTankSize = 0;
+        //Variable for the remaining fuel in vehicle
+        decimal MillilitresOfFuelRemaining = 0;
+        //Variable count for displaying/hiding the fuel bar only
+        int displayFuelBar = 0;
+
+        //Dropout HUD Form
+        Form dropoutHUDForm = new Form();
+
         //The file path of the selected script
         internal string selectedscript = "";
 
@@ -2499,38 +2534,50 @@ namespace MissionPlanner.GCSViews
 
         void dropout_FormClosed(object sender, FormClosedEventArgs e)
         {
-            (sender as Form).SaveStartupLocation();
+            dropoutHUDForm.SaveStartupLocation();
             //GetFormFromGuid(GetOrCreateGuid("fd_hud_guid")).Controls.Add(hud1);
-            ((sender as Form).Tag as Control).Controls.Add(hud1);
+            (dropoutHUDForm.Tag as Control).Controls.Add(hud1);
             //SubMainLeft.Panel1.Controls.Add(hud1);
             if (hud1.Parent == SubMainLeft.Panel1)
                 SubMainLeft.Panel1Collapsed = false;
             huddropout = false;
+            //Add the fuel Gauge back to the correct spot on the HUD once the dropout form has closed
+            ShowFuelGauge();
         }
 
         void dropout_Resize(object sender, EventArgs e)
         {
+            //Variables for the width and the height of the form
+            int height = 0;
+            int width = 0;
+            //Variable for the sender object as a form
+            var form = (sender as Form);
             if (huddropoutresize)
                 return;
 
             huddropoutresize = true;
 
             int hudh = hud1.Height;
-            int formh = ((Form) sender).Height - 30;
+            int formh = (form).Height - 30;
 
-            if (((Form) sender).Height < hudh)
+            if (form.Height < hudh)
             {
-                if (((Form) sender).WindowState == FormWindowState.Maximized)
+                if (form.WindowState == FormWindowState.Maximized)
                 {
-                    Point tl = ((Form) sender).DesktopLocation;
-                    ((Form) sender).WindowState = FormWindowState.Normal;
-                    ((Form) sender).Location = tl;
+                    Point tl = (form).DesktopLocation;
+                    form.WindowState = FormWindowState.Normal;
+                    form.Location = tl;
                 }
-
-                ((Form) sender).Width = (int) (formh * (hud1.SixteenXNine ? 1.777f : 1.333f));
-                ((Form) sender).Height = formh + 20;
             }
-
+            //Set the width and height variables to be the same as the form's width and height
+            width = form.Width = (int)(formh * (hud1.SixteenXNine ? 1.777f : 1.333f));
+            height = form.Height = formh + 20;
+            //If the hud dropout is displaying, change the dimensions of the fuel gauge
+            if (huddropout)
+            {
+                //Resize the fuel gauge bar on the hud dropout correctly
+                FuelGaugeHUDDropoutDimensions(width, height);
+            }
             hud1.Refresh();
             huddropoutresize = false;
         }
@@ -2609,7 +2656,8 @@ namespace MissionPlanner.GCSViews
             groundColorToolStripMenuItem_Click(null, null);
 
             hud1.doResize();
-
+            //Tool strip menu item click event handler for Fuel Gauge
+            FuelGaugeToolStripMenuItem.Click += new EventHandler(FuelGaugeContextMenuStripItem_Click);
             prop = new Propagation(gMapControl1);
 
             splitContainer1.Panel1Collapsed = true;
@@ -3117,19 +3165,89 @@ namespace MissionPlanner.GCSViews
 
             if(hud1.Parent == SubMainLeft.Panel1)
                 SubMainLeft.Panel1Collapsed = true;
-            Form dropout = new Form();
+            Form dropout = new Form();            
             dropout.Text = "HUD Dropout";
             dropout.Size = new Size(hud1.Width, hud1.Height + 20);
             dropout.Tag = hud1.Parent;
             SubMainLeft.Panel1.Controls.Remove(hud1);
             dropout.Controls.Add(hud1);
+            //Assign the Form to the dropoutHUDForm
+            dropoutHUDForm = dropout;
             dropout.Resize += dropout_Resize;
+            //Added - load event handler for the dropoutHUD form
+            dropout.Load += new EventHandler(HUD1Dropout_Load); 
+            //Set the Tool Tip for the fuel gauge bar.
+            FuelGaugeToolTip.SetToolTip(FuelGaugeBar, $"Fuel remaining: {MillilitresOfFuelRemaining} ml");
             dropout.FormClosed += dropout_FormClosed;
             dropout.RestoreStartupLocation();
             dropout.Show();
-            huddropout = true;
+            huddropout = true;            
         }
 
+        private void HUD1Dropout_Load(object sender, EventArgs e)
+        {
+            //Variable for the form from the sender object
+            var form = sender as Form;
+            //If the fuel gauge bar is visible from the original HUD
+            if (displayFuelBar % 2 != 0)
+            {
+                //Set the width and height variables to be the same as the form's width and height
+                int width = form.Width;
+                int height = form.Height;
+                //Set the dimensions for the Fuel Gauge
+                FuelGaugeHUDDropoutDimensions(width, height);
+            }
+        }
+        private void FuelGaugeHUDDropoutDimensions(int width, int height)
+        {
+            //Try block for the fuel gauge on the HUD dropout form
+            try
+            {
+                //Make the fuel gauge visible every second button click on the "FuelGaugeButton" button
+                //if the displayFuelBar variable is divisible by 2, then the fuel gauge bar will not show on the HUD dropout 
+                if (displayFuelBar % 2 == 0)
+                {
+                    FuelGaugeBar.Visible = false;
+                }
+                //if the displayFuelBar int variable value is divisible by 2 or the fuelgauge bar is already visible, then the fuel gauge bar will not show on the HUD dropout 
+                else if (this.FuelGaugeBar.Visible == true || displayFuelBar % 2 != 0)
+                {
+                    FuelGaugeBar.Visible = false;
+                    //If statement to make the Fuel Gauge Bar display in the correct area of the dropout hud according to the width of the dropout hud
+                    if (width >= 610)
+                    {
+                        //Location of the Fuel Gauge
+                        FuelGaugeBar.Location = new Point((int)((0.81) * width), (int)(0.235 * height));
+                        //Size of the Fuel Gauge
+                        FuelGaugeBar.Size = new Size((int)((0.04) * width), (int)(0.2 * height));
+                    }
+                    else if (width < 610 && width >= 350)
+                    {
+                        //Location of the Fuel Gauge
+                        FuelGaugeBar.Location = new Point((int)((0.8) * width), (int)(0.22 * height));
+                        //Size of the Fuel Gauge
+                        FuelGaugeBar.Size = new Size((int)((0.04) * width), (int)(0.2 * height));
+                    }
+                    else if (width < 350)
+                    {
+                        //Location of the Fuel Gauge
+                        this.FuelGaugeBar.Location = new Point((int)((0.78) * width), (int)(0.23 * height));
+                        //Size of the Fuel Gauge
+                        this.FuelGaugeBar.Size = new Size((int)((0.035) * width), (int)(0.2 * height));
+                    }
+                    //Display the fuel gauge bar
+                    this.FuelGaugeBar.Show();
+                    this.FuelGaugeBar.BringToFront();
+                    this.FuelGaugeBar.Update();
+                    this.FuelGaugeBar.Invalidate();
+                    this.FuelGaugeBar.Visible = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show(ex.Message);
+            }
+        }
         private void hud1_ekfclick(object sender, EventArgs e)
         {
             EKFStatus frm = new EKFStatus();
@@ -5803,7 +5921,622 @@ namespace MissionPlanner.GCSViews
                 CustomMessageBox.Show(Strings.InvalidField, Strings.ERROR);
             }
         }
+        private void ControlDimensions()
+        {
+            //Variable for positioning the controls on the Persistant Panel
+            var panelPositionInputLocationX = MainV2.instance.FlightData.panel_persistent.Width - (MainV2.instance.FlightData.panel_persistent.Width * 0.21);
+            //Size and location for the input fuel field
+            FuelTankSize.Location = new Point((int)(panelPositionInputLocationX), (int)(4));
+            FuelTankSize.Size = new Size((int)(MainV2.instance.FlightData.panel_persistent.Width * 0.18), (int)(MainV2.instance.FlightData.panel_persistent.Height * 0.85));
+            //Set the size of the FuelTankSize button
+            FuelTankSizeButton.Size = FuelTankSize.Size;
+            //Variable for X location of the Fuel tank size button
+            var locationX = FuelTankSize.Location.X - FuelTankSize.Width;
+            //Location of the FuelTankSize button
+            FuelTankSizeButton.Location = new Point((int)(locationX - 3), (int)(3));
+            //Set location and size for FuelinTank input field
+            FuelInTank.Location = new Point(FuelTankSize.Location.X, FuelTankSize.Bottom + 2);
+            FuelInTank.Size = FuelTankSize.Size;
+            //Set location and size for fuel gauge button
+            FuelGaugeButton.Location = new Point(FuelTankSizeButton.Location.X, FuelTankSizeButton.Bottom + 2);
+            FuelGaugeButton.Size = FuelTankSizeButton.Size;
+        }
+        private void PersistentPanelFuelGaugeControls_Resize(object sender, EventArgs e)
+        {
+            //Set the Control dimensions to the starting dimentions of the controls when resizing
+            ControlDimensions();
+        }
+        private void FuelGaugeControls_Hide()
+        {
+            //All of the Controls visiblity set to false
+            FuelGaugeButton.Visible = false;
+            FuelTankSizeButton.Visible = false;
+            FuelInTank.Visible = false;
+            FuelTankSize.Visible = false;
+            FuelGaugeBar.Hide();
+            FuelGaugeBar.Update();
+            FuelGaugeBar.Invalidate();
+            FuelGaugeBar.Visible = false;
+            //Set the display fuel bar int value to 0 when hiding the fuel gauge - this is to ensure when the button to display the fuel gauge is clicked, the ShowFuelGauge() method will be used.
+            displayFuelBar = 0;
+            //Set the back colour of the strip menu item for when the Fuel Gaugeis no displaying
+            FuelGaugeToolStripMenuItem.BackColor = System.Drawing.Color.Empty;
+        }
+        private void DisArmedStatusFuelGauge()
+        {
+            //Enable controls
+            FuelTankSizeButton.Enabled = true;
+            FuelTankSize.Enabled = true;
+        }
+        private void ArmedStatusFuelGauge()
+        {
+            //Disable controls
+            FuelTankSizeButton.Enabled = false;
+            FuelTankSize.Enabled = false;
+            FuelInTank.Enabled = false;
+            //Keep the Fuel gauge button enabled so the user will be able to show/hide the bar on the hud while the vehicle is armed
+            FuelGaugeButton.Enabled = true;
+        }
+        private void FuelGaugeControls_Load()
+        {
+            //Change the colour of the Fuel Gauge menu strip item for when the Fuel Gauge is active
+            FuelGaugeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(255, 240, 240, 240);
+            //Fuel Gauge Button Visible
+            FuelGaugeButton.Visible = true;
+            FuelGaugeButton.Enabled = false;
+            //Name of Fuel Gauge button
+            FuelGaugeButton.Text = "Set Fuel Amount (ml)";
+            //Set the font size
+            FuelGaugeButton.Font = new Font(FuelGaugeButton.Font.FontFamily, 6);
+            //Fuel tank size button visible and enabled
+            FuelTankSizeButton.Visible = true;
+            //If disarmed then can set the values and use the controls
+            var isitarmed = MainV2.comPort.MAV.cs.armed;
+            if (!isitarmed)
+            {
+                FuelTankSizeButton.Enabled = true;
+                FuelTankSize.Enabled = true;
+            }
+            else if (isitarmed)
+            {
+                FuelTankSizeButton.Enabled = false;
+                FuelTankSize.Enabled = false;
+            }
+            //Name of Fuel Gauge button and font
+            FuelTankSizeButton.Text = "Set Tank Size (ml)";
+            FuelTankSizeButton.Font = new Font(FuelGaugeButton.Font.FontFamily, 7);
+            //Set minimum and maximum value for the fuel tank size input
+            FuelTankSize.Minimum = 0;
+            FuelTankSize.Maximum = 10000000000;
+            //Make the input field visible
+            FuelTankSize.Visible = true;
+            //Set the minimum value for the fuel added into tank input
+            FuelInTank.Minimum = 0;
+            //Set the fuel in tank input to false and display the field
+            FuelInTank.Enabled = false;
+            FuelInTank.Visible = true;
+            //Set Tool Tips for the controls on the persistent panel
+            FuelGaugeToolTip.SetToolTip(FuelGaugeButton, "Fuel set in milliliters");
+            FuelGaugeToolTip.SetToolTip(FuelTankSizeButton, "Fuel set in milliliters");
+            FuelGaugeToolTip.SetToolTip(FuelTankSize, "Fuel set in milliliters");
+            FuelGaugeToolTip.SetToolTip(FuelInTank, "Fuel set in milliliters");
+            //Display and add the controls to the persistent panel
+            FuelInTank.Show();
+            FuelInTank.BringToFront();
+            FuelInTank.Update();
+            FuelInTank.Invalidate();
+            FuelGaugeButton.Show();
+            FuelGaugeButton.BringToFront();
+            FuelGaugeButton.Update();
+            FuelGaugeButton.Invalidate();
+            FuelTankSizeButton.Show();
+            FuelTankSizeButton.BringToFront();
+            FuelTankSizeButton.Update();
+            FuelTankSizeButton.Invalidate();
+            FuelTankSize.Show();
+            FuelTankSize.BringToFront();
+            FuelTankSize.Update();
+            FuelTankSize.Invalidate();
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(FuelInTank);
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(FuelGaugeButton);
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(FuelTankSize);
+            MainV2.instance.FlightData.panel_persistent.Controls.Add(FuelTankSizeButton);
+        }
+        private void UpdateTenPercentLine()
+        {
+            //Ten percent of the fuel tank size
+            var tenPercent = (decimal)(0.1) * (decimal)(this.FuelTankSize.Value);
+            //Set the variable to the int ten percent fuel in tank
+            TenPercentFuelTankSize = (int)(tenPercent);
+        }
+        //Method for changing the value of input field
+        private void FuelTankSize_ValueChanged(object sender, EventArgs e)
+        {
+            //Checks to see if the fuel tank size input value is greater than 0 or if it is equal to 0 in order to either enable or keep the buttons disabled.
+            if (Convert.ToDecimal(this.FuelTankSize.Value) == 0)
+            {
+                FuelGaugeButton.Enabled = false;
+                FuelTankSizeButton.Enabled = false;
+            }
+            else if (Convert.ToDecimal(this.FuelTankSize.Value) > 0)
+            {
+                //If disarmed then can set the values and use the controls
+                var isitarmed = MainV2.comPort.MAV.cs.armed;
+                if (!isitarmed)
+                {
+                    //The fuel amount added input and button are only enabled once the set fuel tank size button is clicked
+                    FuelGaugeButton.Enabled = false;
+                    FuelInTank.Enabled = false;
+                    //Fuel tank size button is enabled
+                    FuelTankSizeButton.Enabled = true;
+                }
+            }
+        }
+        private void FuelinTank_ValueChanged(object sender, EventArgs e)
+        {
+            //Stop the message box timer
+            FuelGaugeMessageBoxTimer.Stop();
+            //Checks to see if the fuel in the tank input value is greater than 0 or if it is equal to 0 in order to either enable or keep the button disabled.
+            if (Convert.ToDecimal(this.FuelInTank.Value) == 0)
+            {
+                FuelGaugeButton.Enabled = false;
+            }
+            else if (Convert.ToDecimal(this.FuelInTank.Value) > 0)
+            {
+                //Enable both fuel buttons when the value has changed
+                FuelGaugeButton.Enabled = true;
+                FuelTankSizeButton.Enabled = true;
+            }
+        }
+        //FUNCTION: Colour of the chart
+        private Color ChartColour()
+        {
+            //Variable for the fuel gauge bar value
+            var fuelBarValue = MillilitresOfFuelRemaining;
+            //Variable for the COlor of the fuel gauge bar
+            var fuelBarColour = Color.Empty;
+            //Percentage variable for selecting correct color of the fuel gauge bar
+            //30 Percent of fuel tank size
+            var thirtyPercRemaining = Math.Round(Convert.ToDecimal(0.3), 2) * Math.Round(Convert.ToDecimal(this.FuelTankSize.Value), 2);
+            //15 Percent of fuel tank size
+            var fifteenPercRemaining = Math.Round(Convert.ToDecimal(0.15), 2) * Math.Round(Convert.ToDecimal(this.FuelTankSize.Value), 2);
+            //Change the colour based on the amount remaining in the tank
+            //Above 30% = Lime
+            if (Convert.ToInt32(fuelBarValue) > thirtyPercRemaining)
+            {
+                fuelBarColour = Color.Lime;
+                this.FuelGaugeBar.ValueColor = Color.Transparent;
 
+            } // Above 15% and Below 30% = Orange
+            else if (Convert.ToInt32(fuelBarValue) <= thirtyPercRemaining && Convert.ToInt32(fuelBarValue) > fifteenPercRemaining)
+            {
+                fuelBarColour = Color.Orange;
+                this.FuelGaugeBar.ValueColor = Color.Transparent;
+            } //Above 0% and below 15% = Red
+            else if (Convert.ToInt32(fuelBarValue) <= fifteenPercRemaining && Convert.ToInt32(fuelBarValue) > 0)
+            {
+                fuelBarColour = Color.Red;
+                this.FuelGaugeBar.ValueColor = Color.Transparent;
+            } //0% = White
+            else if (Convert.ToInt32(fuelBarValue) == 0)
+            {
+                fuelBarColour = Color.White;
+                this.FuelGaugeBar.ValueColor = Color.Transparent;
+            }
+            return fuelBarColour;
+        }
+        //FuelTankSize input - Enter button
+        private void FuelTankSize_KeyDown(object sender, KeyEventArgs k)
+        {
+            //If the enter button is pressed, make the fuel in tank maximum value equal to the fuelTankSize value
+            if (k.KeyValue == (char)Keys.Enter)
+            {
+                //Assign the fuel tank value to the decimal variable
+                decimal amountOfFuelInTank = Convert.ToDecimal(FuelTankSize.Value);
+                //Maximum value for the progress bar
+                this.FuelGaugeBar.Maximum = (int)(amountOfFuelInTank);
+                //Update the 10 percent line when the Fuel value changes
+                UpdateTenPercentLine();
+                //Set the Maximum value of the fuelinTank input value to be the fuel tank size value and enable the input field
+                FuelInTank.Maximum = FuelTankSize.Value;
+                FuelInTank.Enabled = true;
+                //Enable the Fuel gauge button and set the message box int counts to 0
+                FuelGaugeButton.Enabled = true;
+                FifteenPercentFuelCount = 0;
+                ZeroPercentFuelCount = 0;
+                return;
+            }
+        }
+        //FuelinTank input - Enter button
+        private void FuelinTank_KeyDown(object sender, KeyEventArgs k)
+        {
+            //If the Enter button is pressed, then display the Fuel Gauge bar
+            if (k.KeyValue == (char)Keys.Enter)
+            {                
+                //Load the fuel gauge bar and set the message box int counts to 0
+                LoadFuelGauge(sender, k);
+                FifteenPercentFuelCount = 0;
+                ZeroPercentFuelCount = 0;
+                return;
+            }
+        }
+        private void FuelGauge_Resize(object sender, EventArgs e)
+        {
+            try
+            {
+                //Only resize when displayed
+                if (displayFuelBar % 2 != 0) 
+                {
+                    //Fuel gauge bar set to invisible when starting resizing
+                    FuelGaugeBar.Visible = false;
+                    //Set the fuel gauge size and Location
+                    //Variables for the sizes of the FlightData Screen Controls: MainHCopy, Persistent Panel, tab control actions
+                    var mainHCopySize = MainV2.instance.FlightData.MainHcopy.Size;
+                    var panelPersistentSize = MainV2.instance.FlightData.panel_persistent.Size;
+                    var tabQuickSize = MainV2.instance.FlightData.tabControlactions.Size;
+                    //Width of the map and the Zoom Bar on the right side of the screen
+                    var mapAndZoomBarWidth = MainV2.instance.FlightData.gMapControl1.Size.Width + 56;
+                    //Width size difference between the full size of screen that Mission Planner takes up and the size of the map on Mission Planner
+                    var hUDWidth = mainHCopySize.Width - mapAndZoomBarWidth;
+                    //Calculate approximate HUD Height from teh other controls on the left side of the screen (including the panel persistant and the MainMenu tab at the top of the screen)
+                    var finalHeihgt = mainHCopySize.Height - tabQuickSize.Height - panelPersistentSize.Height;
+                    //Location of the fuel gauge bar
+                    FuelGaugeBar.Location = new Point((int)((0.825) * hUDWidth), (int)(0.25 * finalHeihgt));
+                    //Size of the fuel gauge bar
+                    FuelGaugeBar.Size = new Size((int)((0.04) * hUDWidth), (int)(0.2 * finalHeihgt));
+                    //Display the fuel gauge bar
+                    FuelGaugeBar.Show();
+                    FuelGaugeBar.BringToFront();
+                    FuelGaugeBar.Update();
+                    FuelGaugeBar.Invalidate();
+                    FuelGaugeBar.Visible = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show(ex.Message);
+                FuelGaugeBar.Visible = true;
+            }
+        }
+        private void ShowFuelGauge()
+        {
+            //Display the fuel bar
+            try
+            {
+                //When the display fuel bar variable is not divisible by 2, then display the fuel gauge bar
+                if (displayFuelBar % 2 != 0)
+                {
+                    //Variables for the FlightData Controls
+                    var mainHCopySize = MainV2.instance.FlightData.MainHcopy.Size;
+                    var panelPersistentSize = MainV2.instance.FlightData.panel_persistent.Size;
+                    var tabQuickSize = MainV2.instance.FlightData.tabControlactions.Size;
+                    //Width of ther map and the Zoom Bar on the right side of the screen
+                    var mapAndZoomBarWidth = MainV2.instance.FlightData.gMapControl1.Size.Width + 56;
+                    //Width size difference between the full size of screen that Mission Planner takes up and the size of the map on mission Planner
+                    var hUDWidth = mainHCopySize.Width - mapAndZoomBarWidth;
+                    //Calculate approximate HUD Height from teh other controls on the left side of the screen (including the panel persistant and the MainMenu tab at the top of the screen)
+                    var finalHeihgt = mainHCopySize.Height - tabQuickSize.Height - panelPersistentSize.Height;
+                    //Location of the fuel gauge bar
+                    FuelGaugeBar.Location = new Point((int)((0.825) * hUDWidth), (int)(0.25 * finalHeihgt));
+                    //Size of the fuel gauge bar
+                    FuelGaugeBar.Size = new Size((int)((0.04) * hUDWidth), (int)(0.2 * finalHeihgt));
+                    //Set the bar color
+                    FuelGaugeBar.ValueColor = ChartColour();
+                    //Assign the fuel tank input value to a decimal variable
+                    decimal amountOfFuelInTank = Convert.ToDecimal(FuelInTank.Value);
+                    //Set the fuel gauge bar value as the amount specified in the FuelinTank input value
+                    FuelGaugeBar.Value = (int)(amountOfFuelInTank);
+                    //Make the bar visible
+                    FuelGaugeBar.Visible = true;
+                    //Enable the bar
+                    FuelGaugeBar.Enabled = true;
+                    //Tool Tip to let user know that the fuel is displayed in millilitres
+                    FuelGaugeToolTip.SetToolTip(FuelGaugeButton, "Fuel set in milliliters");
+                    FuelGaugeToolTip.SetToolTip(FuelTankSizeButton, "Fuel set in milliliters");
+                    FuelGaugeToolTip.SetToolTip(FuelTankSize, "Fuel set in milliliters");
+                    FuelGaugeToolTip.SetToolTip(FuelInTank, "Fuel set in milliliters");
+                    //Display and update the bar
+                    FuelGaugeBar.Show();
+                    FuelGaugeBar.BringToFront();
+                    FuelGaugeBar.Update();
+                    FuelGaugeBar.Invalidate();
+                    //Name of Fuel Gauge button
+                    FuelGaugeButton.Text = "Hide Fuel Gauge";
+                    //Font and font size for the Fuel Gauge Button
+                    FuelGaugeButton.Font = new Font(FuelGaugeButton.Font.FontFamily, 6);
+                }
+                else if (displayFuelBar % 2 == 0)
+                {
+                    //Name of Fuel Gauge button and set font and font size
+                    FuelGaugeButton.Text = "Show Fuel Gauge";
+                    FuelGaugeButton.Font = new Font(FuelGaugeButton.Font.FontFamily, 7);
+                    //Make the Bar invisible and disabled
+                    FuelGaugeBar.Visible = false;
+                    FuelGaugeBar.Enabled = false;
+                    FuelGaugeBar.Hide();
+                    //Update/display the progress bar                
+                    FuelGaugeBar.Update();
+                    FuelGaugeBar.Invalidate();
+                }
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show(ex.Message);
+            }
+        }
+        private void SetFuelTankSize_Click(object sender, EventArgs e)
+        {
+            //Assign the fuel tank value to the decimal variable
+            decimal amountOfFuelInTank = Convert.ToDecimal(FuelTankSize.Value);
+            //Maximum value for the bar
+            FuelGaugeBar.Maximum = (int)(amountOfFuelInTank);
+            //Enable the fuel in tank input and button and set the message box int counts to 0
+            //Only can enable when armed
+            FuelInTank.Enabled = true;
+            FuelGaugeButton.Enabled = true;
+            FifteenPercentFuelCount = 0;
+            ZeroPercentFuelCount = 0;
+            //Fuel in tank maximum value set to the fuel tank size value
+            FuelInTank.Maximum = FuelTankSize.Value;
+            //Set the 10% value of the tank
+            UpdateTenPercentLine();
+        }
+        public void LoadFuelGauge(object sender, EventArgs e)
+        {
+            //Add 1 to the display fuel bar count
+            displayFuelBar += 1;
+            //Start the fuel gauge bar timer 
+            FuelGaugeTimer.Start();
+            //If the count above is odd, then display the bar
+            if (displayFuelBar % 2 != 0)
+            {
+                //Display the fuel gauge bar and then set the messagebox int counts to 0
+                ShowFuelGauge();
+                FifteenPercentFuelCount = 0;
+                ZeroPercentFuelCount = 0;
+                //If the Hud Dropout is visible, then the fuel gauge dimensions need to be set for the dropout HUD
+                if (huddropout)
+                {
+                    //Set the width and height variables to be the same as the Hud Dropout form's width and height
+                    int width = dropoutHUDForm.Width;
+                    int height = dropoutHUDForm.Height;
+                    //Resize the fuel gauge bar on the hud dropout correctly
+                    FuelGaugeHUDDropoutDimensions(width, height);
+                }
+            }
+            //Else if the count for displaying the fuel gauge bar is a number divisible by 2, then hide the bar
+            else if (displayFuelBar % 2 == 0)
+            {
+                //Rename fuel gauge button and reset the font size
+                FuelGaugeButton.Text = "Show Fuel Gauge";
+                FuelGaugeButton.Font = new Font(FuelGaugeButton.Font.FontFamily, 7);
+                //Hide the fuel gauge
+                FuelGaugeBar.Visible = false;
+                FuelGaugeBar.Hide();
+                FuelGaugeBar.Update();
+                FuelGaugeBar.Invalidate();
+                //Reset the display fuel gauge variable to 0 so that the next time the button is pressed, the fuel gauge will be shown.
+                displayFuelBar = 0;
+            }            
+        }
+        private decimal LitresOfFuel()
+        {
+            //Variable for the efi_fuelconsumed from MAVlink (in grams) and convert to decimals
+            var dataSource = MainV2.comPort.MAV.cs.efi_fuelconsumed;
+            decimal value = Convert.ToDecimal(dataSource);
+            //Variable for the Ratio conversion: grams/Litre 1000/736
+            decimal ratioValue = Convert.ToDecimal(1.358695652173913);
+            //Formula to calculate the amount of litres that the data source is from (efi_fuelconsumed)
+            decimal millilitresOfFuelConsumed = Math.Round(Convert.ToDecimal((value * ratioValue)), 2);
+            //Total fuel input capacity below is the value of the input field value of fuel added into the fuel tank
+            //Total fuel input available
+            decimal totalFuelInputCapacity = Math.Round(Convert.ToDecimal(this.FuelInTank.Value), 2);
+            //Total fuel left in Millilitres
+            MillilitresOfFuelRemaining = totalFuelInputCapacity - millilitresOfFuelConsumed;
+            return MillilitresOfFuelRemaining;
+        }
+        private void MessageBoxTimer_Tick(object sender, EventArgs e)
+        {
+            //Variable for the percentage of the fuel used
+            var percentageFuelUsed = 1 - (MillilitresOfFuelRemaining / FuelTankSize.Value);
+            //If the percentage ratio is greater than 0 and less than 1, display message box for the user to inform the user that the fuel is below 15%
+            if (percentageFuelUsed > 0 && percentageFuelUsed < 1)
+            {
+                //If message box timer is ticking,  display the message box and stop the message box timer
+                if (FuelGaugeMessageBoxTimer.Enabled)
+                {
+                    //Disable the messagebox timer
+                    FuelGaugeMessageBoxTimer.Enabled = false;
+                    //Stop the Timer
+                    FuelGaugeMessageBoxTimer.Stop();
+                    //Show a customMessageBox
+                    CustomMessageBox.Show("The fuel level of the vehicle is below 15%", $"{(CustomMessageBox.MessageBoxIcon.Warning, "Fuel below 15%")}");
+                }
+                else if (FuelGaugeMessageBoxTimer.Enabled != true)
+                {
+                    //Disable the messagebox timer
+                    FuelGaugeMessageBoxTimer.Enabled = false;
+                    //Stop the Timer
+                    FuelGaugeMessageBoxTimer.Stop();
+                    return;
+                }
+            }
+            //Else if the percentage ratio is greater or equal to 1, display message box for the user to inform the user that the fuel is depleted
+            else if (percentageFuelUsed >= 1)
+            {
+                //If message box timer is ticking,  display the message box and stop the message box timer
+                if (FuelGaugeMessageBoxTimer.Enabled)
+                {
+                    //Disable the message box timer
+                    FuelGaugeMessageBoxTimer.Enabled = false;
+                    //Stop the Timer
+                    FuelGaugeMessageBoxTimer.Stop();
+                    //Show a custom message box
+                    CustomMessageBox.Show("The fuel for the vehicle has depleted", $"{(CustomMessageBox.MessageBoxIcon.Warning, "No Fuel")}");
+                }
+                else if (FuelGaugeMessageBoxTimer.Enabled != true)
+                {
+                    //Disable the messagebox timer
+                    FuelGaugeMessageBoxTimer.Enabled = false;
+                    //Stop the Timer
+                    FuelGaugeMessageBoxTimer.Stop();
+                    return;
+                }
+            }
+        }
+        private void FuelGaugeTimer_Tick(object sender, EventArgs e)
+        {
+            try
+            {
+                //Set the amount of Milliliters
+                LitresOfFuel();
+                //Percentage variable for colors of fuel gauge
+                //30 Percent
+                var thirtyPercRemaining = Math.Round(Convert.ToDecimal(0.3), 2) * Math.Round(Convert.ToDecimal(this.FuelTankSize.Value), 2);
+                //15 Percent
+                var fifteenPercRemaining = Math.Round(Convert.ToDecimal(0.15), 2) * Math.Round(Convert.ToDecimal(this.FuelTankSize.Value), 2);
+                //Variable for the Chart Color
+                var barColour = ChartColour();
+                //Change the colour based on the amount of fuel remaining
+                if (Convert.ToInt32(MillilitresOfFuelRemaining) > thirtyPercRemaining)
+                {
+                    FuelGaugeBar.ForeColor = Color.Transparent;
+                    FuelGaugeBar.ValueColor = barColour;
+                }
+                else if (Convert.ToInt32(MillilitresOfFuelRemaining) <= thirtyPercRemaining && Convert.ToInt32(MillilitresOfFuelRemaining) > fifteenPercRemaining)
+                {
+                    FuelGaugeBar.ForeColor = Color.Transparent;
+                    FuelGaugeBar.ValueColor = barColour;
+                }
+                else if (Convert.ToInt32(MillilitresOfFuelRemaining) <= fifteenPercRemaining && Convert.ToInt32(MillilitresOfFuelRemaining) > 0)
+                {
+                    FuelGaugeBar.ForeColor = Color.Transparent;
+                    FuelGaugeBar.ValueColor = barColour;
+                    if (FifteenPercentFuelCount == 0)
+                    {
+                        //If the vehicle is armed start the message box timer to display the message box
+                        var isitarmed = MainV2.comPort.MAV.cs.armed;
+                        if (isitarmed)
+                        {
+                            //Set the timer interval
+                            FuelGaugeMessageBoxTimer.Interval = 100;
+                            //Start the timer for the message box to display - below 15% remaining
+                            FuelGaugeMessageBoxTimer.Start();
+                            FifteenPercentFuelCount = 1;
+                        }
+                    }
+                    //If the amount in the tank is under 10%, show one color, else show another color
+                    if (MillilitresOfFuelRemaining < (decimal)(TenPercentFuelTankSize))
+                    {
+                        FuelGaugeBar.BackColor = System.Drawing.Color.White;
+                    }
+                    else
+                    {
+                        FuelGaugeBar.BackColor = System.Drawing.Color.DarkGray;
+                    }
+                }
+                else if (Convert.ToInt32(MillilitresOfFuelRemaining) <= 0)
+                {
+                    if (ZeroPercentFuelCount == 0)
+                    {
+                        //If the vehicle is armed start the message box timer to display the message box
+                        var isitarmed = MainV2.comPort.MAV.cs.armed;
+                        if (isitarmed)
+                        {
+                            //Set the timer interval
+                            FuelGaugeMessageBoxTimer.Interval = 100;
+                            //Start the timer for the message box to display - fuel depleted
+                            FuelGaugeMessageBoxTimer.Start();
+                            ZeroPercentFuelCount = 1;
+                        }
+                    }
+                }
+                //Set the value of the bar chart to be the estimated calculated Milliliters remaining in the tank
+                FuelGaugeBar.Value = Convert.ToInt32(MillilitresOfFuelRemaining);
+                //Add the tooltip to the fuel gauge bar - constantly updated in the timer tick function
+                FuelGaugeToolTip.SetToolTip(FuelGaugeBar, $"Fuel remaining: {MillilitresOfFuelRemaining} ml");
+                //Update the Fuel Gauge
+                FuelGaugeBar.Update();
+                FuelGaugeBar.Invalidate();
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show(ex.Message);
+            }
+        }
+        private void ArmStatus_Timer(object sender, EventArgs e)
+        {
+            //Enable/disable the fuel gauge controls if the vehicle is disarmed/armed, respectively
+            var isitarmed = MainV2.comPort.MAV.cs.armed;
+            if (isitarmed == true)
+            {
+                ArmedStatusFuelGauge();
+            }
+            else if (isitarmed == false)
+            {
+                DisArmedStatusFuelGauge();
+            }
+        }
+        private void FuelGaugeContextMenuStripItem_Click(object sender, EventArgs e)
+        {
+            //Make the presistent panel visible
+            MainV2.instance.FlightData.panel_persistent.Visible = true;
+            //Set the arm status timer interval to 3.5 seconds
+            ArmStatusTimer.Interval = 3500;
+            //Check the arm status and keep the buttons armed/disarmed accordingly
+            ArmStatusTimer.Tick += new EventHandler(ArmStatus_Timer);
+            //Add 1 to the display controls int.
+            displayFuelGaugeControls += 1;
+            if (displayFuelGaugeControls % 2 != 0)
+            {
+                //Start the Arm status timer
+                ArmStatusTimer.Start();
+                //Load the fuel gauge controls when the strip menu item for the fuel gauge is clicked every second time
+                FuelGaugeControls_Load();
+            }
+            else if (displayFuelGaugeControls % 2 == 0)
+            {
+                //Stop the Arm Status timer
+                ArmStatusTimer.Stop();
+                //Hide all of the fuel gauge controls when the strip menu item is clicked every second click
+                FuelGaugeControls_Hide();
+            }
+            //Display the controls on the persistent panel for the fuel gauge
+            ControlDimensions();
+            //Fuel tank size and fuel in tank inputs value changed event handlers
+            FuelInTank.ValueChanged += new EventHandler(FuelinTank_ValueChanged);
+            FuelTankSize.ValueChanged += new EventHandler(FuelTankSize_ValueChanged);
+            //Fuel tank size and fuel in tank inputs key down event handlers            
+            FuelTankSize.KeyDown += new KeyEventHandler(FuelTankSize_KeyDown);
+            FuelInTank.KeyDown += new KeyEventHandler(FuelinTank_KeyDown);
+            //Fuel gauge button event handler
+            FuelGaugeButton.Click += new EventHandler(LoadFuelGauge);
+            //Fuel tank size button eventhandler
+            FuelTankSizeButton.Click += new EventHandler(SetFuelTankSize_Click);
+            //The following two resize event handlers are to resize the controls on the persistent panel and resize the fuel gauge bar, respectively.
+            MainV2.instance.FlightData.panel_persistent.Resize += new EventHandler(PersistentPanelFuelGaugeControls_Resize);
+            MainV2.instance.FlightData.gMapControl1.Resize += new EventHandler(FuelGauge_Resize);
+            //Set the back color of the bar
+            FuelGaugeBar.BackColor = System.Drawing.Color.DarkGray;
+            //Set the value color of the fuel bar
+            FuelGaugeBar.ValueColor = ChartColour();
+            //Set the Border color of the bar
+            FuelGaugeBar.BorderColor = Color.Transparent;
+            //Set the Color for the bar at the start
+            FuelGaugeBar.ForeColor = Color.Lime;
+            //Add the bar control to the HUD
+            hud1.Controls.Add(FuelGaugeBar);
+            //Set the 10% for the fuel gauge
+            UpdateTenPercentLine();
+            //Time interval for the timer
+            FuelGaugeTimer.Interval = 1000;
+            //Timer event handler
+            FuelGaugeTimer.Tick += new EventHandler(FuelGaugeTimer_Tick);
+            //Message box timer event handler
+            FuelGaugeMessageBoxTimer.Tick += new EventHandler(MessageBoxTimer_Tick);
+            //Minimum size of the persistent panel
+            MainV2.instance.FlightData.panel_persistent.MinimumSize = new System.Drawing.Size(0, 35);
+        }
         private void hud1_Load(object sender, EventArgs e)
         {
 

--- a/GCSViews/FlightData.resx
+++ b/GCSViews/FlightData.resx
@@ -144,97 +144,103 @@
     <value>714, 17</value>
   </metadata>
   <data name="recordHudToAVIToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="recordHudToAVIToolStripMenuItem.Text" xml:space="preserve">
     <value>Record Hud to AVI</value>
   </data>
   <data name="stopRecordToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="stopRecordToolStripMenuItem.Text" xml:space="preserve">
     <value>Stop Record</value>
   </data>
   <data name="setMJPEGSourceToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="setMJPEGSourceToolStripMenuItem.Text" xml:space="preserve">
     <value>Set MJPEG source</value>
   </data>
   <data name="startCameraToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="startCameraToolStripMenuItem.Text" xml:space="preserve">
     <value>Start Camera</value>
   </data>
   <data name="setGStreamerSourceToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="setGStreamerSourceToolStripMenuItem.Text" xml:space="preserve">
     <value>Set GStreamer Source</value>
   </data>
   <data name="hereLinkVideoToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="hereLinkVideoToolStripMenuItem.Text" xml:space="preserve">
     <value>HereLink Video</value>
   </data>
   <data name="gStreamerStopToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>236, 26</value>
   </data>
   <data name="gStreamerStopToolStripMenuItem.Text" xml:space="preserve">
     <value>GStreamer Stop</value>
   </data>
   <data name="videoToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="videoToolStripMenuItem.Text" xml:space="preserve">
     <value>Video</value>
   </data>
   <data name="setAspectRatioToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="setAspectRatioToolStripMenuItem.Text" xml:space="preserve">
     <value>Set Aspect Ratio</value>
   </data>
   <data name="userItemsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="userItemsToolStripMenuItem.Text" xml:space="preserve">
     <value>User Items</value>
   </data>
   <data name="russianHudToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="russianHudToolStripMenuItem.Text" xml:space="preserve">
     <value>Russian Hud</value>
   </data>
   <data name="swapWithMapToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="swapWithMapToolStripMenuItem.Text" xml:space="preserve">
     <value>Swap With Map</value>
   </data>
   <data name="groundColorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="groundColorToolStripMenuItem.Text" xml:space="preserve">
     <value>Ground Color</value>
   </data>
   <data name="setBatteryCellCountToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="setBatteryCellCountToolStripMenuItem.Text" xml:space="preserve">
     <value>Battery Cell Voltage</value>
   </data>
   <data name="showIconsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>209, 24</value>
   </data>
   <data name="showIconsToolStripMenuItem.Text" xml:space="preserve">
     <value>Show icons</value>
   </data>
+  <data name="FuelGaugeToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 24</value>
+  </data>
+  <data name="FuelGaugeToolStripMenuItem.Text" xml:space="preserve">
+    <value>Fuel Gauge</value>
+  </data>
   <data name="contextMenuStripHud.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 180</value>
+    <value>210, 220</value>
   </data>
   <data name="&gt;&gt;contextMenuStripHud.Name" xml:space="preserve">
     <value>contextMenuStripHud</value>
@@ -289,19 +295,19 @@
     <value>491, 57</value>
   </metadata>
   <data name="customizeToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 22</value>
+    <value>147, 24</value>
   </data>
   <data name="customizeToolStripMenuItem.Text" xml:space="preserve">
     <value>Customize</value>
   </data>
   <data name="multiLineToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 22</value>
+    <value>147, 24</value>
   </data>
   <data name="multiLineToolStripMenuItem.Text" xml:space="preserve">
     <value>MultiLine</value>
   </data>
   <data name="contextMenuStripactionstab.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 48</value>
+    <value>148, 52</value>
   </data>
   <data name="&gt;&gt;contextMenuStripactionstab.Name" xml:space="preserve">
     <value>contextMenuStripactionstab</value>
@@ -325,19 +331,19 @@
     <value>696, 57</value>
   </metadata>
   <data name="setViewCountToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 22</value>
+    <value>178, 24</value>
   </data>
   <data name="setViewCountToolStripMenuItem.Text" xml:space="preserve">
     <value>Set View Count</value>
   </data>
   <data name="undockToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 22</value>
+    <value>178, 24</value>
   </data>
   <data name="undockToolStripMenuItem.Text" xml:space="preserve">
     <value>Undock</value>
   </data>
   <data name="contextMenuStripQuickView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 48</value>
+    <value>179, 52</value>
   </data>
   <data name="&gt;&gt;contextMenuStripQuickView.Name" xml:space="preserve">
     <value>contextMenuStripQuickView</value>
@@ -562,7 +568,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanelQuick.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="quickView6" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="quickView5" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="quickView4" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="quickView3" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="quickView2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="quickView1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="quickView6" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="quickView5" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="quickView4" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="quickView3" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="quickView2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="quickView1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,33,33333,Percent,33,33333,Percent,33,33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tabQuick.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 44</value>
@@ -694,7 +700,7 @@
     <value>modifyandSetLoiterRad</value>
   </data>
   <data name="&gt;&gt;modifyandSetLoiterRad.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ModifyandSet, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ModifyandSet, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;modifyandSetLoiterRad.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -745,7 +751,7 @@
     <value>3, 3</value>
   </data>
   <data name="CMB_action.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 28</value>
+    <value>51, 33</value>
   </data>
   <data name="CMB_action.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
@@ -853,7 +859,7 @@
     <value>modifyandSetAlt</value>
   </data>
   <data name="&gt;&gt;modifyandSetAlt.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ModifyandSet, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ModifyandSet, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;modifyandSetAlt.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -889,7 +895,7 @@
     <value>modifyandSetSpeed</value>
   </data>
   <data name="&gt;&gt;modifyandSetSpeed.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ModifyandSet, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ModifyandSet, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;modifyandSetSpeed.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
@@ -910,7 +916,7 @@
     <value>3, 39</value>
   </data>
   <data name="CMB_setwp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 28</value>
+    <value>51, 33</value>
   </data>
   <data name="CMB_setwp.TabIndex" type="System.Int32, mscorlib">
     <value>72</value>
@@ -1135,7 +1141,7 @@
     <value>3, 111</value>
   </data>
   <data name="CMB_mountmode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 28</value>
+    <value>51, 33</value>
   </data>
   <data name="CMB_mountmode.TabIndex" type="System.Int32, mscorlib">
     <value>82</value>
@@ -1261,7 +1267,7 @@
     <value>3, 75</value>
   </data>
   <data name="CMB_modes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 28</value>
+    <value>51, 33</value>
   </data>
   <data name="CMB_modes.TabIndex" type="System.Int32, mscorlib">
     <value>70</value>
@@ -1582,7 +1588,7 @@
     <value>checkListControl1</value>
   </data>
   <data name="&gt;&gt;checkListControl1.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.PreFlight.CheckListControl, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.PreFlight.CheckListControl, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;checkListControl1.Parent" xml:space="preserve">
     <value>tabPagePreFlight</value>
@@ -2555,7 +2561,7 @@
     <value>113, 89</value>
   </data>
   <data name="NACp_tb.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 20</value>
+    <value>77, 22</value>
   </data>
   <data name="NACp_tb.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -2576,7 +2582,7 @@
     <value>113, 63</value>
   </data>
   <data name="NIC_tb.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 20</value>
+    <value>77, 22</value>
   </data>
   <data name="NIC_tb.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -2603,7 +2609,7 @@
     <value>64, 89</value>
   </data>
   <data name="NACp_lbl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>43, 16</value>
   </data>
   <data name="NACp_lbl.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -2633,7 +2639,7 @@
     <value>64, 63</value>
   </data>
   <data name="NIC_lbl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 13</value>
+    <value>29, 16</value>
   </data>
   <data name="NIC_lbl.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -2663,7 +2669,7 @@
     <value>113, 31</value>
   </data>
   <data name="Squawk_nud.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 26</value>
+    <value>77, 30</value>
   </data>
   <data name="Squawk_nud.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2690,7 +2696,7 @@
     <value>113, 6</value>
   </data>
   <data name="FlightID_tb.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 20</value>
+    <value>77, 23</value>
   </data>
   <data name="FlightID_tb.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -2786,7 +2792,7 @@
     <value>64, 37</value>
   </data>
   <data name="Squawk_label.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
+    <value>55, 16</value>
   </data>
   <data name="Squawk_label.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2816,7 +2822,7 @@
     <value>64, 11</value>
   </data>
   <data name="FlightID_label.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>52, 16</value>
   </data>
   <data name="FlightID_label.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -3071,7 +3077,7 @@
     <value>servoOptions1</value>
   </data>
   <data name="&gt;&gt;servoOptions1.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions1.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3092,7 +3098,7 @@
     <value>servoOptions2</value>
   </data>
   <data name="&gt;&gt;servoOptions2.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions2.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3113,7 +3119,7 @@
     <value>servoOptions3</value>
   </data>
   <data name="&gt;&gt;servoOptions3.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions3.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3134,7 +3140,7 @@
     <value>servoOptions4</value>
   </data>
   <data name="&gt;&gt;servoOptions4.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions4.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3155,7 +3161,7 @@
     <value>servoOptions5</value>
   </data>
   <data name="&gt;&gt;servoOptions5.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions5.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3176,7 +3182,7 @@
     <value>servoOptions6</value>
   </data>
   <data name="&gt;&gt;servoOptions6.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions6.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3197,7 +3203,7 @@
     <value>servoOptions7</value>
   </data>
   <data name="&gt;&gt;servoOptions7.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions7.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3218,7 +3224,7 @@
     <value>servoOptions8</value>
   </data>
   <data name="&gt;&gt;servoOptions8.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions8.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3239,7 +3245,7 @@
     <value>servoOptions9</value>
   </data>
   <data name="&gt;&gt;servoOptions9.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions9.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3260,7 +3266,7 @@
     <value>servoOptions10</value>
   </data>
   <data name="&gt;&gt;servoOptions10.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions10.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3281,7 +3287,7 @@
     <value>servoOptions11</value>
   </data>
   <data name="&gt;&gt;servoOptions11.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions11.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3302,7 +3308,7 @@
     <value>servoOptions12</value>
   </data>
   <data name="&gt;&gt;servoOptions12.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.ServoOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;servoOptions12.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3323,7 +3329,7 @@
     <value>relayOptions1</value>
   </data>
   <data name="&gt;&gt;relayOptions1.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;relayOptions1.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3344,7 +3350,7 @@
     <value>relayOptions2</value>
   </data>
   <data name="&gt;&gt;relayOptions2.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;relayOptions2.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3365,7 +3371,7 @@
     <value>relayOptions3</value>
   </data>
   <data name="&gt;&gt;relayOptions3.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;relayOptions3.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3386,7 +3392,7 @@
     <value>relayOptions4</value>
   </data>
   <data name="&gt;&gt;relayOptions4.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;relayOptions4.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3407,7 +3413,7 @@
     <value>relayOptions5</value>
   </data>
   <data name="&gt;&gt;relayOptions5.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;relayOptions5.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3428,7 +3434,7 @@
     <value>relayOptions6</value>
   </data>
   <data name="&gt;&gt;relayOptions6.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.RelayOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;relayOptions6.Parent" xml:space="preserve">
     <value>flowLayoutPanelServos</value>
@@ -3503,7 +3509,7 @@
     <value>auxOptions1</value>
   </data>
   <data name="&gt;&gt;auxOptions1.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions1.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3524,7 +3530,7 @@
     <value>auxOptions2</value>
   </data>
   <data name="&gt;&gt;auxOptions2.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions2.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3545,7 +3551,7 @@
     <value>auxOptions3</value>
   </data>
   <data name="&gt;&gt;auxOptions3.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions3.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3566,7 +3572,7 @@
     <value>auxOptions4</value>
   </data>
   <data name="&gt;&gt;auxOptions4.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions4.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3587,7 +3593,7 @@
     <value>auxOptions5</value>
   </data>
   <data name="&gt;&gt;auxOptions5.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions5.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3608,7 +3614,7 @@
     <value>auxOptions6</value>
   </data>
   <data name="&gt;&gt;auxOptions6.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions6.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3629,7 +3635,7 @@
     <value>auxOptions7</value>
   </data>
   <data name="&gt;&gt;auxOptions7.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.AuxOptions, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;auxOptions7.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -3698,7 +3704,7 @@
     <value>19, 48</value>
   </data>
   <data name="checkBoxRedirectOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 17</value>
+    <value>176, 20</value>
   </data>
   <data name="checkBoxRedirectOutput.TabIndex" type="System.Int32, mscorlib">
     <value>91</value>
@@ -3758,7 +3764,7 @@
     <value>19, 29</value>
   </data>
   <data name="labelSelectedScript.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 13</value>
+    <value>137, 16</value>
   </data>
   <data name="labelSelectedScript.TabIndex" type="System.Int32, mscorlib">
     <value>89</value>
@@ -3848,7 +3854,7 @@
     <value>19, 10</value>
   </data>
   <data name="labelScriptStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 13</value>
+    <value>194, 16</value>
   </data>
   <data name="labelScriptStatus.TabIndex" type="System.Int32, mscorlib">
     <value>86</value>
@@ -3959,7 +3965,7 @@
     <value>6, 19</value>
   </data>
   <data name="TXT_gimbalRollPos.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 20</value>
+    <value>51, 22</value>
   </data>
   <data name="TXT_gimbalRollPos.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3989,7 +3995,7 @@
     <value>True</value>
   </data>
   <data name="trackBarRoll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 45</value>
+    <value>104, 56</value>
   </data>
   <data name="trackBarRoll.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4034,7 +4040,7 @@
     <value>6, 18</value>
   </data>
   <data name="TXT_gimbalYawPos.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 20</value>
+    <value>51, 22</value>
   </data>
   <data name="TXT_gimbalYawPos.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -4058,7 +4064,7 @@
     <value>63, 18</value>
   </data>
   <data name="trackBarYaw.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 45</value>
+    <value>104, 56</value>
   </data>
   <data name="trackBarYaw.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4136,7 +4142,7 @@
     <value>Vertical</value>
   </data>
   <data name="trackBarPitch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 104</value>
+    <value>56, 104</value>
   </data>
   <data name="trackBarPitch.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4157,7 +4163,7 @@
     <value>6, 18</value>
   </data>
   <data name="TXT_gimbalPitchPos.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
+    <value>50, 22</value>
   </data>
   <data name="TXT_gimbalPitchPos.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -4241,7 +4247,7 @@
     <value>49, 7</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>48, 16</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>84</value>
@@ -4943,7 +4949,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel2.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="BUT_DFMavlink" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_georefimage" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_logbrowse" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_matlab" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_bintolog" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_dflogtokml" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_loganalysis" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="BUT_DFMavlink" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_georefimage" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_logbrowse" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="BUT_matlab" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="but_bintolog" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="but_dflogtokml" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="BUT_loganalysis" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33,33333,Percent,33,33333,Percent,33,33333" /&gt;&lt;Rows Styles="Percent,33,33333,Percent,33,33333,Percent,33,33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tablogbrowse.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 44</value>
@@ -5138,115 +5144,115 @@
     <value>444, 17</value>
   </metadata>
   <data name="goHereToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="goHereToolStripMenuItem.Text" xml:space="preserve">
     <value>Fly To Here</value>
   </data>
   <data name="flyToHereAltToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="flyToHereAltToolStripMenuItem.Text" xml:space="preserve">
     <value>Fly To Here Alt</value>
   </data>
   <data name="flyToCoordsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="flyToCoordsToolStripMenuItem.Text" xml:space="preserve">
     <value>Fly To Coords</value>
   </data>
   <data name="deleteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 22</value>
+    <value>152, 26</value>
   </data>
   <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
     <value>Delete</value>
   </data>
   <data name="saveFileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 22</value>
+    <value>152, 26</value>
   </data>
   <data name="saveFileToolStripMenuItem.Text" xml:space="preserve">
     <value>Save File</value>
   </data>
   <data name="loadFileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 22</value>
+    <value>152, 26</value>
   </data>
   <data name="loadFileToolStripMenuItem.Text" xml:space="preserve">
     <value>Load File</value>
   </data>
   <data name="poiatcoordsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 22</value>
+    <value>152, 26</value>
   </data>
   <data name="poiatcoordsToolStripMenuItem.Text" xml:space="preserve">
     <value>Coords</value>
   </data>
   <data name="addPoiToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="addPoiToolStripMenuItem.Text" xml:space="preserve">
     <value>Add Poi</value>
   </data>
   <data name="pointCameraHereToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="pointCameraHereToolStripMenuItem.Text" xml:space="preserve">
     <value>Point Camera Here</value>
   </data>
   <data name="PointCameraCoordsToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="PointCameraCoordsToolStripMenuItem1.Text" xml:space="preserve">
     <value>Point Camera Coords</value>
   </data>
   <data name="triggerCameraToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="triggerCameraToolStripMenuItem.Text" xml:space="preserve">
     <value>Trigger Camera NOW</value>
   </data>
   <data name="flightPlannerToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="flightPlannerToolStripMenuItem.Text" xml:space="preserve">
     <value>Flight Planner</value>
   </data>
   <data name="setEKFHomeHereToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>222, 26</value>
   </data>
   <data name="setEKFHomeHereToolStripMenuItem.Text" xml:space="preserve">
     <value>Set EKF Origin Here</value>
   </data>
   <data name="setHomeHereToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 22</value>
+    <value>222, 26</value>
   </data>
   <data name="setHomeHereToolStripMenuItem1.Text" xml:space="preserve">
     <value>Set Home Here</value>
   </data>
   <data name="setHomeHereToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="setHomeHereToolStripMenuItem.Text" xml:space="preserve">
     <value>Set Home Here</value>
   </data>
   <data name="takeOffToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="takeOffToolStripMenuItem.Text" xml:space="preserve">
     <value>TakeOff</value>
   </data>
   <data name="onOffCameraOverlapToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="onOffCameraOverlapToolStripMenuItem.Text" xml:space="preserve">
     <value>Camera Overlap</value>
   </data>
   <data name="jumpToTagToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
+    <value>220, 24</value>
   </data>
   <data name="jumpToTagToolStripMenuItem.Text" xml:space="preserve">
     <value>Jump To Tag</value>
   </data>
   <data name="contextMenuStripMap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 290</value>
+    <value>221, 292</value>
   </data>
   <data name="&gt;&gt;contextMenuStripMap.Name" xml:space="preserve">
     <value>contextMenuStripMap</value>
@@ -5300,7 +5306,7 @@
     <value>distanceBar1</value>
   </data>
   <data name="&gt;&gt;distanceBar1.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.DistanceBar, MissionPlanner, Version=1.3.8313.24739, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.DistanceBar, MissionPlanner, Version=1.3.8699.17526, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;distanceBar1.Parent" xml:space="preserve">
     <value>splitContainer1.Panel2</value>
@@ -5348,7 +5354,7 @@
     <value>332, 167</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 13</value>
+    <value>118, 16</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>74</value>
@@ -5381,7 +5387,7 @@
     <value>245, 167</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>102, 16</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>73</value>
@@ -5414,7 +5420,7 @@
     <value>135, 167</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 13</value>
+    <value>124, 16</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>71</value>
@@ -5447,7 +5453,7 @@
     <value>45, 167</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 13</value>
+    <value>104, 16</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>72</value>
@@ -5543,7 +5549,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="gMapControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>550, 197</value>
+    <value>539, 197</value>
   </data>
   <data name="gMapControl1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5567,13 +5573,13 @@
     <value>NoControl</value>
   </data>
   <data name="TRK_zoom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>550, 0</value>
+    <value>539, 0</value>
   </data>
   <data name="TRK_zoom.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
     <value>Vertical</value>
   </data>
   <data name="TRK_zoom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 197</value>
+    <value>56, 197</value>
   </data>
   <data name="TRK_zoom.TabIndex" type="System.Int32, mscorlib">
     <value>72</value>
@@ -5654,7 +5660,7 @@
     <value>438, 2</value>
   </data>
   <data name="Zoomlevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>76, 22</value>
   </data>
   <data name="Zoomlevel.TabIndex" type="System.Int32, mscorlib">
     <value>69</value>
@@ -5714,10 +5720,10 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_autopan.Location" type="System.Drawing.Point, System.Drawing">
-    <value>325, 3</value>
+    <value>325, 0</value>
   </data>
   <data name="CHK_autopan.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 17</value>
+    <value>83, 20</value>
   </data>
   <data name="CHK_autopan.TabIndex" type="System.Int32, mscorlib">
     <value>68</value>
@@ -5750,10 +5756,10 @@
     <value>NoControl</value>
   </data>
   <data name="CB_tuning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>260, 3</value>
+    <value>260, 0</value>
   </data>
   <data name="CB_tuning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 17</value>
+    <value>70, 20</value>
   </data>
   <data name="CB_tuning.TabIndex" type="System.Int32, mscorlib">
     <value>62</value>
@@ -6136,6 +6142,12 @@
   <data name="&gt;&gt;onOffCameraOverlapToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;jumpToTagToolStripMenuItem.Name" xml:space="preserve">
+    <value>jumpToTagToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;jumpToTagToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;bindingSource1.Name" xml:space="preserve">
     <value>bindingSource1</value>
   </data>
@@ -6178,10 +6190,10 @@
   <data name="&gt;&gt;bindingSourceStatusTab.Type" xml:space="preserve">
     <value>System.Windows.Forms.BindingSource, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;jumpToTagToolStripMenuItem.Name" xml:space="preserve">
-    <value>jumpToTagToolStripMenuItem</value>
+  <data name="&gt;&gt;FuelGaugeToolStripMenuItem.Name" xml:space="preserve">
+    <value>FuelGaugeToolStripMenuItem</value>
   </data>
-  <data name="&gt;&gt;jumpToTagToolStripMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;FuelGaugeToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">


### PR DESCRIPTION
New Feature:
The purpose of the fuel gauge is to display an estimation of the amount of fuel that is remaining in the tank of the vehicle. The calculation for the value displayed is based on the efi fuel consumed (in grams) and is multiplied by a ratio of the weight per litre of the fuel to get the value of the efi fuel consumed into millilitres. This calculated value is subtracted off of the fuel amount in the tank as specified by the user. This is the value which displays on the fuel gauge bar.

Functionality:
The Fuel Gauge is a new feature which has been implemented into the FlightData screen on the HUD. It is accessible by right clicking on the HUD and selecting the "Fuel Gauge" menu strip item.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/d7fbbca7-8218-421a-8a3b-b5f59d998359)
Once the user clicks on the Fuel Gauge menu item, five controls are displayed on the persistent panel displayed under the HUD. These controls are namely: the Fuel Tank Size button, labelled as “Set Tank Size (ml)”, and input field and the Fuel Amount in the tank button, labelled as ”Set Fuel Amount (ml)”, and input field, as well as the “Set Fuel Density” button.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/8d941a87-7098-4a2b-be5a-ac60212eec08)
The user will first set the Fuel Density weight per litre of fuel by clicking on the set fuel density button, this will open the Fuel Density Form where there is an explanation of the use of the Fuel Density, which is the same value that the user would submit in the configuration settings in the parameter list(parameter EFI_FUEL_DENS) and that this value for the fuel gauge is only needed to be set the first time using the fuel gauge. The value is only reset if the user changes the value or the Mission Planner is reopened.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/dae8ca54-584c-41b4-8b1e-e6636df6244f)
The user will input the weight per litre of the fuel in grams and once the Set button is pressed, the value will be used  in the fuel consumption calculation.
The user will then be able to set the size of the fuel tank in millilitres, once set the user either can press enter or press the “Set Tank Size (ml)” button which will enable the “Set Fuel Amount (ml) button and the input field for the fuel amount in the tank. Once this value is set and the user presses the button or presses enter while in the input field, the Fuel Gauge will be displayed on the HUD to the right of the Disarmed status and above where the AOA is displayed. 
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/85d58fb3-a3eb-4270-9f41-c5784040bcbd)
Once the Fuel Gauge is displayed on the screen the Button’s, used for setting the fuel amount in the tank, text changes to: “Hide Fuel Gauge”. When pressed, the fuel gauge will be hidden and not display on the HUD, the button will need to be pressed again in order to display the fuel Gauge on the HUD.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/14c2cad2-8598-450c-8e38-0d2922ffd4e6)
When the amount of fuel remaining in the tank is above 30%, the gauge is displayed in a lime colour, when between 15% and 30%, the gauge is displayed in orange, when below 15%, the gauge is displayed in red.
Fuel between 15% and 30% - Orange
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/3bb99ce8-9ff6-4406-930d-b29741d8530a)
Fuel between 0% and 15% - Red
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/b89457ae-f5ff-4551-81e7-ab64fc74aac0)
If a user does not want to view the Fuel Gauge bar and its controls any more, the user can right click on the HUD and select the “Fuel Gauge” menu item which will hide all of the fuel gauge controls.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/3391c4a2-f559-40aa-8f07-139bb46c6f7a)
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/2b512c2c-9372-485c-a457-6e3483d479df)
When hovering over any of the controls displayed in the persistent panel for the fuel gauge input setup, the tooltip displays some text to inform the user that the fuel gauge is set and calculated in millilitres. Once the Fuel Density has been set, the Fuel Density buttons’ tooltip displays the set fuel density in grams which the user set in the fuel density form.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/724ce08f-2f58-4c47-a518-7646354f2b6a)
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/7226b1d4-842f-4463-9380-1abfeb0b72ec)

HUD Dropout Form
When the user double clicks on the HUD in order to view the Hud in its own form, the fuel gauge is also added onto the HUD if it was already displaying on the original HUD
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/85e130cd-e8dc-4666-9430-4af1d69a7263)
When the HUD dropout form is resized, the fuel gauge stays in the same place relative to the size of the form.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/bb390214-17c0-44dc-9c18-843d2a793351)

The functionality works the same way when the fuel gauge is displayed on the HUD dropout as to when it is on the original HUD, the fuel gauge bar can be hidden, redisplayed, resized, the bar changes value when connected to an EFI fuel system.
Fuel Level warnings
When the fuel amount remaining reaches 15%, a message box pops up to inform the user that the fuel is below 15%, and when the fuel has reached 0, another message box displays to inform the user that the fuel has been depleted. The message boxes are only displayed when the vehicle which is connected is armed.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/3ee670b6-7045-4af0-9078-5840c6d503de)
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/0b1ffc12-2e42-45b9-9917-eba3e20d71f7)

When a user hovers over the fuel gauge bar on the HUD, the user will be able to view the amount of millilitres remaining in the fuel tank.
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/c3b9bb5b-f798-475a-8038-fe7b12c25437)

Resizing the HUD
When the HUD is resized the fuel gauge will stay in the same position relative to the size of the HUD
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/93470516-37ca-4f7e-8c5c-39ebcd3e9219)
![image](https://github.com/ArduPilot/MissionPlanner/assets/140613096/3a5eedb5-7654-4fc0-95c4-e6797a9db1d7)