### PR TITLE
RTS enable is now settable with a checkbox under the COM port selector

### DIFF
--- a/Controls/ConnectionControl.Designer.cs
+++ b/Controls/ConnectionControl.Designer.cs
@@ -33,6 +33,7 @@
             this.cmb_Connection = new System.Windows.Forms.ComboBox();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.cmb_sysid = new System.Windows.Forms.ComboBox();
+            this.chk_RTS = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // cmb_Baud
@@ -90,9 +91,18 @@
             this.cmb_sysid.SelectedIndexChanged += new System.EventHandler(this.CMB_sysid_SelectedIndexChanged);
             this.cmb_sysid.Format += new System.Windows.Forms.ListControlConvertEventHandler(this.cmb_sysid_Format);
             // 
+            // chk_RTS
+            // 
+            resources.ApplyResources(this.chk_RTS, "chk_RTS");
+            this.chk_RTS.BackColor = System.Drawing.Color.Black;
+            this.chk_RTS.ForeColor = System.Drawing.Color.White;
+            this.chk_RTS.Name = "chk_RTS";
+            this.chk_RTS.UseVisualStyleBackColor = false;
+            // 
             // ConnectionControl
             // 
             this.BackgroundImage = global::MissionPlanner.Properties.Resources.bgdark;
+            this.Controls.Add(this.chk_RTS);
             this.Controls.Add(this.cmb_sysid);
             this.Controls.Add(this.linkLabel1);
             this.Controls.Add(this.cmb_Connection);
@@ -112,5 +122,6 @@
         private System.Windows.Forms.ComboBox cmb_Connection;
         private System.Windows.Forms.LinkLabel linkLabel1;
         public System.Windows.Forms.ComboBox cmb_sysid;
+        private System.Windows.Forms.CheckBox chk_RTS;
     }
 }

--- a/Controls/ConnectionControl.cs
+++ b/Controls/ConnectionControl.cs
@@ -28,6 +28,10 @@ namespace MissionPlanner.Controls
             get { return this.cmb_Connection; }
         }
 
+        public CheckBox chk_RTSEnable
+        {
+            get { return this.chk_RTS; }
+        }
 
         /// <summary>
         /// Called from the main form - set whether we are connected or not currently.

--- a/Controls/ConnectionControl.resx
+++ b/Controls/ConnectionControl.resx
@@ -192,7 +192,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmb_Baud.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="cmb_Connection.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
@@ -216,7 +216,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmb_Connection.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -246,7 +246,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="cmb_sysid.Location" type="System.Drawing.Point, System.Drawing">
     <value>102, 27</value>
@@ -267,6 +267,33 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmb_sysid.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chk_RTS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_RTS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>49, 30</value>
+  </data>
+  <data name="chk_RTS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 17</value>
+  </data>
+  <data name="chk_RTS.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="chk_RTS.Text" xml:space="preserve">
+    <value>RTS</value>
+  </data>
+  <data name="&gt;&gt;chk_RTS.Name" xml:space="preserve">
+    <value>chk_RTS</value>
+  </data>
+  <data name="&gt;&gt;chk_RTS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_RTS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_RTS.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -750,19 +750,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
 
                     count++;
 
-                    // if we get no data, try enableing rts/cts
-                    if (buffer.Length == 0 && BaseStream is SerialPort && start.AddSeconds(20) < DateTime.Now)
-                    {
-                        try
-                        {
-                            log.Debug("about to set RTS to " + !BaseStream.RtsEnable);
-                            BaseStream.RtsEnable = !BaseStream.RtsEnable;
-                        }
-                        catch
-                        {
-                        }
-                    }
-
                     // SLCAN check
                     if (Regex.IsMatch(plaintxtline, @"\rT[0-9A-Z]{9,32}$", RegexOptions.Multiline))
                     {

--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -108,6 +108,23 @@ namespace MissionPlanner.Utilities
             return result;
         }
 
+        public bool GetRTSEnable(string COMPort)
+        {
+            try
+            {
+                return bool.Parse(this[COMPort + "_RTSENABLE"]);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void SetRTSEnable(string COMPort, bool Enabled)
+        {
+            this[COMPort + "_RTSENABLE"] = Enabled.ToString();
+        }
+
         public string BaudRate
         {
             get
@@ -122,6 +139,18 @@ namespace MissionPlanner.Utilities
                 }
             }
             set { this[ComPort + "_BAUD"] = value; }
+        }
+
+        public bool RtsEnable
+        {
+            get
+            {
+                return GetRTSEnable(ComPort);
+            }
+            set 
+            { 
+                SetRTSEnable(ComPort, value); 
+            }
         }
 
         public string LogDir

--- a/GCSViews/ConfigurationView/ConfigFirmwareManifest.cs
+++ b/GCSViews/ConfigurationView/ConfigFirmwareManifest.cs
@@ -537,7 +537,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // connect to mavlink
             var mav = new MAVLinkInterface();
             MainV2.instance.doConnect(mav, MainV2._connectionControl.CMB_serialport.Text,
-                MainV2._connectionControl.CMB_baudrate.Text, false);
+                MainV2._connectionControl.CMB_baudrate.Text, false, RTSEnable: MainV2._connectionControl.chk_RTSEnable.Checked);
 
             if (mav.BaseStream == null || !mav.BaseStream.IsOpen)
             {

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -1506,7 +1506,8 @@ namespace MissionPlanner
             this.MenuConnect.Image = global::MissionPlanner.Properties.Resources.light_connect_icon;
         }
 
-        public void doConnect(MAVLinkInterface comPort, string portname, string baud, bool getparams = true, bool showui = true)
+        public void doConnect(MAVLinkInterface comPort, string portname, string baud, bool getparams = true, bool showui = true,
+            bool RTSEnable = false)
         {
             bool skipconnectcheck = false;
             log.Info($"We are connecting to {portname} {baud}");
@@ -1607,6 +1608,7 @@ namespace MissionPlanner
                 {
                     if (baud != "" && baud != "0" && baud.IsNumber())
                         comPort.BaseStream.BaudRate = int.Parse(baud);
+                    comPort.BaseStream.RtsEnable = RTSEnable;
                 }
                 catch (Exception exp)
                 {
@@ -1924,7 +1926,7 @@ namespace MissionPlanner
             }
             else
             {
-                doConnect(comPort, _connectionControl.CMB_serialport.Text, _connectionControl.CMB_baudrate.Text);
+                doConnect(comPort, _connectionControl.CMB_serialport.Text, _connectionControl.CMB_baudrate.Text, RTSEnable: _connectionControl.chk_RTSEnable.Checked);
             }
 
             _connectionControl.UpdateSysIDS();
@@ -2010,6 +2012,8 @@ namespace MissionPlanner
             {
                 _connectionControl.CMB_baudrate.Enabled = true;
             }
+            _connectionControl.chk_RTSEnable.Enabled = _connectionControl.CMB_baudrate.Enabled;
+            _connectionControl.chk_RTSEnable.Visible = _connectionControl.chk_RTSEnable.Enabled;
 
             try
             {
@@ -2018,7 +2022,15 @@ namespace MissionPlanner
                 {
                     _connectionControl.CMB_baudrate.Text =
                         Settings.Instance[_connectionControl.CMB_serialport.Text.Replace(" ", "_") + "_BAUD"];
-                }
+                }   
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                _connectionControl.chk_RTSEnable.Checked = Settings.Instance.GetRTSEnable(_connectionControl.CMB_serialport.Text);
             }
             catch
             {
@@ -2258,6 +2270,8 @@ namespace MissionPlanner
 
                 if (_connectionControl != null)
                     Settings.Instance.BaudRate = _connectionControl.CMB_baudrate.Text;
+
+                Settings.Instance.RtsEnable = _connectionControl.chk_RTSEnable.Checked;
 
                 Settings.Instance.APMFirmware = MainV2.comPort.MAV.cs.firmware.ToString();
 


### PR DESCRIPTION
When a modem is used which is configured with hardware flow control (RTS/CTS) enabled, mission planner took about 20 seconds to connect to the aircraft, before it automatically changed itself to also use hardware flow control.  

This pull request adds a checkbox ("RTS") under the COM port selector, to manually enable or disable hardware flow control, and removes to auto switch over.  Testing shows that this removes the 20 second idle when connecting to a remote aircraft, when using a modem with hardware flow control enabled.  