### PR TITLE
ConnectionOptions fixes

### DIFF
--- a/Controls/ConnectionOptions.cs
+++ b/Controls/ConnectionOptions.cs
@@ -32,9 +32,15 @@ namespace MissionPlanner.Controls
 
             try
             {
-                MainV2.instance.doConnect(mav, CMB_serialport.Text, CMB_baudrate.Text);
+                // Connect, but don't try to get params yet, the serial reader thread doesn't try to
+                // read from this port until we add it to Comports, and it cannot be added to Comports
+                // until the BaseStream is open.
+                MainV2.instance.doConnect(mav, CMB_serialport.Text, CMB_baudrate.Text, getparams:false);
 
                 MainV2.Comports.Add(mav);
+
+                // It is now safe to fetch params
+                mav.getParamList();
 
                 MainV2._connectionControl.UpdateSysIDS();
             }

--- a/Program.cs
+++ b/Program.cs
@@ -385,7 +385,11 @@ namespace MissionPlanner
 
             // generic status report screen
             MAVLinkInterface.CreateIProgressReporterDialogue += title =>
-                new ProgressReporterDialogue() {StartPosition = FormStartPosition.CenterScreen, Text = title};
+            {
+                var ret = new ProgressReporterDialogue() {StartPosition = FormStartPosition.CenterScreen, Text = title};
+                ThemeManager.ApplyThemeTo(ret);
+                return ret;
+            };
 
             Console.WriteLine("Setup proxy");
             try


### PR DESCRIPTION
When launching redundant links with `ConnectionOptions`, it would always use the old-school param download, and the theme of the progress window would be wrong.