### PR TITLE
WPOverlay: fix loiter circle rendering

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -193,7 +193,8 @@ namespace MissionPlanner.ArduPilot
                                 if (dist > this_loiterradius)
                                 {
                                     route.Add(pointlist[pointlist.Count - 1]);
-                                    var offset = from.newpos(bearing - loiterdirection*90, this_loiterradius);
+                                    var theta = Math.Acos(this_loiterradius / dist) * MathHelper.rad2deg;
+                                    var offset = from.newpos(bearing - loiterdirection*theta, this_loiterradius);
                                     route.Add(offset);
                                 }
                                 else


### PR DESCRIPTION
Loiter circles should draw at their individually-specified radii, if specified. Also, the exit tangent was hard-coded to assume counter-clockwise orbits.

Additionally, I made a minor correction to where the tangent point is drawn, so that it's truly tangent to the circle. Previously we were just adding/subtracting 90 degrees from the bearing.