### PR TITLE
CurrentState: Propagate Named Float messages across components with same sysid.

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -2028,7 +2028,11 @@ namespace MissionPlanner
         {
             if (mavLinkMessage.sysid == parent.sysid && mavLinkMessage.compid == parent.compid
                 || mavLinkMessage.msgid == (uint)MAVLink.MAVLINK_MSG_ID.RADIO // propagate the RADIO/RADIO_STATUS message across all devices on this link
-                || mavLinkMessage.msgid == (uint)MAVLink.MAVLINK_MSG_ID.RADIO_STATUS)
+                || mavLinkMessage.msgid == (uint)MAVLink.MAVLINK_MSG_ID.RADIO_STATUS
+                || ( mavLinkMessage.sysid == parent.sysid                      // Propagate NAMED_VALUE_FLOAT messages across all components within the same device
+                     && mavLinkMessage.msgid == (uint)MAVLink.MAVLINK_MSG_ID.NAMED_VALUE_FLOAT 
+                     && Settings.Instance.GetBoolean("propagateNamedFloats", true)) )
+                     
             {
                 switch (mavLinkMessage.msgid)
                 {


### PR DESCRIPTION
There were an increased number of requests about using named floats to display data in the QuickView tab. Unfortunately, if the msg is sent with other than component ID 1, then it is displayed only when the component is selected in the connect window. (Sending it with compid 1 generates seqno errors so it is not recommended) This patch propagates named float messages across components with the same sysid. This will help in most cases. In the rare case when there is a need to separate named_floats by component id the propagation can be switched off by setting <propagateNamedFloats>false</propagateNamedFloats> in config.xml
