### PR TITLE
BinaryLog: escape characters in byte arrays

### DIFF
--- a/ExtLibs/Utilities/BinaryLog.cs
+++ b/ExtLibs/Utilities/BinaryLog.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.IO;
 using System.Runtime.InteropServices;
 using uint8_t = System.Byte;
+using System.Diagnostics;
 
 namespace MissionPlanner.Utilities
 {
@@ -158,7 +159,18 @@ namespace MissionPlanner.Utilities
                                                   if (a.IsNumber())
                                                       return (((IConvertible)a).ToString(CultureInfo.InvariantCulture));
                                                   else if (a is System.Byte[])
-                                                      return System.Text.Encoding.ASCII.GetString(a as byte[]).Trim('\0');
+                                                  {
+                                                      var str = Encoding.ASCII.GetString(a as byte[]).Trim('\0');
+                                                      // Escape \ as \\
+                                                      str = str.Replace("\\", "\\\\");
+                                                      // Escape certain whitespace characters
+                                                      str = str.Replace("\n", "\\n");
+                                                      str = str.Replace("\r", "\\r");
+                                                      str = str.Replace("\t", "\\t");
+                                                      // Escape all other non-printable characters
+                                                      str = str.Select(c => (c < 32 || c > 127) ? $"\\x{Convert.ToByte(c):X2}" : $"{c}").Aggregate((x, y) => $"{x}{y}");
+                                                      return str;
+                                                  }
                                                   else
                                                       return a?.ToString();
                                               })) + "\r\n";


### PR DESCRIPTION
Some byte arrays in logs are raw binary data, containing problematic characters (like newlines and other unprintables). Others are printable strings meant to be displayed. This allows both to be handled.

This fixes an issue Randy was having with "FILE" messages containing newlines, which was messing up a .log analysis he's working on.