### PR TITLE
ConfigRawParams: Various bugfixes

### DIFF
--- a/Controls/MyDataGridView.cs
+++ b/Controls/MyDataGridView.cs
@@ -6,6 +6,10 @@ namespace MissionPlanner.Controls
 {
     public class MyDataGridView : DataGridView
     {
+        public MyDataGridView() : base()
+        {
+            this.DoubleBuffered = true;            
+        }
         protected override void OnPaint(PaintEventArgs e)
         {
             // mono bug - when deleting all rows, the sharedrow no longer exists and throws System.ArgumentOutOfRangeException

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -1002,7 +1002,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         // Create and place the relevant control in the options column when a row is entered
         private void Params_RowEnter(object sender, DataGridViewCellEventArgs e)
         {
-            if (e.RowIndex < 1)
+            if (e.RowIndex < 0)
                 return;
             
             if (optionsControl != null)

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -644,10 +644,24 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             treeView1.Nodes.Clear();
             var currentNode = treeView1.Nodes.Add("All");
             string currentPrefix = "";
-            DataGridViewRowCollection rows = Params.Rows;
-            for (int i = 0; i < rows.Count; i++)
+
+            // Get command names from the gridview
+            List<string> commands = new List<string>();
+            foreach (DataGridViewRow row in Params.Rows)
             {
-                string param = rows[i].Cells[Command.Index].Value.ToString();
+                string command = row.Cells[Command.Index].Value.ToString();
+                if (!commands.Contains(command))
+                {
+                    commands.Add(command);
+                }
+            }
+
+            // Sort them again (because of the favorites, they may be out of order)
+            commands.Sort();
+
+            for (int i = 0; i < commands.Count; i++)
+            {
+                string param = commands[i];
 
                 // While param does not start with currentPrefix, step up a layer in the tree
                 while (!param.StartsWith(currentPrefix))
@@ -657,13 +671,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 }
 
                 // If this is the last parameter, add it
-                if (i == rows.Count - 1)
+                if (i == commands.Count - 1)
                 {
                     currentNode.Nodes.Add(param);
                     break;
                 }
 
-                string next_param = rows[i + 1].Cells[Command.Index].Value.ToString();
+                string next_param = commands[i + 1];
                 // While the next parameter has a common prefix with this, add branch nodes
                 string nodeToAdd = param.Substring(currentPrefix.Length).Split('_')[0] + "_";
                 while (nodeToAdd.Length > 1 // While the currentPrefix is smaller than param


### PR DESCRIPTION
1) Add double buffering to MyDataGridView. Prevents dangerous graphical corruption that can occur when scrolling, causing the name of the parameter you are editing to look like a different parameter. See this example; the `CAN_P1_BITRATE` parameter is falsely labeled as `CAN_LOGLEVEL`:
![image](https://github.com/ArduPilot/MissionPlanner/assets/14059190/5750d21f-2364-42b9-8825-b9bf27000fcd)
2) Fix an off-by-one error on a row-check that broke additional controls, like the bitmask button, on row 1
![image](https://github.com/ArduPilot/MissionPlanner/assets/14059190/606b4092-b669-4f54-8c67-0bc28ad5e00e)
3) Stop the tree view from taking favorites into account:
![image](https://github.com/ArduPilot/MissionPlanner/assets/14059190/ac222e3d-f7a9-435d-8a35-55412b5b692c)

