### PR TITLE
MAVLinkInterface: remove legacy text severity

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -5276,25 +5276,11 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
 
                         bool printit = false;
 
-                        // the change of severity and the autopilot version where introduced at the same time, so any version non 0 can be used
-                        // copter 3.4+
-                        // plane 3.4+
                         MAV_SEVERITY mavsev = MAV_SEVERITY.EMERGENCY;
-                        if (MAVlist[sysid, compidcurrent].cs.version.Major > 0 ||
-                            MAVlist[sysid, compidcurrent].cs.version.Minor >= 4)
+                        if (sev <= (byte)Settings.Instance.GetInt32("severity", 4))
                         {
-                            if (sev <= (byte)Settings.Instance.GetInt32("severity", 4))
-                            {
-                                printit = true;
-                                mavsev = (MAV_SEVERITY)sev;
-                            }
-                        }
-                        else
-                        {
-                            if (sev >= 3)
-                            {
-                                printit = true;
-                            }
+                            printit = true;
+                            mavsev = (MAV_SEVERITY)sev;
                         }
 
                         if (logdata.StartsWith("Tuning:") || logdata.StartsWith("PreArm:") ||


### PR DESCRIPTION
Sometimes a statustext sneaks through before the version comes in. ArduPilot 3.4 came out in 2015, so I think we can safely remove this now. I could do something backward-compatible instead if we want, but it would be messy.