### PR TITLE
Joystick: fix expo saving function

### DIFF
--- a/ExtLibs/ArduPilot/Joystick/JoystickBase.cs
+++ b/ExtLibs/ArduPilot/Joystick/JoystickBase.cs
@@ -213,6 +213,11 @@ namespace MissionPlanner.Joystick
             JoyChannels[channel].axis = axis;
         }
 
+        public void setExpo(int channel, int expo)
+        {
+            JoyChannels[channel].expo = expo;
+        }
+
         public void setChannel(int channel, joystickaxis axis, bool reverse, int expo)
         {
             JoyChannel joy = new JoyChannel();

--- a/Joystick/JoystickSetup.cs
+++ b/Joystick/JoystickSetup.cs
@@ -95,6 +95,13 @@ namespace MissionPlanner.Joystick
                     return (short)MainV2.comPort.MAV.cs.GetType().GetField("rcoverridech" + ax.ChannelNo)
                         .GetValue(MainV2.comPort.MAV.cs);
                 };
+                ax.Expo = () =>
+                {
+                    if (int.TryParse(ax.ExpoValue, out int expoValue))
+                    {
+                        MainV2.joystick?.setExpo(ax.ChannelNo, expoValue);
+                    }
+                };
 
                 Controls.Add(ax);
 


### PR DESCRIPTION
This fixes the issue where the Expo values for the Joystick configuration were not being saved correctly.