### PR TITLE
WPOverlay: treat VTOL_LAND like LAND

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -72,7 +72,7 @@ namespace MissionPlanner.ArduPilot
                     || command == (ushort) MAVLink.MAV_CMD.DO_SET_ROI || command == (ushort)MAVLink.MAV_CMD.DO_LAND_START)
                 {
                     // land can be 0,0 or a lat,lng
-                    if (command == (ushort) MAVLink.MAV_CMD.LAND && item.lat == 0 && item.lng == 0)
+                    if ((command == (ushort)MAVLink.MAV_CMD.LAND || command == (ushort)MAVLink.MAV_CMD.VTOL_LAND) && item.lat == 0 && item.lng == 0)
                     {
                         continue;
                     }
@@ -96,7 +96,7 @@ namespace MissionPlanner.ArduPilot
                         addpolygonmarker((a + 1).ToString(), item.lng, item.lat,
                             item.alt * altunitmultiplier, null, wpradius);
                     } 
-                    else if (command == (ushort) MAVLink.MAV_CMD.LAND && item.lat != 0 && item.lng != 0)
+                    else if ((command == (ushort) MAVLink.MAV_CMD.LAND || command == (ushort) MAVLink.MAV_CMD.VTOL_LAND) && item.lat != 0 && item.lng != 0)
                     {
                         pointlist.Add(new PointLatLngAlt(item.lat, item.lng,
                             item.alt + gethomealt((MAVLink.MAV_FRAME) item.frame, item.lat, item.lng),


### PR DESCRIPTION
Don't draw connecting lines from a VTOL_LAND to the next waypoint.

Before:
![Screenshot 2023-11-17 123335](https://github.com/ArduPilot/MissionPlanner/assets/14059190/a3248211-8f34-4795-a914-fce2e84c2226)


After:
![image](https://github.com/ArduPilot/MissionPlanner/assets/14059190/f75c5f25-4e45-4a87-a74d-df79767ea4fc)
