### PR TITLE
MavlinkNumericUpDown: adjusted to consider scale for Min and Max values

### DIFF
--- a/Controls/MavlinkNumericUpDown.cs
+++ b/Controls/MavlinkNumericUpDown.cs
@@ -84,8 +84,8 @@ namespace MissionPlanner.Controls
                     Increment = (float) Inc;
 
             _scale = Scale;
-            this.Minimum = (decimal)(Min);
-            this.Maximum = (decimal)(Max);
+            this.Minimum = (decimal)(Min / _scale);
+            this.Maximum = (decimal)(Max / _scale);
             this.Increment = (decimal)(Increment);
             this.DecimalPlaces = BitConverter.GetBytes(decimal.GetBits((decimal)Increment)[3])[2];
 


### PR DESCRIPTION
Implemented unit conversion for RTL_ALT's minimum and maximum values in Geo Fence screen to allow setting RTL Altitude[m] below 200m.

"RTL Altitude[m]" on the Geo Fence screen cannot be set to less than the current setting.
![image](https://github.com/ArduPilot/MissionPlanner/assets/16643069/8ba58145-8b26-42da-8595-d0466e23d3f7)

The setting must be changed in the Full Parameter List.

The cause was that the minimum value for RTL_ALT is 200 cm and the conversion of units is not taken into account.
In this PR, units are now taken into account for the minimum and maximum.