### PR TITLE
Fixing a performance problem in message display

### DIFF
--- a/ExtLibs/AltitudeAngelWings.Plugin/ControlOverlayMessageDisplay.cs
+++ b/ExtLibs/AltitudeAngelWings.Plugin/ControlOverlayMessageDisplay.cs
@@ -56,15 +56,22 @@ namespace AltitudeAngelWings.Plugin
                 if (!_parent.Visible) return;
                 _parent.SuspendLayout();
                 var labels = GetMessageLabels();
+                var removed = false;
                 foreach (var label in labels)
                 {
                     if (label.Tag != message) continue;
                     _parent.Controls.Remove(label);
                     labels.Remove(label);
                     label.Dispose();
+                    removed = true;
                     break;
                 }
-                LayoutLabels(labels);
+
+                if (removed)
+                {
+                    LayoutLabels(labels);
+                }
+
                 _parent.ResumeLayout();
             });
         }
@@ -110,7 +117,7 @@ namespace AltitudeAngelWings.Plugin
             }
         }
 
-        private void LayoutLabels(ICollection<Label> labels)
+        private void LayoutLabels(IEnumerable<Label> labels)
         {
             var totalHeight = 0;
             foreach (var label in labels)

--- a/ExtLibs/AltitudeAngelWings/ObservableProperty.cs
+++ b/ExtLibs/AltitudeAngelWings/ObservableProperty.cs
@@ -7,7 +7,7 @@ namespace AltitudeAngelWings
 {
     public class ObservableProperty<T> : INotifyPropertyChanged, IObservable<T>, IDisposable
     {
-        private readonly ISubject<T> _subject;
+        private readonly ReplaySubject<T> _subject;
         private T _value;
 
         public ObservableProperty()
@@ -68,7 +68,7 @@ namespace AltitudeAngelWings
         {
             if (disposing)
             {
-                ((IDisposable)_subject)?.Dispose();
+                _subject?.Dispose();
             }
         }
 

--- a/ExtLibs/AltitudeAngelWings/Service/Messaging/IMessagesService.cs
+++ b/ExtLibs/AltitudeAngelWings/Service/Messaging/IMessagesService.cs
@@ -5,7 +5,6 @@ namespace AltitudeAngelWings.Service.Messaging
 {
     public interface IMessagesService
     {
-        ObservableProperty<Message> Messages { get; }
         Task AddMessageAsync(Message message);
     }
 }


### PR DESCRIPTION
On long flights the message display would progressively consume more CPU and memory, eventually making Mission Planner very slow. This PR fixes that problem. The cause was to do with the async calls trying to context switch between the same context and too many context. Instead, the context is now disconnected from the async calls so removing a message can happen in a different context from adding. In addition, the number of contexts being created has been reduced.