### PR TITLE
ExtLibs: Utilities: BinaryLog: fix FW version detection used for mode names

### DIFF
--- a/ExtLibs/Utilities/BinaryLog.cs
+++ b/ExtLibs/Utilities/BinaryLog.cs
@@ -157,6 +157,8 @@ namespace MissionPlanner.Utilities
                                               {
                                                   if (a.IsNumber())
                                                       return (((IConvertible)a).ToString(CultureInfo.InvariantCulture));
+                                                  else if (a is System.Byte[])
+                                                      return System.Text.Encoding.ASCII.GetString(a as byte[]).Trim('\0');
                                                   else
                                                       return a?.ToString();
                                               })) + "\r\n";


### PR DESCRIPTION
Correctly parsing the `System.Byte[]` to a string fixes the setting of the `_firmware` variable which is used to lookup the mode names from the numbers. Same idea as https://github.com/ArduPilot/MissionPlanner/pull/3210

Without we just get numbers:
![image](https://github.com/ArduPilot/MissionPlanner/assets/33176108/84d6f296-fa50-43a0-a45e-ecd70f06c001)

With we get names again:
![image](https://github.com/ArduPilot/MissionPlanner/assets/33176108/cf5a3d4b-a70d-49d5-9111-35a23028493e)
