### PR TITLE
MissionPlanner.csproj : Fix post build command to accept space in folder names

### DIFF
--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -5242,6 +5242,6 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(ProjectDir)\ExtLibs\System.IO.Compression.dll $(ProjectDir)$(OutDir)</PostBuildEvent>
+    <PostBuildEvent>copy "$(ProjectDir)ExtLibs\System.IO.Compression.dll" "$(ProjectDir)$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added apostrophes to allow run post-build command when the project parent folder contains spaces.