### PR TITLE
Fix Transponder ON Btn Display Cond to Match ON_btn_Click Definition

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -6155,8 +6155,8 @@ namespace MissionPlanner.GCSViews
                                                              !Mode_clb.GetItemChecked(2) && 
                                                              !Mode_clb.GetItemChecked(3)) ? FontStyle.Bold : FontStyle.Regular);
                     ON_btn.Font   = new Font(ON_btn.Font,   ( Mode_clb.GetItemChecked(0) &&
-                                                              Mode_clb.GetItemChecked(1) &&
-                                                             !Mode_clb.GetItemChecked(2) &&
+                                                             !Mode_clb.GetItemChecked(1) &&
+                                                              Mode_clb.GetItemChecked(2) &&
                                                               Mode_clb.GetItemChecked(3)) ? FontStyle.Bold : FontStyle.Regular);
                     ALT_btn.Font  = new Font(ALT_btn.Font,  ( Mode_clb.GetItemChecked(0) &&
                                                               Mode_clb.GetItemChecked(1) &&


### PR DESCRIPTION
The ON_btn_Click function correctly turns Mode C off; but the check for which mode the transponder is currently in wrongly assumes that Mode S must be off. To reproduce the bug this causes, 
- Connect to a transponder and set the mode to ON -> The mode text turns bold.
- Click Away from Mission Planner and the mode text will return to regular.
- This is not the case when you set the mode to be STBY or ALT.

To fix, I changed the condition check to match the definition.