### PR TITLE
CurrentState: honor MAVLinkInterface.speechenable

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -2827,6 +2827,7 @@ namespace MissionPlanner
                                 try
                                 {
                                     if (oldmode != mode && Speech != null && Speech.speechEnable &&
+                                        parent?.parent?.speechenabled == true &&
                                         parent?.parent?.MAV?.cs == this &&
                                         Settings.Instance.GetBoolean("speechmodeenabled") &&
                                         (armed || !Settings.Instance.GetBoolean("speech_armed_only")))
@@ -3324,6 +3325,7 @@ namespace MissionPlanner
                             try
                             {
                                 if (oldwp != wpno && Speech != null && Speech.speechEnable && parent != null &&
+                                    parent.parent.speechenabled &&
                                     parent.parent.MAV.cs == this &&
                                     Settings.Instance.GetBoolean("speechwaypointenabled") &&
                                     (armed || !Settings.Instance.GetBoolean("speech_armed_only")))


### PR DESCRIPTION
Some speech events, like mode changes, fire off on all connected com ports, not just the primary. Additionally, `CurrentState` ignores the `speechenable` flag of the `MAVLinkInterface` that it's attached to, causing it to go off even for interfaces that are supposed to be silent.

This PR makes `CurrentState` honor the `speechenable` flag. Additionally, it sets `speechenable` on an interface when `MainV2.comPort` is set to that interface, and clears `speechenable` on the old interface that `MainV2.comPort` was pointing to.