### PR TITLE
GMapMarkerBase: add options for transparent MAVs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -157,7 +157,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: com.michaeloborne.MissionPlanner.apk.zip
-          path: ExtLibs\Xamarin\Xamarin.Android\bin\Release\*-signed.apk
+          path: ExtLibs\Xamarin\Xamarin.Android\bin\Release/${{ github.event_name == 'push' && '*-signed.apk' || '*.apk' }}
           
       - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         if: ${{ github.event_name == 'push' }}

--- a/Common.cs
+++ b/Common.cs
@@ -43,6 +43,7 @@ namespace MissionPlanner
                         itemp.Target = MAV.cs.target_bearing;
                         itemp.Nav_bearing = MAV.cs.nav_bearing;
                         itemp.Radius = (float)CurrentState.fromDistDisplayUnit(MAV.cs.radius);
+                        itemp.IsActive = MAV == MainV2.comPort?.MAV;
                         return null;
                     }
                     else if (item is GMapMarkerQuad)
@@ -53,6 +54,7 @@ namespace MissionPlanner
                         itemq.Cog = MAV.cs.groundcourse;
                         itemq.Target = MAV.cs.nav_bearing;
                         itemq.Sysid = MAV.sysid;
+                        itemq.IsActive = MAV == MainV2.comPort?.MAV;
                         return null;
                     }
                     else if (item is GMapMarkerRover)
@@ -63,6 +65,7 @@ namespace MissionPlanner
                         itemr.Cog = MAV.cs.groundcourse;
                         itemr.Target = MAV.cs.target_bearing;
                         itemr.Nav_bearing = MAV.cs.nav_bearing;
+                        itemr.IsActive = MAV == MainV2.comPort?.MAV;
                         return null;
                     }
                     else
@@ -71,53 +74,112 @@ namespace MissionPlanner
                     }
                 }
             }
-
-            if (MAV.aptype == MAVLink.MAV_TYPE.FIXED_WING || MAV.aptype >= MAVLink.MAV_TYPE.VTOL_DUOROTOR && MAV.aptype <= MAVLink.MAV_TYPE.VTOL_RESERVED5)
+            if (MAV.aptype == MAVLink.MAV_TYPE.FIXED_WING ||
+                MAV.aptype >= MAVLink.MAV_TYPE.VTOL_DUOROTOR && MAV.aptype <= MAVLink.MAV_TYPE.VTOL_RESERVED5)
             {
-                return (new GMapMarkerPlane(MAV.sysid - 1, portlocation, MAV.cs.yaw,
-                    MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.cs.target_bearing,
-                    (float)CurrentState.toDistDisplayUnit(MAV.cs.radius))
+                return new GMapMarkerPlane(
+                    MAV.sysid - 1,
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing,
+                    MAV.cs.target_bearing,
+                    (float)CurrentState.fromDistDisplayUnit(MAV.cs.radius))
                 {
+                    IsActive = MAV == MainV2.comPort?.MAV,
                     ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
-                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ? MarkerTooltipMode.Never : MarkerTooltipMode.Always,
+                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ?
+                                  MarkerTooltipMode.Never :
+                                  MarkerTooltipMode.Always,
                     Tag = MAV
-                });
+                };
             }
             else if (MAV.aptype == MAVLink.MAV_TYPE.GROUND_ROVER)
             {
-                return (new GMapMarkerRover(portlocation, MAV.cs.yaw,
-                    MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.cs.target_bearing)
+                return new GMapMarkerRover(
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing,
+                    MAV.cs.target_bearing)
                 {
-                    ToolTipText = MAV.cs.alt.ToString("0") + "\n" + MAV.sysid.ToString("sysid: 0"),
-                    ToolTipMode = MarkerTooltipMode.Always,
+                    IsActive = MAV == MainV2.comPort?.MAV,
+                    ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
+                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ?
+                                  MarkerTooltipMode.Never :
+                                  MarkerTooltipMode.Always,
                     Tag = MAV
-                });
+                };
             }
             else if (MAV.aptype == MAVLink.MAV_TYPE.SURFACE_BOAT)
             {
-                return (new GMapMarkerBoat(portlocation, MAV.cs.yaw,
-                    MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.cs.target_bearing){  Tag = MAV});
+                return new GMapMarkerBoat(
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing,
+                    MAV.cs.target_bearing)
+                {
+                    IsActive = MAV == MainV2.comPort?.MAV,
+                    ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
+                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ?
+                                  MarkerTooltipMode.Never :
+                                  MarkerTooltipMode.Always,
+                    Tag = MAV
+                };
             }
             else if (MAV.aptype == MAVLink.MAV_TYPE.SUBMARINE)
             {
-                return (new GMapMarkerSub(portlocation, MAV.cs.yaw,
-                    MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.cs.target_bearing){ Tag = MAV});
+                return new GMapMarkerSub(
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing,
+                    MAV.cs.target_bearing)
+                {
+                    IsActive = MAV == MainV2.comPort?.MAV,
+                    ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
+                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ?
+                                  MarkerTooltipMode.Never :
+                                  MarkerTooltipMode.Always,
+                    Tag = MAV
+                };
             }
             else if (MAV.aptype == MAVLink.MAV_TYPE.HELICOPTER)
             {
-                return (new GMapMarkerHeli(portlocation, MAV.cs.yaw,
-                    MAV.cs.groundcourse, MAV.cs.nav_bearing){ Tag = MAV});
+                return new GMapMarkerHeli(
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing)
+                {
+                    IsActive = MAV == MainV2.comPort?.MAV,
+                    ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
+                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ?
+                                  MarkerTooltipMode.Never :
+                                  MarkerTooltipMode.Always,
+                    Tag = MAV
+                };
             }
             else if (MAV.cs.firmware == Firmwares.ArduTracker)
             {
-                return (new GMapMarkerAntennaTracker(portlocation, MAV.cs.yaw,
-                    MAV.cs.target_bearing){ Tag = MAV});
+                return new GMapMarkerAntennaTracker(portlocation, MAV.cs.yaw, MAV.cs.target_bearing)
+                {
+                    Tag = MAV
+                };
             }
             else if (MAV.aptype == MAVLink.MAV_TYPE.COAXIAL)
             {
-                return (new GMapMarkerSingle(portlocation, MAV.cs.yaw,
-                   MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.sysid)
-                { Tag = MAV });
+                return new GMapMarkerSingle(
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing,
+                    MAV.sysid)
+                {
+                    IsActive = MAV == MainV2.comPort?.MAV,
+                    Tag = MAV
+                };
             }
             else if (MAV.cs.firmware == Firmwares.ArduCopter2 || MAV.aptype == MAVLink.MAV_TYPE.QUADROTOR)
             {
@@ -125,27 +187,38 @@ namespace MissionPlanner
                 {
                     var w = MAV.param["AVD_W_DIST_XY"].Value;
                     var f = MAV.param["AVD_F_DIST_XY"].Value;
-                    return (new GMapMarkerQuad(portlocation, MAV.cs.yaw,
-                        MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.sysid)
+                    return new GMapMarkerQuad(
+                        portlocation,
+                        MAV.cs.yaw,
+                        MAV.cs.groundcourse,
+                        MAV.cs.nav_bearing,
+                        MAV.sysid)
                     {
+                        IsActive = MAV == MainV2.comPort?.MAV,
                         danger = (int)f,
                         warn = (int)w,
                         Tag = MAV
-                    });
+                    };
                 }
 
-                return (new GMapMarkerQuad(portlocation, MAV.cs.yaw,
-                        MAV.cs.groundcourse, MAV.cs.nav_bearing, MAV.sysid)
+                return new GMapMarkerQuad(
+                    portlocation,
+                    MAV.cs.yaw,
+                    MAV.cs.groundcourse,
+                    MAV.cs.nav_bearing,
+                    MAV.sysid)
                 {
-                    ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
-                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ? MarkerTooltipMode.Never : MarkerTooltipMode.Always,
+                    IsActive = MAV == MainV2.comPort?.MAV,
                     Tag = MAV
-                });
+                };
             }
             else
             {
                 // unknown type
-                return (new GMarkerGoogle(portlocation, GMarkerGoogleType.green_dot) { Tag = MAV });
+                return new GMarkerGoogle(portlocation, GMarkerGoogleType.green_dot)
+                {
+                    Tag = MAV
+                };
             }
         }
         public static Form LoadingBox(string title, string promptText)

--- a/ExtLibs/Maps/GMapMarkerBase.cs
+++ b/ExtLibs/Maps/GMapMarkerBase.cs
@@ -9,15 +9,33 @@ namespace MissionPlanner.Maps
     [Serializable]
     public class GMapMarkerBase: GMapMarker
     {
-        public static bool DisplayCOG = true;
-        public static bool DisplayHeading = true;
-        public static bool DisplayNavBearing = true;
-        public static bool DisplayRadius = true;
-        public static bool DisplayTarget = true;
+        public static bool DisplayCOGSetting = true;
+        public static bool DisplayHeadingSetting = true;
+        public static bool DisplayNavBearingSetting = true;
+        public static bool DisplayRadiusSetting = true;
+        public static bool DisplayTargetSetting = true;
         public static int length = 500;
-
+        public static InactiveDisplayStyleEnum InactiveDisplayStyle = InactiveDisplayStyleEnum.Normal;
+        
+        // Instance variables
+        public bool IsActive = true;
+        protected bool IsHidden => InactiveDisplayStyle == InactiveDisplayStyleEnum.Hidden && !IsActive;
+        protected bool IsTransparent => InactiveDisplayStyle == InactiveDisplayStyleEnum.Transparent && !IsActive;
+        protected bool DisplayCOG => DisplayCOGSetting && !IsTransparent;
+        protected bool DisplayHeading => DisplayHeadingSetting && !IsTransparent;
+        protected bool DisplayNavBearing => DisplayNavBearingSetting && !IsTransparent;
+        protected bool DisplayRadius => DisplayRadiusSetting && !IsTransparent;
+        protected bool DisplayTarget => DisplayTargetSetting && !IsTransparent;
+        
         public GMapMarkerBase(PointLatLng pos):base(pos)
         {
+        }
+
+        public enum InactiveDisplayStyleEnum
+        {
+            Normal,
+            Transparent,
+            Hidden
         }
     }
 }

--- a/ExtLibs/Maps/GMapMarkerBoat.cs
+++ b/ExtLibs/Maps/GMapMarkerBoat.cs
@@ -30,6 +30,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if(IsHidden)
+            {
+                return;
+            }
+            
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -69,9 +74,21 @@ namespace MissionPlanner.Maps
             {
             }
 
+#if NET472_OR_GREATER
+            var img = Resources.boat;
+            var ia = new System.Drawing.Imaging.ImageAttributes();
+            if(IsTransparent)
+            {
+                // Draw image with transparency using a color matrix
+                var cm = new System.Drawing.Imaging.ColorMatrix { Matrix33 = 0.39f };
+                ia.SetColorMatrix(cm, System.Drawing.Imaging.ColorMatrixFlag.Default, System.Drawing.Imaging.ColorAdjustType.Bitmap);
+            }
+            g.DrawImage(img, new Rectangle(-img.Width / 2, -img.Width / 2, img.Width, img.Height), 0, 0, img.Width, img.Height, GraphicsUnit.Pixel, ia);
+#else
             g.DrawImageUnscaled(global::MissionPlanner.Maps.Resources.boat,
                 Size.Width / -2,
                 Size.Height / -2);
+#endif
 
             g.Transform = temp;
         }

--- a/ExtLibs/Maps/GMapMarkerHeli.cs
+++ b/ExtLibs/Maps/GMapMarkerHeli.cs
@@ -26,6 +26,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if (IsHidden)
+            {
+                return;
+            }
+            
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -59,7 +64,18 @@ namespace MissionPlanner.Maps
             {
             }
 
+#if NET472_OR_GREATER
+            var ia = new System.Drawing.Imaging.ImageAttributes();
+            if (IsTransparent)
+            {
+                // Draw image with transparency using a color matrix
+                var cm = new System.Drawing.Imaging.ColorMatrix { Matrix33 = 0.39f };
+                ia.SetColorMatrix(cm, System.Drawing.Imaging.ColorMatrixFlag.Default, System.Drawing.Imaging.ColorAdjustType.Bitmap);
+            }
+            g.DrawImage(icon, new Rectangle(-icon.Width / 2, -icon.Width / 2, icon.Width, icon.Height), 0, 0, icon.Width, icon.Height, GraphicsUnit.Pixel, ia);
+#else
             g.DrawImageUnscaled(icon, icon.Width / -2 + 2, icon.Height / -2);
+#endif
 
             g.Transform = temp;
         }

--- a/ExtLibs/Maps/GMapMarkerPlane.cs
+++ b/ExtLibs/Maps/GMapMarkerPlane.cs
@@ -74,6 +74,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if(IsHidden)
+            {
+                return;
+            }
+
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -165,20 +170,28 @@ namespace MissionPlanner.Maps
             // the plane
             g.TranslateTransform(-2, -2);
 
+            var color = Color.White;
             if (which % 7 == 0)
-                g.FillPolygon(Brushes.Red, plane);
+                color = Color.Red;
             if (which % 7 == 1)
-                g.FillPolygon(Brushes.Black, plane);
+                color = Color.Black;
             if (which % 7 == 2)
-                g.FillPolygon(Brushes.Blue, plane);
+                color = Color.Blue;
             if (which % 7 == 3)
-                g.FillPolygon(Brushes.LimeGreen, plane);
+                color = Color.LimeGreen;
             if (which % 7 == 4)
-                g.FillPolygon(Brushes.Yellow, plane);
+                color = Color.Yellow;
             if (which % 7 == 5)
-                g.FillPolygon(Brushes.Orange, plane);
+                color = Color.Orange;
             if (which % 7 == 6)
-                g.FillPolygon(Brushes.Pink, plane);
+                color = Color.Pink;
+
+            if(IsTransparent)
+            {
+                color = Color.FromArgb(100, color);
+            }
+
+            g.FillPolygon(new SolidBrush(color), plane);
 
             g.Transform = temp;
         }

--- a/ExtLibs/Maps/GMapMarkerQuad.cs
+++ b/ExtLibs/Maps/GMapMarkerQuad.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using GMap.NET;
 using GMap.NET.WindowsForms;
 using MissionPlanner.Utilities;
+using Org.BouncyCastle.Crypto.Signers;
 
 namespace MissionPlanner.Maps
 {
@@ -19,17 +20,94 @@ namespace MissionPlanner.Maps
         public float warn = -1;
         public float danger = -1;
 
-        static Color green = ExtensionsMaps.ColorFromHex("8dc63f");
-        static Color blue = ExtensionsMaps.ColorFromHex("00aeef");
-        static Pen greenpen = new Pen(green, 3);
-        static Pen bluepen = new Pen(blue, 3);
-        static SolidBrush greenbrush = new SolidBrush(green);
+        private static Pen _greenpen;
+        private static Pen _transparent_greenpen;
+        private static Pen _bluepen;
+        private static Pen _transparent_bluepen;
+        private static SolidBrush _greenbrush;
+        private static SolidBrush _transparent_greenbrush;
+        private static SolidBrush _textbrush;
+        private static SolidBrush _transparent_textbrush;
+
+        static Pen greenpen
+        {
+            set
+            {
+                _greenpen = value;
+                _transparent_greenpen = new Pen(Color.FromArgb(100, _greenpen.Color), _greenpen.Width);
+            }
+        }
+        static Pen bluepen
+        {
+            set
+            {
+                _bluepen = value;
+                _transparent_bluepen = new Pen(Color.FromArgb(100, _bluepen.Color), _bluepen.Width);
+            }
+        }
+        static SolidBrush greenbrush
+        {
+            set
+            {
+                _greenbrush = value;
+                _transparent_greenbrush = new SolidBrush(Color.FromArgb(100, _greenbrush.Color));
+            }
+        }
+
+        static SolidBrush textbrush
+        {
+            set
+            {
+                _textbrush = value;
+                _transparent_textbrush = new SolidBrush(Color.FromArgb(100, _textbrush.Color));
+            }
+        }
+
+        private Pen thisgreenpen
+        {
+            get
+            {
+                return IsTransparent ? _transparent_greenpen : _greenpen;
+            }
+        }
+
+        private Pen thisbluepen
+        {
+            get
+            {
+                return IsTransparent ? _transparent_bluepen : _bluepen;
+            }
+        }
+
+        private SolidBrush thisgreenbrush
+        {
+            get
+            {
+                return IsTransparent ? _transparent_greenbrush : _greenbrush;
+            }
+        }
+
+        private SolidBrush thistextbrush
+        {
+            get
+            {
+                return IsTransparent ? _transparent_textbrush : _textbrush;
+            }
+        }
 
         public float Heading { get => heading; set => heading = value; }
         public float Cog { get => cog; set => cog = value; }
         public float Target { get => target; set => target = value; }
         public int Sysid { get => sysid; set => sysid = value; }
         public float framerotation { get; set; } = 0;
+
+        static GMapMarkerQuad()
+        {
+            greenpen = new Pen(ExtensionsMaps.ColorFromHex("8dc63f"), 3);
+            bluepen = new Pen(ExtensionsMaps.ColorFromHex("00aeef"), _greenpen.Width);
+            greenbrush = new SolidBrush(_greenpen.Color);
+            textbrush = new SolidBrush(Color.Red);
+        }
 
         public GMapMarkerQuad(PointLatLng p, float heading, float cog, float target, int sysid)
             : base(p)
@@ -45,6 +123,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if (IsHidden)
+            {
+                return;
+            }
+
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
             g.TranslateTransform(-Offset.X, -Offset.Y);
@@ -88,27 +171,26 @@ namespace MissionPlanner.Maps
                 g.RotateTransform(framerotation);
 
                 //motors
-                g.DrawArc(greenpen, 35f - 10 + Offset.X, 12f - 10 + Offset.Y, 20, 20, 0, 360);
-                g.DrawArc(greenpen, 35f - 10 + Offset.X, 57f - 10 + Offset.Y, 20, 20, 0, 360);
-                g.DrawArc(greenpen, 57f - 10 + Offset.X, 35f - 10 + Offset.Y, 20, 20, 0, 360);
-                g.DrawArc(greenpen, 12f - 10 + Offset.X, 35f - 10 + Offset.Y, 20, 20, 0, 360);
+                g.DrawArc(thisgreenpen, 35f - 10 + Offset.X, 12f - 10 + Offset.Y, 20, 20, 0, 360);
+                g.DrawArc(thisgreenpen, 35f - 10 + Offset.X, 57f - 10 + Offset.Y, 20, 20, 0, 360);
+                g.DrawArc(thisgreenpen, 57f - 10 + Offset.X, 35f - 10 + Offset.Y, 20, 20, 0, 360);
+                g.DrawArc(thisgreenpen, 12f - 10 + Offset.X, 35f - 10 + Offset.Y, 20, 20, 0, 360);
 
-                g.DrawArc(greenpen, 35f - 2.5f + Offset.X, 12f - 2.5f + Offset.Y, 5, 5, 0, 360);
-                g.DrawArc(greenpen, 35f - 2.5f + Offset.X, 57f - 2.5f + Offset.Y, 5, 5, 0, 360);
-                g.DrawArc(greenpen, 57f - 2.5f + Offset.X, 35f - 2.5f + Offset.Y, 5, 5, 0, 360);
-                g.DrawArc(greenpen, 12f - 2.5f + Offset.X, 35f - 2.5f + Offset.Y, 5, 5, 0, 360);
+                g.DrawArc(thisgreenpen, 35f - 2.5f + Offset.X, 12f - 2.5f + Offset.Y, 5, 5, 0, 360);
+                g.DrawArc(thisgreenpen, 35f - 2.5f + Offset.X, 57f - 2.5f + Offset.Y, 5, 5, 0, 360);
+                g.DrawArc(thisgreenpen, 57f - 2.5f + Offset.X, 35f - 2.5f + Offset.Y, 5, 5, 0, 360);
+                g.DrawArc(thisgreenpen, 12f - 2.5f + Offset.X, 35f - 2.5f + Offset.Y, 5, 5, 0, 360);
                                 
-                g.DrawLine(bluepen, 35 + Offset.X, 12 + Offset.Y, 35 + Offset.X, 35 + Offset.Y);
-                g.DrawLine(greenpen, 35 + Offset.X, 36 + Offset.Y, 35 + Offset.X, 57 + Offset.Y);
-                g.DrawLine(greenpen, 57 + Offset.X, 35 + Offset.Y, 12 + Offset.X, 35 + Offset.Y);
+                g.DrawLine(thisbluepen, 35 + Offset.X, 12 + Offset.Y, 35 + Offset.X, 35 + Offset.Y);
+                g.DrawLine(thisgreenpen, 35 + Offset.X, 36 + Offset.Y, 35 + Offset.X, 57 + Offset.Y);
+                g.DrawLine(thisgreenpen, 57 + Offset.X, 35 + Offset.Y, 12 + Offset.X, 35 + Offset.Y);
 
-                g.FillRectangle(greenbrush, 32 + Offset.X, 30 + Offset.Y, 5, 8);
+                g.FillRectangle(thisgreenbrush, 32 + Offset.X, 30 + Offset.Y, 5, 8);
 
                 g.RotateTransform(-framerotation);
             }
 
-            g.DrawString(Sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), Brushes.Red, -8,
-              -8);
+            g.DrawString(Sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), thistextbrush, -8, -8);
 
             g.Transform = temp;
 

--- a/ExtLibs/Maps/GMapMarkerRover.cs
+++ b/ExtLibs/Maps/GMapMarkerRover.cs
@@ -35,6 +35,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if(IsHidden)
+            {
+                return;
+            }
+
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -73,10 +78,21 @@ namespace MissionPlanner.Maps
             catch
             {
             }
-
+#if NET472_OR_GREATER
+            var img = Resources.rover;
+            var ia = new System.Drawing.Imaging.ImageAttributes();
+            if (IsTransparent)
+            {
+                // Draw image with transparency using a color matrix
+                var cm = new System.Drawing.Imaging.ColorMatrix { Matrix33 = 0.39f };
+                ia.SetColorMatrix(cm, System.Drawing.Imaging.ColorMatrixFlag.Default, System.Drawing.Imaging.ColorAdjustType.Bitmap);
+            }
+            g.DrawImage(img, new Rectangle(-img.Width / 2, -img.Width / 2, img.Width, img.Height), 0, 0, img.Width, img.Height, GraphicsUnit.Pixel, ia);
+#else
             g.DrawImageUnscaled(global::MissionPlanner.Maps.Resources.rover,
                 Size.Width / -2,
                 Size.Height / -2);
+#endif
 
             g.Transform = temp;
         }

--- a/ExtLibs/Maps/GMapMarkerSingle.cs
+++ b/ExtLibs/Maps/GMapMarkerSingle.cs
@@ -28,6 +28,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if (IsHidden)
+            {
+                return;
+            }
+            
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -60,10 +65,23 @@ namespace MissionPlanner.Maps
             {
             }
 
-            g.DrawImageUnscaled(icon, icon.Width / -2 + 2, icon.Height / -2);
+            var fontBrush = new SolidBrush(Color.Red);
+#if NET472_OR_GREATER
+            var ia = new System.Drawing.Imaging.ImageAttributes();
+            if (IsTransparent)
+            {
+                // Draw image with transparency using a color matrix
+                var cm = new System.Drawing.Imaging.ColorMatrix { Matrix33 = 0.39f };
+                ia.SetColorMatrix(cm, System.Drawing.Imaging.ColorMatrixFlag.Default, System.Drawing.Imaging.ColorAdjustType.Bitmap);
 
-            g.DrawString(sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), Brushes.Red, -8,
-                -8);
+                fontBrush.Color = Color.FromArgb(100, fontBrush.Color);
+            }
+            g.DrawImage(icon, new Rectangle(-icon.Width / 2, -icon.Width / 2, icon.Width, icon.Height), 0, 0, icon.Width, icon.Height, GraphicsUnit.Pixel, ia);
+#else
+            g.DrawImageUnscaled(icon, icon.Width / -2 + 2, icon.Height / -2);
+#endif
+
+            g.DrawString(sysid.ToString(), new Font(FontFamily.GenericMonospace, 15, FontStyle.Bold), fontBrush, -8, -8);
 
             g.Transform = temp;
         }

--- a/ExtLibs/Maps/GMapMarkerSub.cs
+++ b/ExtLibs/Maps/GMapMarkerSub.cs
@@ -30,6 +30,11 @@ namespace MissionPlanner.Maps
 
         public override void OnRender(IGraphics g)
         {
+            if (IsHidden)
+            {
+                return;
+            }
+
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
 
@@ -68,7 +73,20 @@ namespace MissionPlanner.Maps
             catch
             {
             }
+
+#if NET472_OR_GREATER
+            var ia = new System.Drawing.Imaging.ImageAttributes();
+            if (IsTransparent)
+            {
+                // Draw image with transparency using a color matrix
+                var cm = new System.Drawing.Imaging.ColorMatrix { Matrix33 = 0.39f };
+                ia.SetColorMatrix(cm, System.Drawing.Imaging.ColorMatrixFlag.Default, System.Drawing.Imaging.ColorAdjustType.Bitmap);
+            }
+            g.DrawImage(imagecache, new Rectangle(-imagecache.Width / 2, -imagecache.Width / 2, imagecache.Width, imagecache.Height), 0, 0, imagecache.Width, imagecache.Height, GraphicsUnit.Pixel, ia);
+#else
             g.DrawImageUnscaled(imagecache, 59/-2, 59/-2);
+#endif
+
 
             g.Transform = temp;
         }

--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -108,8 +108,20 @@
             this.chk_slowMachine = new System.Windows.Forms.CheckBox();
             this.CHK_speechArmedOnly = new System.Windows.Forms.CheckBox();
             this.label8 = new System.Windows.Forms.Label();
+            this.label9 = new System.Windows.Forms.Label();
+            this.cmb_secondarydisplaystyle = new System.Windows.Forms.ComboBox();
+            this.chk_displaycog = new System.Windows.Forms.CheckBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.chk_displayheading = new System.Windows.Forms.CheckBox();
+            this.chk_displaynavbearing = new System.Windows.Forms.CheckBox();
+            this.chk_displayradius = new System.Windows.Forms.CheckBox();
+            this.chk_displaytarget = new System.Windows.Forms.CheckBox();
+            this.num_linelength = new System.Windows.Forms.NumericUpDown();
+            this.label11 = new System.Windows.Forms.Label();
+            this.chk_displaytooltip = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_gcsid)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.num_linelength)).BeginInit();
             this.SuspendLayout();
             // 
             // label33
@@ -119,6 +131,7 @@
             // 
             // CMB_ratesensors
             // 
+            resources.ApplyResources(this.CMB_ratesensors, "CMB_ratesensors");
             this.CMB_ratesensors.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_ratesensors.FormattingEnabled = true;
             this.CMB_ratesensors.Items.AddRange(new object[] {
@@ -137,7 +150,6 @@
             resources.GetString("CMB_ratesensors.Items12"),
             resources.GetString("CMB_ratesensors.Items13"),
             resources.GetString("CMB_ratesensors.Items14")});
-            resources.ApplyResources(this.CMB_ratesensors, "CMB_ratesensors");
             this.CMB_ratesensors.Name = "CMB_ratesensors";
             this.CMB_ratesensors.SelectedIndexChanged += new System.EventHandler(this.CMB_ratesensors_SelectedIndexChanged);
             // 
@@ -148,9 +160,9 @@
             // 
             // CMB_videoresolutions
             // 
+            resources.ApplyResources(this.CMB_videoresolutions, "CMB_videoresolutions");
             this.CMB_videoresolutions.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_videoresolutions.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_videoresolutions, "CMB_videoresolutions");
             this.CMB_videoresolutions.Name = "CMB_videoresolutions";
             // 
             // label12
@@ -184,12 +196,12 @@
             // 
             // NUM_tracklength
             // 
+            resources.ApplyResources(this.NUM_tracklength, "NUM_tracklength");
             this.NUM_tracklength.Increment = new decimal(new int[] {
             100,
             0,
             0,
             0});
-            resources.ApplyResources(this.NUM_tracklength, "NUM_tracklength");
             this.NUM_tracklength.Maximum = new decimal(new int[] {
             200000,
             0,
@@ -241,6 +253,7 @@
             // 
             // CMB_raterc
             // 
+            resources.ApplyResources(this.CMB_raterc, "CMB_raterc");
             this.CMB_raterc.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_raterc.FormattingEnabled = true;
             this.CMB_raterc.Items.AddRange(new object[] {
@@ -259,7 +272,6 @@
             resources.GetString("CMB_raterc.Items12"),
             resources.GetString("CMB_raterc.Items13"),
             resources.GetString("CMB_raterc.Items14")});
-            resources.ApplyResources(this.CMB_raterc, "CMB_raterc");
             this.CMB_raterc.Name = "CMB_raterc";
             this.CMB_raterc.SelectedIndexChanged += new System.EventHandler(this.CMB_raterc_SelectedIndexChanged);
             // 
@@ -285,6 +297,7 @@
             // 
             // CMB_ratestatus
             // 
+            resources.ApplyResources(this.CMB_ratestatus, "CMB_ratestatus");
             this.CMB_ratestatus.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_ratestatus.FormattingEnabled = true;
             this.CMB_ratestatus.Items.AddRange(new object[] {
@@ -303,12 +316,12 @@
             resources.GetString("CMB_ratestatus.Items12"),
             resources.GetString("CMB_ratestatus.Items13"),
             resources.GetString("CMB_ratestatus.Items14")});
-            resources.ApplyResources(this.CMB_ratestatus, "CMB_ratestatus");
             this.CMB_ratestatus.Name = "CMB_ratestatus";
             this.CMB_ratestatus.SelectedIndexChanged += new System.EventHandler(this.CMB_ratestatus_SelectedIndexChanged);
             // 
             // CMB_rateposition
             // 
+            resources.ApplyResources(this.CMB_rateposition, "CMB_rateposition");
             this.CMB_rateposition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_rateposition.FormattingEnabled = true;
             this.CMB_rateposition.Items.AddRange(new object[] {
@@ -327,12 +340,12 @@
             resources.GetString("CMB_rateposition.Items12"),
             resources.GetString("CMB_rateposition.Items13"),
             resources.GetString("CMB_rateposition.Items14")});
-            resources.ApplyResources(this.CMB_rateposition, "CMB_rateposition");
             this.CMB_rateposition.Name = "CMB_rateposition";
             this.CMB_rateposition.SelectedIndexChanged += new System.EventHandler(this.CMB_rateposition_SelectedIndexChanged);
             // 
             // CMB_rateattitude
             // 
+            resources.ApplyResources(this.CMB_rateattitude, "CMB_rateattitude");
             this.CMB_rateattitude.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_rateattitude.FormattingEnabled = true;
             this.CMB_rateattitude.Items.AddRange(new object[] {
@@ -350,7 +363,6 @@
             resources.GetString("CMB_rateattitude.Items11"),
             resources.GetString("CMB_rateattitude.Items12"),
             resources.GetString("CMB_rateattitude.Items13")});
-            resources.ApplyResources(this.CMB_rateattitude, "CMB_rateattitude");
             this.CMB_rateattitude.Name = "CMB_rateattitude";
             this.CMB_rateattitude.SelectedIndexChanged += new System.EventHandler(this.CMB_rateattitude_SelectedIndexChanged);
             // 
@@ -371,17 +383,17 @@
             // 
             // CMB_speedunits
             // 
+            resources.ApplyResources(this.CMB_speedunits, "CMB_speedunits");
             this.CMB_speedunits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_speedunits.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_speedunits, "CMB_speedunits");
             this.CMB_speedunits.Name = "CMB_speedunits";
             this.CMB_speedunits.SelectedIndexChanged += new System.EventHandler(this.CMB_speedunits_SelectedIndexChanged);
             // 
             // CMB_distunits
             // 
+            resources.ApplyResources(this.CMB_distunits, "CMB_distunits");
             this.CMB_distunits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_distunits.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_distunits, "CMB_distunits");
             this.CMB_distunits.Name = "CMB_distunits";
             this.CMB_distunits.SelectedIndexChanged += new System.EventHandler(this.CMB_distunits_SelectedIndexChanged);
             // 
@@ -430,27 +442,27 @@
             // 
             // CMB_osdcolor
             // 
+            resources.ApplyResources(this.CMB_osdcolor, "CMB_osdcolor");
             this.CMB_osdcolor.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.CMB_osdcolor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_osdcolor.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_osdcolor, "CMB_osdcolor");
             this.CMB_osdcolor.Name = "CMB_osdcolor";
             this.CMB_osdcolor.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.CMB_osdcolor_DrawItem);
             this.CMB_osdcolor.SelectedIndexChanged += new System.EventHandler(this.CMB_osdcolor_SelectedIndexChanged);
             // 
             // CMB_severity
             // 
+            resources.ApplyResources(this.CMB_severity, "CMB_severity");
             this.CMB_severity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_severity.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_severity, "CMB_severity");
             this.CMB_severity.Name = "CMB_severity";
             this.CMB_severity.SelectedIndexChanged += new System.EventHandler(this.CMB_severity_SelectedIndexChanged);
             // 
             // CMB_language
             // 
+            resources.ApplyResources(this.CMB_language, "CMB_language");
             this.CMB_language.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_language.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_language, "CMB_language");
             this.CMB_language.Name = "CMB_language";
             this.CMB_language.SelectedIndexChanged += new System.EventHandler(this.CMB_language_SelectedIndexChanged);
             // 
@@ -468,9 +480,9 @@
             // 
             // CHK_hudshow
             // 
+            resources.ApplyResources(this.CHK_hudshow, "CHK_hudshow");
             this.CHK_hudshow.Checked = true;
             this.CHK_hudshow.CheckState = System.Windows.Forms.CheckState.Checked;
-            resources.ApplyResources(this.CHK_hudshow, "CHK_hudshow");
             this.CHK_hudshow.Name = "CHK_hudshow";
             this.CHK_hudshow.UseVisualStyleBackColor = true;
             this.CHK_hudshow.CheckedChanged += new System.EventHandler(this.CHK_hudshow_CheckedChanged);
@@ -482,9 +494,9 @@
             // 
             // CMB_videosources
             // 
+            resources.ApplyResources(this.CMB_videosources, "CMB_videosources");
             this.CMB_videosources.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_videosources.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_videosources, "CMB_videosources");
             this.CMB_videosources.Name = "CMB_videosources";
             this.CMB_videosources.SelectedIndexChanged += new System.EventHandler(this.CMB_videosources_SelectedIndexChanged);
             this.CMB_videosources.Click += new System.EventHandler(this.CMB_videosources_Click);
@@ -508,9 +520,9 @@
             // 
             // CHK_disttohomeflightdata
             // 
+            resources.ApplyResources(this.CHK_disttohomeflightdata, "CHK_disttohomeflightdata");
             this.CHK_disttohomeflightdata.Checked = true;
             this.CHK_disttohomeflightdata.CheckState = System.Windows.Forms.CheckState.Checked;
-            resources.ApplyResources(this.CHK_disttohomeflightdata, "CHK_disttohomeflightdata");
             this.CHK_disttohomeflightdata.Name = "CHK_disttohomeflightdata";
             this.CHK_disttohomeflightdata.UseVisualStyleBackColor = true;
             this.CHK_disttohomeflightdata.CheckedChanged += new System.EventHandler(this.CHK_disttohomeflightdata_CheckedChanged);
@@ -519,6 +531,7 @@
             // 
             resources.ApplyResources(this.BUT_Joystick, "BUT_Joystick");
             this.BUT_Joystick.Name = "BUT_Joystick";
+            this.BUT_Joystick.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Joystick.UseVisualStyleBackColor = true;
             this.BUT_Joystick.Click += new System.EventHandler(this.BUT_Joystick_Click);
             // 
@@ -526,6 +539,7 @@
             // 
             resources.ApplyResources(this.BUT_videostop, "BUT_videostop");
             this.BUT_videostop.Name = "BUT_videostop";
+            this.BUT_videostop.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_videostop.UseVisualStyleBackColor = true;
             this.BUT_videostop.Click += new System.EventHandler(this.BUT_videostop_Click);
             // 
@@ -533,6 +547,7 @@
             // 
             resources.ApplyResources(this.BUT_videostart, "BUT_videostart");
             this.BUT_videostart.Name = "BUT_videostart";
+            this.BUT_videostart.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_videostart.UseVisualStyleBackColor = true;
             this.BUT_videostart.Click += new System.EventHandler(this.BUT_videostart_Click);
             // 
@@ -550,6 +565,7 @@
             // 
             resources.ApplyResources(this.BUT_logdirbrowse, "BUT_logdirbrowse");
             this.BUT_logdirbrowse.Name = "BUT_logdirbrowse";
+            this.BUT_logdirbrowse.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_logdirbrowse.UseVisualStyleBackColor = true;
             this.BUT_logdirbrowse.Click += new System.EventHandler(this.BUT_logdirbrowse_Click);
             // 
@@ -560,9 +576,9 @@
             // 
             // CMB_theme
             // 
+            resources.ApplyResources(this.CMB_theme, "CMB_theme");
             this.CMB_theme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_theme.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_theme, "CMB_theme");
             this.CMB_theme.Name = "CMB_theme";
             this.CMB_theme.SelectedIndexChanged += new System.EventHandler(this.CMB_theme_SelectedIndexChanged);
             // 
@@ -570,6 +586,7 @@
             // 
             resources.ApplyResources(this.BUT_themecustom, "BUT_themecustom");
             this.BUT_themecustom.Name = "BUT_themecustom";
+            this.BUT_themecustom.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_themecustom.UseVisualStyleBackColor = true;
             this.BUT_themecustom.Click += new System.EventHandler(this.BUT_themecustom_Click);
             // 
@@ -584,6 +601,7 @@
             // 
             resources.ApplyResources(this.BUT_Vario, "BUT_Vario");
             this.BUT_Vario.Name = "BUT_Vario";
+            this.BUT_Vario.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Vario.UseVisualStyleBackColor = true;
             this.BUT_Vario.Click += new System.EventHandler(this.BUT_Vario_Click);
             // 
@@ -656,9 +674,9 @@
             // 
             // CMB_Layout
             // 
+            resources.ApplyResources(this.CMB_Layout, "CMB_Layout");
             this.CMB_Layout.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_Layout.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_Layout, "CMB_Layout");
             this.CMB_Layout.Name = "CMB_Layout";
             this.CMB_Layout.SelectedIndexChanged += new System.EventHandler(this.CMB_Layout_SelectedIndexChanged);
             // 
@@ -692,9 +710,9 @@
             // 
             // CMB_altunits
             // 
+            resources.ApplyResources(this.CMB_altunits, "CMB_altunits");
             this.CMB_altunits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_altunits.FormattingEnabled = true;
-            resources.ApplyResources(this.CMB_altunits, "CMB_altunits");
             this.CMB_altunits.Name = "CMB_altunits";
             this.CMB_altunits.SelectedIndexChanged += new System.EventHandler(this.CMB_altunits_SelectedIndexChanged);
             // 
@@ -750,9 +768,103 @@
             resources.ApplyResources(this.label8, "label8");
             this.label8.Name = "label8";
             // 
+            // label9
+            // 
+            resources.ApplyResources(this.label9, "label9");
+            this.label9.Name = "label9";
+            // 
+            // cmb_secondarydisplaystyle
+            // 
+            resources.ApplyResources(this.cmb_secondarydisplaystyle, "cmb_secondarydisplaystyle");
+            this.cmb_secondarydisplaystyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmb_secondarydisplaystyle.FormattingEnabled = true;
+            this.cmb_secondarydisplaystyle.Name = "cmb_secondarydisplaystyle";
+            this.cmb_secondarydisplaystyle.SelectedIndexChanged += new System.EventHandler(this.cmb_secondarydisplaystyle_SelectedIndexChanged);
+            // 
+            // chk_displaycog
+            // 
+            resources.ApplyResources(this.chk_displaycog, "chk_displaycog");
+            this.chk_displaycog.Name = "chk_displaycog";
+            this.chk_displaycog.UseVisualStyleBackColor = true;
+            this.chk_displaycog.CheckedChanged += new System.EventHandler(this.chk_displaycog_CheckedChanged);
+            // 
+            // label10
+            // 
+            resources.ApplyResources(this.label10, "label10");
+            this.label10.Name = "label10";
+            // 
+            // chk_displayheading
+            // 
+            resources.ApplyResources(this.chk_displayheading, "chk_displayheading");
+            this.chk_displayheading.Name = "chk_displayheading";
+            this.chk_displayheading.UseVisualStyleBackColor = true;
+            this.chk_displayheading.CheckedChanged += new System.EventHandler(this.chk_displayheading_CheckedChanged);
+            // 
+            // chk_displaynavbearing
+            // 
+            resources.ApplyResources(this.chk_displaynavbearing, "chk_displaynavbearing");
+            this.chk_displaynavbearing.Name = "chk_displaynavbearing";
+            this.chk_displaynavbearing.UseVisualStyleBackColor = true;
+            this.chk_displaynavbearing.CheckedChanged += new System.EventHandler(this.chk_displaynavbearing_CheckedChanged);
+            // 
+            // chk_displayradius
+            // 
+            resources.ApplyResources(this.chk_displayradius, "chk_displayradius");
+            this.chk_displayradius.Name = "chk_displayradius";
+            this.chk_displayradius.UseVisualStyleBackColor = true;
+            this.chk_displayradius.CheckedChanged += new System.EventHandler(this.chk_displayradius_CheckedChanged);
+            // 
+            // chk_displaytarget
+            // 
+            resources.ApplyResources(this.chk_displaytarget, "chk_displaytarget");
+            this.chk_displaytarget.Name = "chk_displaytarget";
+            this.chk_displaytarget.UseVisualStyleBackColor = true;
+            this.chk_displaytarget.CheckedChanged += new System.EventHandler(this.chk_displaytarget_CheckedChanged);
+            // 
+            // num_linelength
+            // 
+            resources.ApplyResources(this.num_linelength, "num_linelength");
+            this.num_linelength.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.num_linelength.Maximum = new decimal(new int[] {
+            2000,
+            0,
+            0,
+            0});
+            this.num_linelength.Minimum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.num_linelength.Name = "num_linelength";
+            this.num_linelength.Value = new decimal(new int[] {
+            200,
+            0,
+            0,
+            0});
+            this.num_linelength.ValueChanged += new System.EventHandler(this.num_linelength_ValueChanged);
+            // 
+            // label11
+            // 
+            resources.ApplyResources(this.label11, "label11");
+            this.label11.Name = "label11";
+            // 
+            // chk_displaytooltip
+            // 
+            resources.ApplyResources(this.chk_displaytooltip, "chk_displaytooltip");
+            this.chk_displaytooltip.Name = "chk_displaytooltip";
+            this.chk_displaytooltip.UseVisualStyleBackColor = true;
+            this.chk_displaytooltip.CheckedChanged += new System.EventHandler(this.chk_displaytooltip_CheckedChanged);
+            // 
             // ConfigPlanner
             // 
             resources.ApplyResources(this, "$this");
+            this.Controls.Add(this.label10);
+            this.Controls.Add(this.cmb_secondarydisplaystyle);
+            this.Controls.Add(this.label9);
             this.Controls.Add(this.label8);
             this.Controls.Add(this.CHK_speechArmedOnly);
             this.Controls.Add(this.chk_slowMachine);
@@ -771,6 +883,12 @@
             this.Controls.Add(this.chk_ADSB);
             this.Controls.Add(this.CHK_showairports);
             this.Controls.Add(this.CHK_speechlowspeed);
+            this.Controls.Add(this.chk_displaytarget);
+            this.Controls.Add(this.chk_displayradius);
+            this.Controls.Add(this.chk_displaynavbearing);
+            this.Controls.Add(this.chk_displayheading);
+            this.Controls.Add(this.chk_displaytooltip);
+            this.Controls.Add(this.chk_displaycog);
             this.Controls.Add(this.CHK_Password);
             this.Controls.Add(this.CHK_beta);
             this.Controls.Add(this.chk_analytics);
@@ -790,11 +908,13 @@
             this.Controls.Add(this.CMB_ratesensors);
             this.Controls.Add(this.label26);
             this.Controls.Add(this.CMB_videoresolutions);
+            this.Controls.Add(this.label11);
             this.Controls.Add(this.label12);
             this.Controls.Add(this.CHK_GDIPlus);
             this.Controls.Add(this.label24);
             this.Controls.Add(this.CHK_loadwponconnect);
             this.Controls.Add(this.label23);
+            this.Controls.Add(this.num_linelength);
             this.Controls.Add(this.NUM_tracklength);
             this.Controls.Add(this.CHK_speechaltwarning);
             this.Controls.Add(this.label108);
@@ -836,6 +956,7 @@
             this.Load += new System.EventHandler(this.ConfigPlanner_Load);
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_gcsid)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.num_linelength)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -922,5 +1043,16 @@
         private System.Windows.Forms.CheckBox chk_slowMachine;
         private System.Windows.Forms.CheckBox CHK_speechArmedOnly;
         private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label9;
+        public System.Windows.Forms.ComboBox cmb_secondarydisplaystyle;
+        private System.Windows.Forms.CheckBox chk_displaycog;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.CheckBox chk_displayheading;
+        private System.Windows.Forms.CheckBox chk_displaynavbearing;
+        private System.Windows.Forms.CheckBox chk_displayradius;
+        private System.Windows.Forms.CheckBox chk_displaytarget;
+        private System.Windows.Forms.NumericUpDown num_linelength;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.CheckBox chk_displaytooltip;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -23,6 +23,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         public ConfigPlanner()
         {
+            startup = true;
+
             InitializeComponent();
             CMB_Layout.Items.Add(DisplayNames.Basic);
             CMB_Layout.Items.Add(DisplayNames.Advanced);
@@ -38,6 +40,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             CMB_severity.Items.Add(SeverityLevel.Notice);
             CMB_severity.Items.Add(SeverityLevel.Info);
             CMB_severity.Items.Add(SeverityLevel.Debug);
+
+            cmb_secondarydisplaystyle.DataSource = Enum.GetNames(typeof(Maps.GMapMarkerBase.InactiveDisplayStyleEnum));
+            cmb_secondarydisplaystyle.Text = Settings.Instance.GetString(
+                "GMapMarkerBase_InactiveDisplayStyle",
+                Maps.GMapMarkerBase.InactiveDisplayStyleEnum.Normal.ToString()
+            );
         }
 
 
@@ -222,6 +230,15 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
 
             txt_log_dir.Text = Settings.Instance.LogDir;
+
+            // Setup aircraft icon settings
+            chk_displaycog.Checked = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayCOG", true);
+            chk_displayheading.Checked = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayHeading", true);
+            chk_displaynavbearing.Checked = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayNavBearing", true);
+            chk_displayradius.Checked = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayRadius", true);
+            chk_displaytarget.Checked = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayTarget", true);
+            chk_displaytooltip.Checked = Settings.Instance.GetString("mapicondesc", "") != "";
+            num_linelength.Value = Settings.Instance.GetInt32("GMapMarkerBase_Length", 500);
 
             startup = false;
         }
@@ -1025,6 +1042,88 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             MainV2.speech_armed_only = CHK_speechArmedOnly.Checked;
             Settings.Instance["speech_armed_only"] = CHK_speechArmedOnly.Checked.ToString();
+        }
+
+        private void chk_displaycog_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Instance["GMapMarkerBase_DisplayCOG"] = chk_displaycog.Checked.ToString();
+            Maps.GMapMarkerBase.DisplayCOGSetting = chk_displaycog.Checked;
+        }
+
+        private void chk_displayheading_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Instance["GMapMarkerBase_DisplayHeading"] = chk_displayheading.Checked.ToString();
+            Maps.GMapMarkerBase.DisplayHeadingSetting = chk_displayheading.Checked;
+        }
+
+        private void chk_displaynavbearing_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Instance["GMapMarkerBase_DisplayNavBearing"] = chk_displaynavbearing.Checked.ToString();
+            Maps.GMapMarkerBase.DisplayNavBearingSetting = chk_displaynavbearing.Checked;
+        }
+
+        private void chk_displayradius_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Instance["GMapMarkerBase_DisplayRadius"] = chk_displayradius.Checked.ToString();
+            Maps.GMapMarkerBase.DisplayRadiusSetting = chk_displayradius.Checked;
+        }
+
+        private void chk_displaytarget_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Instance["GMapMarkerBase_DisplayTarget"] = chk_displaytarget.Checked.ToString();
+            Maps.GMapMarkerBase.DisplayTargetSetting = chk_displaytarget.Checked;
+        }
+
+        private void chk_displaytooltip_CheckedChanged(object sender, EventArgs e)
+        {
+            if (startup)
+            {
+                return;
+            }
+            if (chk_displaytooltip.Checked)
+            {
+                // Prompt user for text
+                var descstring = Settings.Instance["mapicondesc_default",
+                    "{alt}{altunit} {airspeed}{speedunit} id:{sysid} Sats:{satcount} HDOP:{gpshdop} Volts:{battery_voltage}"];
+
+                if (DialogResult.Cancel == InputBox.Show("Description", "What do you want it to show?", ref descstring))
+                {
+                    return;
+                }
+
+                Settings.Instance["mapicondesc"] = descstring;
+                Settings.Instance["mapicondesc_default"] = descstring;
+            }
+            else
+            {
+                Settings.Instance["mapicondesc"] = "";
+            }
+            
+        }
+
+        private void num_linelength_ValueChanged(object sender, EventArgs e)
+        {
+            Settings.Instance["GMapMarkerBase_length"] = num_linelength.Value.ToString();
+            Maps.GMapMarkerBase.length = (int)(num_linelength.Value);
+        }
+
+        private void cmb_secondarydisplaystyle_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if(startup)
+            {
+                return;
+            }
+            if (Enum.TryParse(cmb_secondarydisplaystyle.Text,
+                              out Maps.GMapMarkerBase.InactiveDisplayStyleEnum result))
+            {
+                Settings.Instance["GMapMarkerBase_InactiveDisplayStyle"] = cmb_secondarydisplaystyle.Text;
+                Maps.GMapMarkerBase.InactiveDisplayStyle = result;
+            }
+            else
+            {
+                Settings.Instance["GMapMarkerBase_InactiveDisplayStyle"] = Maps.GMapMarkerBase.InactiveDisplayStyleEnum.Normal.ToString();
+                Maps.GMapMarkerBase.InactiveDisplayStyle = Maps.GMapMarkerBase.InactiveDisplayStyleEnum.Normal;
+            }
         }
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.ko-KR.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.ko-KR.resx
@@ -128,7 +128,7 @@
     <value>545, 253</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label26.Text" xml:space="preserve">
     <value>영상 형식</value>
@@ -137,7 +137,7 @@
     <value>9, 352</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 16</value>
+    <value>84, 13</value>
   </data>
   <data name="label12.Text" xml:space="preserve">
     <value>투영 영상(HUD)</value>
@@ -152,7 +152,7 @@
     <value>9, 329</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>경로 지점</value>
@@ -167,7 +167,7 @@
     <value>9, 303</value>
   </data>
   <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label23.Text" xml:space="preserve">
     <value>트랙 길이</value>
@@ -179,7 +179,7 @@
     <value>592, 90</value>
   </data>
   <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 20</value>
+    <value>73, 17</value>
   </data>
   <data name="CHK_speechaltwarning.Text" xml:space="preserve">
     <value>고도 경고</value>
@@ -188,7 +188,7 @@
     <value>9, 280</value>
   </data>
   <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 16</value>
+    <value>65, 13</value>
   </data>
   <data name="label108.Text" xml:space="preserve">
     <value>연결 재설정</value>
@@ -200,7 +200,7 @@
     <value>USB 연결시 초기화(DTR 전환)</value>
   </data>
   <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 609</value>
+    <value>107, 627</value>
   </data>
   <data name="CHK_mavdebug.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 17</value>
@@ -248,7 +248,7 @@
     <value>9, 256</value>
   </data>
   <data name="label101.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 16</value>
+    <value>79, 13</value>
   </data>
   <data name="label101.Text" xml:space="preserve">
     <value>원격 측정 속도</value>
@@ -273,7 +273,7 @@
     <value>9, 227</value>
   </data>
   <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label98.Text" xml:space="preserve">
     <value>속력 단위</value>
@@ -282,7 +282,7 @@
     <value>9, 200</value>
   </data>
   <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label97.Text" xml:space="preserve">
     <value>거리 단위</value>
@@ -297,10 +297,13 @@
     <value>9, 173</value>
   </data>
   <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 16</value>
+    <value>51, 13</value>
   </data>
   <data name="label96.Text" xml:space="preserve">
     <value>조이스틱</value>
+  </data>
+  <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
+    <value>54, 13</value>
   </data>
   <data name="label95.Text" xml:space="preserve">
     <value>음성 안내</value>
@@ -309,7 +312,7 @@
     <value>489, 90</value>
   </data>
   <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 20</value>
+    <value>84, 17</value>
   </data>
   <data name="CHK_speechbattery.Text" xml:space="preserve">
     <value>배터리 경고</value>
@@ -318,7 +321,7 @@
     <value>409, 90</value>
   </data>
   <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>74, 17</value>
   </data>
   <data name="CHK_speechcustom.Text" xml:space="preserve">
     <value>30초 간격</value>
@@ -327,7 +330,7 @@
     <value>343, 89</value>
   </data>
   <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 20</value>
+    <value>51, 17</value>
   </data>
   <data name="CHK_speechmode.Text" xml:space="preserve">
     <value>모드 </value>
@@ -336,13 +339,13 @@
     <value>207, 89</value>
   </data>
   <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 20</value>
+    <value>73, 17</value>
   </data>
   <data name="CHK_speechwaypoint.Text" xml:space="preserve">
     <value>경로 지점</value>
   </data>
   <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 16</value>
+    <value>55, 13</value>
   </data>
   <data name="label94.Text" xml:space="preserve">
     <value>OSD 색상</value>
@@ -357,13 +360,13 @@
     <value>9, 141</value>
   </data>
   <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 16</value>
+    <value>87, 13</value>
   </data>
   <data name="label93.Text" xml:space="preserve">
     <value>인터페이스 언어</value>
   </data>
   <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 20</value>
+    <value>98, 17</value>
   </data>
   <data name="CHK_enablespeech.Text" xml:space="preserve">
     <value>음성 안내 활성</value>
@@ -375,13 +378,16 @@
     <value>투영 영상(HUD) 오버레이</value>
   </data>
   <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label92.Text" xml:space="preserve">
     <value>영상 장치</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 375</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 13</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>지도 따라가기</value>
@@ -420,7 +426,7 @@
     <value>9, 400</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 16</value>
+    <value>79, 13</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
     <value>로그 저장 경로</value>
@@ -438,7 +444,7 @@
     <value>9, 426</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 16</value>
+    <value>29, 13</value>
   </data>
   <data name="label4.Text" xml:space="preserve">
     <value>테마</value>
@@ -456,40 +462,28 @@
     <value>671, 90</value>
   </data>
   <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 20</value>
+    <value>75, 17</value>
   </data>
   <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
     <value>시동/제동</value>
   </data>
-  <data name="BUT_Vario.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 503</value>
-  </data>
   <data name="BUT_Vario.Text" xml:space="preserve">
     <value>승강계 켬/끔</value>
   </data>
-  <data name="chk_analytics.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 529</value>
-  </data>
   <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 20</value>
+    <value>98, 17</value>
   </data>
   <data name="chk_analytics.Text" xml:space="preserve">
     <value>익명 상황 제외</value>
   </data>
-  <data name="CHK_beta.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 529</value>
-  </data>
   <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 20</value>
+    <value>95, 17</value>
   </data>
   <data name="CHK_beta.Text" xml:space="preserve">
     <value>베타 업데이트</value>
   </data>
-  <data name="CHK_Password.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 506</value>
-  </data>
   <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 20</value>
+    <value>98, 17</value>
   </data>
   <data name="CHK_Password.Text" xml:space="preserve">
     <value>암호 보호 설정</value>
@@ -498,43 +492,31 @@
     <value>748, 90</value>
   </data>
   <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 20</value>
+    <value>48, 17</value>
   </data>
   <data name="CHK_speechlowspeed.Text" xml:space="preserve">
     <value>저속</value>
   </data>
-  <data name="CHK_showairports.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 506</value>
-  </data>
   <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 20</value>
+    <value>73, 17</value>
   </data>
   <data name="CHK_showairports.Text" xml:space="preserve">
     <value>공항 표시</value>
   </data>
-  <data name="chk_ADSB.Location" type="System.Drawing.Point, System.Drawing">
-    <value>598, 506</value>
-  </data>
-  <data name="chk_tfr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 529</value>
-  </data>
   <data name="chk_tfr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 20</value>
+    <value>73, 17</value>
   </data>
   <data name="chk_tfr.Text" xml:space="preserve">
     <value>고도 유지</value>
   </data>
   <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>341, 609</value>
+    <value>341, 627</value>
   </data>
   <data name="chk_temp.Text" xml:space="preserve">
     <value>시험 화면</value>
   </data>
-  <data name="chk_norcreceiver.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 529</value>
-  </data>
   <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 20</value>
+    <value>131, 17</value>
   </data>
   <data name="chk_norcreceiver.Text" xml:space="preserve">
     <value>원격조종 수신기 없음</value>
@@ -546,25 +528,19 @@
     <value>9, 453</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 16</value>
+    <value>29, 13</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>배치</value>
   </data>
-  <data name="CHK_AutoParamCommit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>598, 530</value>
-  </data>
   <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>120, 17</value>
   </data>
   <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
     <value>매개변수 자동 반영</value>
   </data>
-  <data name="chk_shownofly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>671, 506</value>
-  </data>
   <data name="chk_shownofly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 20</value>
+    <value>73, 17</value>
   </data>
   <data name="chk_shownofly.Text" xml:space="preserve">
     <value>비행 안함</value>
@@ -573,7 +549,7 @@
     <value>249, 200</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>54, 13</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>고도 단위</value>
@@ -588,22 +564,19 @@
     <value>9, 479</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 16</value>
+    <value>68, 13</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>지상 통제 ID</value>
   </data>
-  <data name="CHK_params_bg.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 552</value>
-  </data>
   <data name="CHK_params_bg.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 20</value>
+    <value>197, 17</value>
   </data>
   <data name="CHK_params_bg.Text" xml:space="preserve">
     <value>백그라운드에서 매개변수 다운로드</value>
   </data>
   <data name="chk_slowMachine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>341, 555</value>
+    <value>341, 603</value>
   </data>
   <data name="CHK_speechArmedOnly.Location" type="System.Drawing.Point, System.Drawing">
     <value>275, 89</value>
@@ -612,6 +585,6 @@
     <value>251, 111</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>816, 635</value>
+    <value>918, 653</value>
   </data>
 </root>

--- a/GCSViews/ConfigurationView/ConfigPlanner.pt.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.pt.resx
@@ -117,41 +117,39 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CHK_maprotation.Text" xml:space="preserve">
-    <value>Mapa roda seguindo o veiculo</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 13</value>
   </data>
-  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
-    <value>Aviso Alt</value>
+  <data name="label26.Text" xml:space="preserve">
+    <value>Formato video</value>
   </data>
-  <data name="BUT_videostop.Text" xml:space="preserve">
-    <value>Parar</value>
+  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
+    <value>Carregar WPs na conexão?</value>
   </data>
-  <data name="CHK_speechbattery.Text" xml:space="preserve">
-    <value>Aviso de bateria</value>
-  </data>
-  <data name="CHK_enablespeech.Text" xml:space="preserve">
-    <value>Habilita fala</value>
-  </data>
-  <data name="CHK_Password.Text" xml:space="preserve">
-    <value>Password de configuração</value>
-  </data>
-  <data name="chk_norcreceiver.Text" xml:space="preserve">
-    <value>Sem receptor RC</value>
+  <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 13</value>
   </data>
   <data name="label23.Text" xml:space="preserve">
     <value>Tamanho do rastro</value>
   </data>
-  <data name="CHK_speechcustom.Text" xml:space="preserve">
-    <value>Intervalo 30s</value>
+  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 17</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Distancia ao Home</value>
+  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
+    <value>Aviso Alt</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Log percurso</value>
+  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
+    <value>Reset APM no conector USB</value>
   </data>
-  <data name="label26.Text" xml:space="preserve">
-    <value>Formato video</value>
+  <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
+    <value>106, 642</value>
+  </data>
+  <data name="CHK_mavdebug.Text" xml:space="preserve">
+    <value>Debugar Mensagem Mavlink</value>
+  </data>
+  <data name="label104.Text" xml:space="preserve">
+    <value>Modo/Estat.</value>
   </data>
   <data name="label103.Text" xml:space="preserve">
     <value>Posiç.</value>
@@ -159,76 +157,145 @@
   <data name="label102.Text" xml:space="preserve">
     <value>Altitude</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Seguir Mapa</value>
-  </data>
   <data name="label101.Text" xml:space="preserve">
     <value>Taxas telemetria</value>
-  </data>
-  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
-    <value>Baixa velocidade</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Tema</value>
-  </data>
-  <data name="label104.Text" xml:space="preserve">
-    <value>Modo/Estat.</value>
-  </data>
-  <data name="CHK_hudshow.Text" xml:space="preserve">
-    <value>Hebilita HUD Overlay</value>
-  </data>
-  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
-    <value>Carregar WPs na conexão?</value>
-  </data>
-  <data name="label98.Text" xml:space="preserve">
-    <value>Unidade Veloc.</value>
   </data>
   <data name="label99.Text" xml:space="preserve">
     <value>NOTA: O tab de configuração não vai mostrar essas unidades já que são valores brutos.</value>
   </data>
-  <data name="label92.Text" xml:space="preserve">
-    <value>Dispositivo de video</value>
+  <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 13</value>
   </data>
-  <data name="label93.Text" xml:space="preserve">
-    <value>Idioma da UI</value>
+  <data name="label98.Text" xml:space="preserve">
+    <value>Unidade Veloc.</value>
   </data>
-  <data name="label94.Text" xml:space="preserve">
-    <value>Cor OSD</value>
+  <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 13</value>
   </data>
   <data name="label97.Text" xml:space="preserve">
     <value>Unidade Dist</value>
   </data>
-  <data name="CHK_showairports.Text" xml:space="preserve">
-    <value>Mostrar aeroportos</value>
-  </data>
-  <data name="BUT_themecustom.Text" xml:space="preserve">
-    <value>Customizado</value>
+  <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
+    <value>27, 13</value>
   </data>
   <data name="label95.Text" xml:space="preserve">
     <value>Fala</value>
   </data>
-  <data name="BUT_Joystick.Text" xml:space="preserve">
-    <value>Ajuste Joystick</value>
+  <data name="CHK_speechbattery.Text" xml:space="preserve">
+    <value>Aviso de bateria</value>
   </data>
-  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
-    <value>Mostrar na "TelaNav"</value>
+  <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>87, 17</value>
   </data>
-  <data name="CHK_mavdebug.Text" xml:space="preserve">
-    <value>Debugar Mensagem Mavlink</value>
+  <data name="CHK_speechcustom.Text" xml:space="preserve">
+    <value>Intervalo 30s</value>
   </data>
-  <data name="chk_temp.Text" xml:space="preserve">
-    <value>Tela de teste</value>
-  </data>
-  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
-    <value>Reset APM no conector USB</value>
+  <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 17</value>
   </data>
   <data name="CHK_speechmode.Text" xml:space="preserve">
     <value>Modo</value>
   </data>
-  <data name="BUT_logdirbrowse.Text" xml:space="preserve">
-    <value>Navegar</value>
+  <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="label94.Text" xml:space="preserve">
+    <value>Cor OSD</value>
+  </data>
+  <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="label93.Text" xml:space="preserve">
+    <value>Idioma da UI</value>
+  </data>
+  <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 17</value>
+  </data>
+  <data name="CHK_enablespeech.Text" xml:space="preserve">
+    <value>Habilita fala</value>
+  </data>
+  <data name="CHK_hudshow.Text" xml:space="preserve">
+    <value>Hebilita HUD Overlay</value>
+  </data>
+  <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
+  </data>
+  <data name="label92.Text" xml:space="preserve">
+    <value>Dispositivo de video</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Seguir Mapa</value>
+  </data>
+  <data name="CHK_maprotation.Text" xml:space="preserve">
+    <value>Mapa roda seguindo o veiculo</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Distancia ao Home</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
+    <value>Mostrar na "TelaNav"</value>
+  </data>
+  <data name="BUT_Joystick.Text" xml:space="preserve">
+    <value>Ajuste Joystick</value>
+  </data>
+  <data name="BUT_videostop.Text" xml:space="preserve">
+    <value>Parar</value>
   </data>
   <data name="BUT_videostart.Text" xml:space="preserve">
     <value>Inicio</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 13</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Log percurso</value>
+  </data>
+  <data name="BUT_logdirbrowse.Text" xml:space="preserve">
+    <value>Navegar</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 13</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="BUT_themecustom.Text" xml:space="preserve">
+    <value>Customizado</value>
+  </data>
+  <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 17</value>
+  </data>
+  <data name="CHK_Password.Text" xml:space="preserve">
+    <value>Password de configuração</value>
+  </data>
+  <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 17</value>
+  </data>
+  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
+    <value>Baixa velocidade</value>
+  </data>
+  <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 17</value>
+  </data>
+  <data name="CHK_showairports.Text" xml:space="preserve">
+    <value>Mostrar aeroportos</value>
+  </data>
+  <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 642</value>
+  </data>
+  <data name="chk_temp.Text" xml:space="preserve">
+    <value>Tela de teste</value>
+  </data>
+  <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 17</value>
+  </data>
+  <data name="chk_norcreceiver.Text" xml:space="preserve">
+    <value>Sem receptor RC</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>974, 662</value>
   </data>
 </root>

--- a/GCSViews/ConfigurationView/ConfigPlanner.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.resx
@@ -142,22 +142,22 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_rateposition.ZOrder" xml:space="preserve">
-    <value>54</value>
+    <value>65</value>
   </data>
   <data name="&gt;&gt;label96.ZOrder" xml:space="preserve">
-    <value>61</value>
+    <value>72</value>
   </data>
   <data name="CHK_Password.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 504</value>
+    <value>340, 554</value>
   </data>
   <data name="CMB_altunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+    <value>138, 21</value>
   </data>
   <data name="&gt;&gt;CHK_speechwaypoint.ZOrder" xml:space="preserve">
-    <value>66</value>
+    <value>77</value>
   </data>
   <data name="&gt;&gt;label108.ZOrder" xml:space="preserve">
-    <value>44</value>
+    <value>55</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -165,11 +165,17 @@
   <data name="&gt;&gt;label93.Name" xml:space="preserve">
     <value>label93</value>
   </data>
+  <data name="chk_displaytarget.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
   <data name="&gt;&gt;CHK_disttohomeflightdata.Name" xml:space="preserve">
     <value>CHK_disttohomeflightdata</value>
   </data>
-  <data name="&gt;&gt;CHK_speechcustom.ZOrder" xml:space="preserve">
-    <value>64</value>
+  <data name="chk_displaytooltip.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 17</value>
   </data>
   <data name="&gt;&gt;label101.Name" xml:space="preserve">
     <value>label101</value>
@@ -177,17 +183,23 @@
   <data name="CMB_rateattitude.Items" xml:space="preserve">
     <value>-1</value>
   </data>
+  <data name="label26.Text" xml:space="preserve">
+    <value>Video Format</value>
+  </data>
   <data name="CMB_speedunits.TabIndex" type="System.Int32, mscorlib">
     <value>60</value>
   </data>
   <data name="CHK_GDIPlus.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 349</value>
   </data>
-  <data name="CMB_rateattitude.TabIndex" type="System.Int32, mscorlib">
-    <value>56</value>
+  <data name="chk_displayheading.Size" type="System.Drawing.Size, System.Drawing">
+    <value>103, 17</value>
+  </data>
+  <data name="&gt;&gt;BUT_logdirbrowse.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="txt_log_dir.Size" type="System.Drawing.Size, System.Drawing">
-    <value>386, 22</value>
+    <value>386, 20</value>
   </data>
   <data name="&gt;&gt;CMB_ratestatus.Name" xml:space="preserve">
     <value>CMB_ratestatus</value>
@@ -204,17 +216,17 @@
   <data name="label3.Text" xml:space="preserve">
     <value>Log Path</value>
   </data>
-  <data name="num_gcsid.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 22</value>
+  <data name="label95.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="&gt;&gt;CHK_maprotation.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>41</value>
   </data>
   <data name="CMB_rateposition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 24</value>
+    <value>40, 21</value>
   </data>
   <data name="label104.Location" type="System.Drawing.Point, System.Drawing">
     <value>330, 254</value>
@@ -229,7 +241,7 @@
     <value>76</value>
   </data>
   <data name="&gt;&gt;CHK_GDIPlus.ZOrder" xml:space="preserve">
-    <value>38</value>
+    <value>48</value>
   </data>
   <data name="CMB_raterc.Items7" xml:space="preserve">
     <value>6</value>
@@ -244,7 +256,7 @@
     <value>NOTE: Set the low level of SEVERITY to speak</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>949, 591</value>
+    <value>949, 643</value>
   </data>
   <data name="CMB_raterc.Items14" xml:space="preserve">
     <value>50</value>
@@ -261,8 +273,8 @@
   <data name="CHK_Password.TabIndex" type="System.Int32, mscorlib">
     <value>104</value>
   </data>
-  <data name="chk_slowMachine.TabIndex" type="System.Int32, mscorlib">
-    <value>123</value>
+  <data name="&gt;&gt;label107.ZOrder" xml:space="preserve">
+    <value>58</value>
   </data>
   <data name="CHK_AutoParamCommit.TabIndex" type="System.Int32, mscorlib">
     <value>116</value>
@@ -271,13 +283,13 @@
     <value>Custom</value>
   </data>
   <data name="&gt;&gt;label95.ZOrder" xml:space="preserve">
-    <value>62</value>
+    <value>73</value>
   </data>
   <data name="&gt;&gt;label7.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;CMB_videoresolutions.Name" xml:space="preserve">
-    <value>CMB_videoresolutions</value>
+  <data name="BUT_Joystick.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="chk_slowMachine.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -285,14 +297,20 @@
   <data name="&gt;&gt;chk_tfr.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
+  <data name="&gt;&gt;CMB_videosources.ZOrder" xml:space="preserve">
+    <value>86</value>
+  </data>
   <data name="&gt;&gt;BUT_themecustom.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>32</value>
   </data>
   <data name="label107.Size" type="System.Drawing.Size, System.Drawing">
     <value>22, 13</value>
   </data>
+  <data name="chk_displayradius.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="&gt;&gt;BUT_videostop.ZOrder" xml:space="preserve">
-    <value>77</value>
+    <value>88</value>
   </data>
   <data name="&gt;&gt;CHK_GDIPlus.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -301,7 +319,7 @@
     <value>20</value>
   </data>
   <data name="&gt;&gt;CHK_loadwponconnect.ZOrder" xml:space="preserve">
-    <value>40</value>
+    <value>50</value>
   </data>
   <data name="label93.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 142</value>
@@ -316,10 +334,7 @@
     <value>$this</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 16</value>
-  </data>
-  <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 16</value>
+    <value>43, 13</value>
   </data>
   <data name="label95.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -334,10 +349,10 @@
     <value>88</value>
   </data>
   <data name="chk_tfr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 527</value>
+    <value>496, 577</value>
   </data>
   <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 20</value>
+    <value>81, 17</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>115</value>
@@ -348,8 +363,8 @@
   <data name="&gt;&gt;BUT_Vario.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="CHK_showairports.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;chk_displaytooltip.ZOrder" xml:space="preserve">
+    <value>25</value>
   </data>
   <data name="BUT_Joystick.Text" xml:space="preserve">
     <value>Joystick Setup</value>
@@ -373,7 +388,13 @@
     <value>False</value>
   </data>
   <data name="&gt;&gt;BUT_Vario.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>30</value>
+  </data>
+  <data name="CMB_rateattitude.Items10" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="num_linelength.Location" type="System.Drawing.Point, System.Drawing">
+    <value>768, 500</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.MyUserControl, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
@@ -388,7 +409,7 @@
     <value>NoControl</value>
   </data>
   <data name="chk_slowMachine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 20</value>
+    <value>155, 17</value>
   </data>
   <data name="chk_analytics.Text" xml:space="preserve">
     <value>OptOut Anon Stats</value>
@@ -397,7 +418,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;NUM_tracklength.ZOrder" xml:space="preserve">
-    <value>42</value>
+    <value>53</value>
   </data>
   <data name="&gt;&gt;BUT_themecustom.Type" xml:space="preserve">
     <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
@@ -408,14 +429,26 @@
   <data name="&gt;&gt;chk_temp.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;BUT_Joystick.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="label94.Text" xml:space="preserve">
+    <value>OSD Color</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytooltip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label11.Name" xml:space="preserve">
+    <value>label11</value>
+  </data>
+  <data name="CMB_raterc.Items10" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 373</value>
   </data>
-  <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="label96.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 171</value>
+  </data>
+  <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 13</value>
   </data>
   <data name="&gt;&gt;CHK_beta.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -450,8 +483,8 @@
   <data name="&gt;&gt;chk_slowMachine.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label95.Name" xml:space="preserve">
-    <value>label95</value>
+  <data name="chk_temp.TabIndex" type="System.Int32, mscorlib">
+    <value>110</value>
   </data>
   <data name="CHK_speechwaypoint.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -474,26 +507,32 @@
   <data name="&gt;&gt;CMB_language.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
+    <value>Alt Warning</value>
+  </data>
   <data name="label6.Text" xml:space="preserve">
     <value>Alt Units</value>
   </data>
   <data name="&gt;&gt;CMB_theme.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="num_linelength.TabIndex" type="System.Int32, mscorlib">
+    <value>80</value>
+  </data>
   <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>39</value>
+    <value>49</value>
   </data>
   <data name="CHK_Password.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 20</value>
+    <value>91, 17</value>
   </data>
   <data name="BUT_themecustom.Location" type="System.Drawing.Point, System.Drawing">
     <value>249, 421</value>
   </data>
   <data name="&gt;&gt;chk_tfr.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>17</value>
   </data>
   <data name="&gt;&gt;BUT_videostart.Name" xml:space="preserve">
     <value>BUT_videostart</value>
@@ -517,13 +556,13 @@
     <value>9</value>
   </data>
   <data name="&gt;&gt;label94.ZOrder" xml:space="preserve">
-    <value>67</value>
+    <value>78</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 16</value>
+    <value>39, 13</value>
   </data>
-  <data name="CMB_ratesensors.Items14" xml:space="preserve">
-    <value>100</value>
+  <data name="BUT_logdirbrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="CMB_ratesensors.Items4" xml:space="preserve">
     <value>3</value>
@@ -533,6 +572,12 @@
   </data>
   <data name="label99.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
+    <value>46</value>
+  </data>
+  <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
   </data>
   <data name="&gt;&gt;BUT_Joystick.Parent" xml:space="preserve">
     <value>$this</value>
@@ -544,7 +589,7 @@
     <value>56, 13</value>
   </data>
   <data name="&gt;&gt;CHK_showairports.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>19</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ConfigPlanner</value>
@@ -555,8 +600,8 @@
   <data name="BUT_videostop.Location" type="System.Drawing.Point, System.Drawing">
     <value>439, 6</value>
   </data>
-  <data name="&gt;&gt;CMB_videosources.Name" xml:space="preserve">
-    <value>CMB_videosources</value>
+  <data name="cmb_secondarydisplaystyle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 524</value>
   </data>
   <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -564,17 +609,23 @@
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
     <value>157, 31</value>
   </data>
+  <data name="&gt;&gt;chk_displaycog.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>37</value>
+    <value>47</value>
   </data>
   <data name="&gt;&gt;CMB_altunits.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 16</value>
+  <data name="&gt;&gt;chk_displaytooltip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="BUT_Joystick.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostart.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechwaypoint.Parent" xml:space="preserve">
     <value>$this</value>
@@ -585,11 +636,8 @@
   <data name="CHK_GDIPlus.Text" xml:space="preserve">
     <value>GDI+ (old type/no HW acceleration)</value>
   </data>
-  <data name="&gt;&gt;CMB_speedunits.Name" xml:space="preserve">
-    <value>CMB_speedunits</value>
-  </data>
-  <data name="label24.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="&gt;&gt;label12.Parent" xml:space="preserve">
     <value>$this</value>
@@ -606,14 +654,17 @@
   <data name="BUT_logdirbrowse.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
+  <data name="CMB_theme.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
   <data name="&gt;&gt;label104.Name" xml:space="preserve">
     <value>label104</value>
   </data>
   <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 477</value>
   </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;label108.Name" xml:space="preserve">
+    <value>label108</value>
   </data>
   <data name="CHK_speechArmedOnly.Location" type="System.Drawing.Point, System.Drawing">
     <value>212, 89</value>
@@ -639,6 +690,9 @@
   <data name="&gt;&gt;CMB_raterc.Name" xml:space="preserve">
     <value>CMB_raterc</value>
   </data>
+  <data name="CHK_params_bg.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="CHK_disttohomeflightdata.Size" type="System.Drawing.Size, System.Drawing">
     <value>129, 17</value>
   </data>
@@ -654,11 +708,17 @@
   <data name="label103.Location" type="System.Drawing.Point, System.Drawing">
     <value>220, 254</value>
   </data>
-  <data name="&gt;&gt;txt_log_dir.Parent" xml:space="preserve">
+  <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 502</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechlowspeed.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>20</value>
+  </data>
+  <data name="label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="&gt;&gt;label5.Name" xml:space="preserve">
     <value>label5</value>
@@ -668,6 +728,9 @@
   </data>
   <data name="&gt;&gt;CHK_Password.Name" xml:space="preserve">
     <value>CHK_Password</value>
+  </data>
+  <data name="chk_displayradius.Location" type="System.Drawing.Point, System.Drawing">
+    <value>436, 501</value>
   </data>
   <data name="&gt;&gt;label24.Name" xml:space="preserve">
     <value>label24</value>
@@ -685,10 +748,10 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_speechaltwarning.ZOrder" xml:space="preserve">
-    <value>43</value>
+    <value>54</value>
   </data>
   <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 16</value>
+    <value>52, 13</value>
   </data>
   <data name="&gt;&gt;CHK_resetapmonconnect.Name" xml:space="preserve">
     <value>CHK_resetapmonconnect</value>
@@ -698,6 +761,9 @@
   </data>
   <data name="&gt;&gt;CHK_speechbattery.Name" xml:space="preserve">
     <value>CHK_speechbattery</value>
+  </data>
+  <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="CHK_disttohomeflightdata.TabIndex" type="System.Int32, mscorlib">
     <value>92</value>
@@ -717,8 +783,14 @@
   <data name="label1.Text" xml:space="preserve">
     <value>Map Follow</value>
   </data>
+  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="CHK_speechmode.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
+  </data>
+  <data name="CHK_speechcustom.Location" type="System.Drawing.Point, System.Drawing">
+    <value>469, 89</value>
   </data>
   <data name="&gt;&gt;label101.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -729,23 +801,20 @@
   <data name="chk_slowMachine.Text" xml:space="preserve">
     <value>Runing on a slow computer</value>
   </data>
-  <data name="&gt;&gt;CMB_Layout.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 398</value>
   </data>
   <data name="CHK_params_bg.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 20</value>
+    <value>186, 17</value>
   </data>
   <data name="num_gcsid.TabIndex" type="System.Int32, mscorlib">
     <value>120</value>
   </data>
   <data name="CHK_showairports.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 504</value>
+    <value>496, 554</value>
   </data>
-  <data name="CMB_distunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+  <data name="chk_displaycog.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="label99.Location" type="System.Drawing.Point, System.Drawing">
     <value>480, 198</value>
@@ -754,31 +823,37 @@
     <value>55</value>
   </data>
   <data name="chk_shownofly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>671, 504</value>
+    <value>671, 554</value>
   </data>
   <data name="&gt;&gt;label96.Name" xml:space="preserve">
     <value>label96</value>
   </data>
-  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
-    <value>Alt Warning</value>
+  <data name="chk_displayradius.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 17</value>
+  </data>
+  <data name="label9.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="BUT_Vario.TabIndex" type="System.Int32, mscorlib">
     <value>100</value>
   </data>
   <data name="&gt;&gt;CHK_speechArmedOnly.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>41</value>
+    <value>51</value>
   </data>
   <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 20</value>
+    <value>99, 17</value>
   </data>
   <data name="CMB_raterc.Location" type="System.Drawing.Point, System.Drawing">
     <value>489, 251</value>
   </data>
   <data name="&gt;&gt;CHK_beta.Parent" xml:space="preserve">
     <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.ZOrder" xml:space="preserve">
+    <value>21</value>
   </data>
   <data name="CMB_Layout.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 448</value>
@@ -787,7 +862,7 @@
     <value>NoControl</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 141</value>
+    <value>9, 527</value>
   </data>
   <data name="&gt;&gt;CMB_severity.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -796,16 +871,25 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label93.ZOrder" xml:space="preserve">
-    <value>71</value>
+    <value>82</value>
   </data>
   <data name="&gt;&gt;CHK_speechArmedOnly.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chk_displaycog.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 501</value>
   </data>
   <data name="CMB_ratesensors.Location" type="System.Drawing.Point, System.Drawing">
     <value>584, 251</value>
   </data>
   <data name="CMB_ratestatus.Items12" xml:space="preserve">
     <value>25</value>
+  </data>
+  <data name="chk_displaytarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 17</value>
+  </data>
+  <data name="chk_displayradius.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="BUT_themecustom.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 20</value>
@@ -820,13 +904,13 @@
     <value>True</value>
   </data>
   <data name="&gt;&gt;label99.ZOrder" xml:space="preserve">
-    <value>56</value>
+    <value>67</value>
   </data>
   <data name="&gt;&gt;CMB_osdcolor.Name" xml:space="preserve">
     <value>CMB_osdcolor</value>
   </data>
   <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 571</value>
+    <value>340, 623</value>
   </data>
   <data name="CHK_enablespeech.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -837,8 +921,8 @@
   <data name="CHK_hudshow.Location" type="System.Drawing.Point, System.Drawing">
     <value>520, 10</value>
   </data>
-  <data name="CMB_rateposition.Items13" xml:space="preserve">
-    <value>50</value>
+  <data name="CHK_showairports.TabIndex" type="System.Int32, mscorlib">
+    <value>107</value>
   </data>
   <data name="label101.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -849,11 +933,14 @@
   <data name="txt_log_dir.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 395</value>
   </data>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="CMB_raterc.Items9" xml:space="preserve">
     <value>8</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>38</value>
   </data>
   <data name="label98.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -862,16 +949,22 @@
     <value>Show Airports</value>
   </data>
   <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>35</value>
+    <value>44</value>
   </data>
-  <data name="&gt;&gt;CHK_speechaltwarning.Name" xml:space="preserve">
-    <value>CHK_speechaltwarning</value>
+  <data name="chk_displaytarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmb_secondarydisplaystyle.TabIndex" type="System.Int32, mscorlib">
+    <value>129</value>
   </data>
   <data name="label92.Text" xml:space="preserve">
     <value>Video Device</value>
   </data>
   <data name="CMB_ratestatus.Items" xml:space="preserve">
     <value>-1</value>
+  </data>
+  <data name="CHK_GDIPlus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>220, 17</value>
   </data>
   <data name="CHK_params_bg.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -886,10 +979,10 @@
     <value>85</value>
   </data>
   <data name="&gt;&gt;CMB_raterc.ZOrder" xml:space="preserve">
-    <value>48</value>
+    <value>59</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 16</value>
+    <value>57, 13</value>
   </data>
   <data name="&gt;&gt;label98.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -900,14 +993,20 @@
   <data name="&gt;&gt;label104.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="CMB_rateattitude.Items11" xml:space="preserve">
-    <value>10</value>
+  <data name="CMB_rateposition.Items10" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="chk_displaytooltip.Text" xml:space="preserve">
+    <value>Display ToolTip</value>
   </data>
   <data name="label108.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
   </data>
-  <data name="CMB_distunits.TabIndex" type="System.Int32, mscorlib">
-    <value>61</value>
+  <data name="&gt;&gt;num_linelength.Name" xml:space="preserve">
+    <value>num_linelength</value>
+  </data>
+  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="CHK_speechmode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -915,8 +1014,11 @@
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
     <value>43, 13</value>
   </data>
+  <data name="chk_displaynavbearing.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
   <data name="NUM_tracklength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 22</value>
+    <value>67, 20</value>
   </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -925,7 +1027,10 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CMB_osdcolor.ZOrder" xml:space="preserve">
-    <value>68</value>
+    <value>79</value>
+  </data>
+  <data name="CMB_distunits.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
   </data>
   <data name="label101.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -933,14 +1038,20 @@
   <data name="&gt;&gt;CMB_Layout.Name" xml:space="preserve">
     <value>CMB_Layout</value>
   </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
   <data name="BUT_videostop.TabIndex" type="System.Int32, mscorlib">
     <value>77</value>
   </data>
   <data name="&gt;&gt;CMB_theme.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>33</value>
   </data>
   <data name="chk_tfr.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.ZOrder" xml:space="preserve">
+    <value>24</value>
   </data>
   <data name="&gt;&gt;CHK_speechaltwarning.Parent" xml:space="preserve">
     <value>$this</value>
@@ -949,10 +1060,10 @@
     <value>105</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
-    <value>127</value>
+    <value>128</value>
   </data>
   <data name="CMB_rateattitude.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 24</value>
+    <value>40, 21</value>
   </data>
   <data name="&gt;&gt;label107.Parent" xml:space="preserve">
     <value>$this</value>
@@ -963,14 +1074,17 @@
   <data name="CHK_maprotation.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 372</value>
   </data>
-  <data name="BUT_videostart.TabIndex" type="System.Int32, mscorlib">
-    <value>78</value>
-  </data>
   <data name="CMB_videoresolutions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>408, 24</value>
+    <value>408, 21</value>
+  </data>
+  <data name="chk_displayheading.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="&gt;&gt;CMB_videosources.Name" xml:space="preserve">
+    <value>CMB_videosources</value>
   </data>
   <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>56, 17</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -979,7 +1093,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="CMB_raterc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 24</value>
+    <value>40, 21</value>
   </data>
   <data name="CHK_speechArmedOnly.Text" xml:space="preserve">
     <value>Only when Armed</value>
@@ -990,11 +1104,14 @@
   <data name="&gt;&gt;CHK_mavdebug.Name" xml:space="preserve">
     <value>CHK_mavdebug</value>
   </data>
+  <data name="&gt;&gt;label10.Name" xml:space="preserve">
+    <value>label10</value>
+  </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 16</value>
+    <value>46, 13</value>
   </data>
   <data name="&gt;&gt;chk_ADSB.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>18</value>
   </data>
   <data name="&gt;&gt;label96.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1006,7 +1123,7 @@
     <value>72</value>
   </data>
   <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
-    <value>172, 20</value>
+    <value>142, 17</value>
   </data>
   <data name="&gt;&gt;label92.Name" xml:space="preserve">
     <value>label92</value>
@@ -1018,7 +1135,7 @@
     <value>332, 89</value>
   </data>
   <data name="chk_shownofly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 20</value>
+    <value>56, 17</value>
   </data>
   <data name="&gt;&gt;label94.Name" xml:space="preserve">
     <value>label94</value>
@@ -1045,7 +1162,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label104.ZOrder" xml:space="preserve">
-    <value>49</value>
+    <value>60</value>
   </data>
   <data name="&gt;&gt;CMB_rateposition.Name" xml:space="preserve">
     <value>CMB_rateposition</value>
@@ -1055,6 +1172,9 @@
   </data>
   <data name="CMB_ratesensors.Items3" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="&gt;&gt;CMB_videoresolutions.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="CMB_raterc.Items" xml:space="preserve">
     <value>-1</value>
@@ -1077,6 +1197,9 @@
   <data name="CHK_disttohomeflightdata.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="chk_displayradius.Text" xml:space="preserve">
+    <value>Display Turn Radius</value>
+  </data>
   <data name="CMB_raterc.Items13" xml:space="preserve">
     <value>35</value>
   </data>
@@ -1092,11 +1215,8 @@
   <data name="CMB_osdcolor.TabIndex" type="System.Int32, mscorlib">
     <value>69</value>
   </data>
-  <data name="CMB_rateposition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 251</value>
-  </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 16</value>
+    <value>31, 13</value>
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>Waypoints</value>
@@ -1104,20 +1224,23 @@
   <data name="&gt;&gt;CMB_rateposition.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;chk_displaytooltip.Name" xml:space="preserve">
+    <value>chk_displaytooltip</value>
+  </data>
   <data name="&gt;&gt;CHK_speechbattery.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="CHK_params_bg.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 550</value>
+    <value>107, 600</value>
   </data>
   <data name="label93.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="&gt;&gt;CMB_distunits.ZOrder" xml:space="preserve">
-    <value>60</value>
+    <value>71</value>
   </data>
   <data name="&gt;&gt;CHK_mavdebug.ZOrder" xml:space="preserve">
-    <value>46</value>
+    <value>57</value>
   </data>
   <data name="label96.Text" xml:space="preserve">
     <value>Joystick</value>
@@ -1131,20 +1254,26 @@
   <data name="&gt;&gt;num_gcsid.Name" xml:space="preserve">
     <value>num_gcsid</value>
   </data>
+  <data name="&gt;&gt;chk_displayradius.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="label94.TabIndex" type="System.Int32, mscorlib">
     <value>68</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Dist to Home</value>
   </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;CMB_Layout.ZOrder" xml:space="preserve">
+    <value>14</value>
   </data>
   <data name="&gt;&gt;CMB_ratesensors.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="CHK_hudshow.Text" xml:space="preserve">
     <value>Enable HUD Overlay</value>
+  </data>
+  <data name="&gt;&gt;label98.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="CMB_raterc.Items8" xml:space="preserve">
     <value>7</value>
@@ -1153,13 +1282,16 @@
     <value>111</value>
   </data>
   <data name="&gt;&gt;label92.ZOrder" xml:space="preserve">
-    <value>74</value>
+    <value>85</value>
   </data>
   <data name="&gt;&gt;CHK_speechmode.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label8.Name" xml:space="preserve">
     <value>label8</value>
+  </data>
+  <data name="chk_displaytarget.Text" xml:space="preserve">
+    <value>Display Target</value>
   </data>
   <data name="CMB_raterc.Items1" xml:space="preserve">
     <value>0</value>
@@ -1180,7 +1312,7 @@
     <value>5</value>
   </data>
   <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 16</value>
+    <value>71, 13</value>
   </data>
   <data name="label12.Text" xml:space="preserve">
     <value>HUD</value>
@@ -1192,22 +1324,25 @@
     <value>CHK_showairports</value>
   </data>
   <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 20</value>
+    <value>102, 17</value>
   </data>
   <data name="&gt;&gt;CHK_hudshow.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label98.ZOrder" xml:space="preserve">
-    <value>57</value>
+    <value>68</value>
   </data>
   <data name="CMB_rateattitude.Items13" xml:space="preserve">
     <value>100</value>
   </data>
-  <data name="&gt;&gt;CMB_speedunits.ZOrder" xml:space="preserve">
-    <value>59</value>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label103.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;CMB_speedunits.ZOrder" xml:space="preserve">
+    <value>70</value>
+  </data>
+  <data name="label24.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="&gt;&gt;CMB_theme.Name" xml:space="preserve">
     <value>CMB_theme</value>
@@ -1218,8 +1353,8 @@
   <data name="CMB_ratesensors.Items" xml:space="preserve">
     <value>-1</value>
   </data>
-  <data name="&gt;&gt;chk_temp.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;BUT_Joystick.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chk_shownofly.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1231,7 +1366,10 @@
     <value>Connect Reset</value>
   </data>
   <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 20</value>
+    <value>81, 17</value>
+  </data>
+  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;chk_slowMachine.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1240,19 +1378,31 @@
     <value>$this</value>
   </data>
   <data name="chk_slowMachine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 550</value>
+    <value>340, 600</value>
   </data>
-  <data name="CMB_osdcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 23</value>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="chk_displaytarget.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="CHK_enablespeech.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="chk_displaytarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>563, 501</value>
   </data>
   <data name="&gt;&gt;CHK_enablespeech.ZOrder" xml:space="preserve">
-    <value>72</value>
+    <value>83</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CMB_rateposition.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1267,7 +1417,7 @@
     <value>$this</value>
   </data>
   <data name="CMB_speedunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+    <value>138, 21</value>
   </data>
   <data name="chk_analytics.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1278,11 +1428,17 @@
   <data name="CHK_beta.TabIndex" type="System.Int32, mscorlib">
     <value>103</value>
   </data>
+  <data name="&gt;&gt;chk_displaytarget.Name" xml:space="preserve">
+    <value>chk_displaytarget</value>
+  </data>
   <data name="CHK_speechcustom.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label102.Location" type="System.Drawing.Point, System.Drawing">
     <value>104, 254</value>
+  </data>
+  <data name="&gt;&gt;chk_displaynavbearing.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;CMB_distunits.Name" xml:space="preserve">
     <value>CMB_distunits</value>
@@ -1309,7 +1465,7 @@
     <value>$this</value>
   </data>
   <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 20</value>
+    <value>115, 17</value>
   </data>
   <data name="&gt;&gt;CHK_resetapmonconnect.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1321,10 +1477,13 @@
     <value>62</value>
   </data>
   <data name="&gt;&gt;txt_log_dir.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>36</value>
   </data>
-  <data name="&gt;&gt;CHK_disttohomeflightdata.ZOrder" xml:space="preserve">
-    <value>30</value>
+  <data name="&gt;&gt;CHK_speechcustom.ZOrder" xml:space="preserve">
+    <value>75</value>
+  </data>
+  <data name="chk_displaycog.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 17</value>
   </data>
   <data name="label104.TabIndex" type="System.Int32, mscorlib">
     <value>50</value>
@@ -1342,19 +1501,16 @@
     <value>True</value>
   </data>
   <data name="CMB_videosources.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 24</value>
+    <value>245, 21</value>
   </data>
   <data name="&gt;&gt;CHK_GDIPlus.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label103.ZOrder" xml:space="preserve">
-    <value>50</value>
+    <value>61</value>
   </data>
   <data name="&gt;&gt;NUM_tracklength.Parent" xml:space="preserve">
     <value>$this</value>
-  </data>
-  <data name="chk_norcreceiver.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="&gt;&gt;CHK_speechlowspeed.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1368,6 +1524,9 @@
   <data name="CMB_ratesensors.Items5" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
+    <value>535, 254</value>
+  </data>
   <data name="CHK_speechmode.Location" type="System.Drawing.Point, System.Drawing">
     <value>408, 89</value>
   </data>
@@ -1377,14 +1536,11 @@
   <data name="BUT_videostart.Text" xml:space="preserve">
     <value>Start</value>
   </data>
-  <data name="chk_temp.TabIndex" type="System.Int32, mscorlib">
-    <value>110</value>
-  </data>
   <data name="&gt;&gt;CMB_osdcolor.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;label6.Name" xml:space="preserve">
     <value>label6</value>
@@ -1396,7 +1552,7 @@
     <value>BUT_logdirbrowse</value>
   </data>
   <data name="&gt;&gt;CHK_Password.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>27</value>
   </data>
   <data name="CMB_raterc.Items11" xml:space="preserve">
     <value>10</value>
@@ -1404,11 +1560,14 @@
   <data name="&gt;&gt;BUT_videostop.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
+  <data name="CMB_ratestatus.Items5" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="&gt;&gt;CHK_beta.Name" xml:space="preserve">
     <value>CHK_beta</value>
   </data>
-  <data name="&gt;&gt;label98.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CHK_mavdebug.TabIndex" type="System.Int32, mscorlib">
+    <value>47</value>
   </data>
   <data name="label23.Text" xml:space="preserve">
     <value>Track Length</value>
@@ -1416,11 +1575,17 @@
   <data name="CHK_loadwponconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="&gt;&gt;chk_displaycog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chk_displayheading.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label95.TabIndex" type="System.Int32, mscorlib">
-    <value>63</value>
+  <data name="label9.Text" xml:space="preserve">
+    <value>Inactive Aircraft</value>
   </data>
   <data name="CMB_rateattitude.Items2" xml:space="preserve">
     <value>1</value>
@@ -1435,10 +1600,13 @@
     <value>True</value>
   </data>
   <data name="&gt;&gt;CMB_rateattitude.ZOrder" xml:space="preserve">
-    <value>55</value>
+    <value>66</value>
   </data>
   <data name="label92.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostart.ZOrder" xml:space="preserve">
+    <value>89</value>
   </data>
   <data name="&gt;&gt;CHK_maprotation.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1453,7 +1621,7 @@
     <value>NoControl</value>
   </data>
   <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 571</value>
+    <value>106, 623</value>
   </data>
   <data name="CMB_rateposition.Items11" xml:space="preserve">
     <value>10</value>
@@ -1465,25 +1633,22 @@
     <value>9, 451</value>
   </data>
   <data name="&gt;&gt;CMB_ratesensors.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>43</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 16</value>
+    <value>69, 13</value>
   </data>
   <data name="CHK_speechArmedOnly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 20</value>
+    <value>109, 17</value>
   </data>
   <data name="&gt;&gt;chk_temp.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>16</value>
   </data>
   <data name="&gt;&gt;CHK_showairports.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="label94.Text" xml:space="preserve">
-    <value>OSD Color</value>
-  </data>
   <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 16</value>
+    <value>57, 13</value>
   </data>
   <data name="CHK_speechaltwarning.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1491,8 +1656,14 @@
   <data name="CHK_resetapmonconnect.Size" type="System.Drawing.Size, System.Drawing">
     <value>217, 17</value>
   </data>
+  <data name="&gt;&gt;CMB_videoresolutions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chk_displayradius.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
   <data name="CMB_severity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+    <value>138, 21</value>
   </data>
   <data name="&gt;&gt;CMB_speedunits.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1502,6 +1673,9 @@
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>89</value>
+  </data>
+  <data name="chk_displaynavbearing.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 501</value>
   </data>
   <data name="BUT_Vario.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1515,17 +1689,14 @@
   <data name="CHK_maprotation.Text" xml:space="preserve">
     <value>Map is rotated to follow the plane</value>
   </data>
-  <data name="CHK_maprotation.TabIndex" type="System.Int32, mscorlib">
-    <value>90</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;num_linelength.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 20</value>
+    <value>123, 17</value>
   </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
-    <value>96</value>
+  <data name="&gt;&gt;chk_displaycog.Name" xml:space="preserve">
+    <value>chk_displaycog</value>
   </data>
   <data name="BUT_Vario.Size" type="System.Drawing.Size, System.Drawing">
     <value>99, 20</value>
@@ -1533,14 +1704,17 @@
   <data name="chk_ADSB.TabIndex" type="System.Int32, mscorlib">
     <value>108</value>
   </data>
+  <data name="chk_displaytooltip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 17</value>
+  </data>
   <data name="CMB_ratestatus.Items4" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;BUT_videostart.ZOrder" xml:space="preserve">
-    <value>78</value>
+  <data name="&gt;&gt;label95.Name" xml:space="preserve">
+    <value>label95</value>
   </data>
-  <data name="BUT_logdirbrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="label10.Text" xml:space="preserve">
+    <value>Aircraft Icon</value>
   </data>
   <data name="CHK_loadwponconnect.Size" type="System.Drawing.Size, System.Drawing">
     <value>177, 17</value>
@@ -1548,17 +1722,32 @@
   <data name="label97.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="&gt;&gt;chk_displaynavbearing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 350</value>
   </data>
   <data name="CHK_speechArmedOnly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="&gt;&gt;CMB_speedunits.Name" xml:space="preserve">
+    <value>CMB_speedunits</value>
+  </data>
   <data name="CHK_mavdebug.Text" xml:space="preserve">
     <value>Mavlink Message Debug</value>
   </data>
   <data name="CHK_beta.Text" xml:space="preserve">
     <value>Beta Updates</value>
+  </data>
+  <data name="label10.TabIndex" type="System.Int32, mscorlib">
+    <value>130</value>
+  </data>
+  <data name="chk_displayheading.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="label95.Text" xml:space="preserve">
     <value>Speech</value>
@@ -1573,13 +1762,16 @@
     <value>NoControl</value>
   </data>
   <data name="&gt;&gt;label101.ZOrder" xml:space="preserve">
-    <value>52</value>
+    <value>63</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="chk_temp.Text" xml:space="preserve">
     <value>Testing Screen</value>
+  </data>
+  <data name="&gt;&gt;CMB_videoresolutions.Name" xml:space="preserve">
+    <value>CMB_videoresolutions</value>
   </data>
   <data name="label12.TabIndex" type="System.Int32, mscorlib">
     <value>84</value>
@@ -1591,19 +1783,19 @@
     <value>35</value>
   </data>
   <data name="&gt;&gt;CHK_speecharmdisarm.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>31</value>
   </data>
   <data name="label97.TabIndex" type="System.Int32, mscorlib">
     <value>59</value>
   </data>
-  <data name="CMB_theme.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+  <data name="label11.Text" xml:space="preserve">
+    <value>Line Length</value>
   </data>
   <data name="&gt;&gt;label102.ZOrder" xml:space="preserve">
-    <value>51</value>
+    <value>62</value>
   </data>
   <data name="&gt;&gt;chk_analytics.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>29</value>
   </data>
   <data name="&gt;&gt;BUT_themecustom.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1614,14 +1806,14 @@
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>93</value>
   </data>
-  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_ratestatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>415, 251</value>
   </data>
   <data name="label96.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="CHK_params_bg.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="BUT_videostart.TabIndex" type="System.Int32, mscorlib">
+    <value>78</value>
   </data>
   <data name="CHK_speechmode.Text" xml:space="preserve">
     <value>Mode </value>
@@ -1662,11 +1854,17 @@
   <data name="CMB_rateposition.Items9" xml:space="preserve">
     <value>8</value>
   </data>
+  <data name="chk_displaycog.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
   <data name="NUM_tracklength.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 300</value>
   </data>
   <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;label9.Name" xml:space="preserve">
+    <value>label9</value>
   </data>
   <data name="CMB_severity.TabIndex" type="System.Int32, mscorlib">
     <value>125</value>
@@ -1680,20 +1878,23 @@
   <data name="&gt;&gt;label4.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
   <data name="&gt;&gt;label107.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 16</value>
+    <value>71, 13</value>
   </data>
   <data name="CMB_ratesensors.Items1" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="&gt;&gt;CMB_severity.ZOrder" xml:space="preserve">
-    <value>69</value>
+    <value>80</value>
   </data>
   <data name="&gt;&gt;CHK_speechmode.ZOrder" xml:space="preserve">
-    <value>65</value>
+    <value>76</value>
   </data>
   <data name="&gt;&gt;BUT_Joystick.Name" xml:space="preserve">
     <value>BUT_Joystick</value>
@@ -1703,6 +1904,9 @@
   </data>
   <data name="CMB_videosources.TabIndex" type="System.Int32, mscorlib">
     <value>75</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;label9.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1723,19 +1927,19 @@
     <value>58</value>
   </data>
   <data name="chk_norcreceiver.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 527</value>
+    <value>340, 577</value>
   </data>
   <data name="CMB_ratesensors.Items8" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="label96.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 171</value>
+  <data name="label11.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="CHK_speechbattery.Text" xml:space="preserve">
     <value>Battery Warning</value>
   </data>
   <data name="CMB_Layout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+    <value>138, 21</value>
   </data>
   <data name="&gt;&gt;CMB_ratesensors.Name" xml:space="preserve">
     <value>CMB_ratesensors</value>
@@ -1755,11 +1959,11 @@
   <data name="&gt;&gt;CHK_loadwponconnect.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
-    <value>535, 254</value>
+  <data name="&gt;&gt;chk_displayheading.Name" xml:space="preserve">
+    <value>chk_displayheading</value>
   </data>
-  <data name="CMB_ratestatus.Items5" xml:space="preserve">
-    <value>4</value>
+  <data name="label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="CMB_rateposition.Items" xml:space="preserve">
     <value>-1</value>
@@ -1791,20 +1995,20 @@
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;CMB_videoresolutions.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="chk_displaytooltip.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
   </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
+  <data name="CMB_rateposition.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 251</value>
   </data>
-  <data name="CMB_rateattitude.Items10" xml:space="preserve">
-    <value>9</value>
+  <data name="CMB_rateposition.Items13" xml:space="preserve">
+    <value>50</value>
   </data>
-  <data name="CHK_showairports.TabIndex" type="System.Int32, mscorlib">
-    <value>107</value>
+  <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 13</value>
   </data>
   <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 16</value>
+    <value>65, 13</value>
   </data>
   <data name="&gt;&gt;chk_shownofly.Name" xml:space="preserve">
     <value>chk_shownofly</value>
@@ -1813,19 +2017,22 @@
     <value>79, 13</value>
   </data>
   <data name="CMB_language.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 24</value>
+    <value>138, 21</value>
   </data>
   <data name="BUT_Vario.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 501</value>
+    <value>107, 551</value>
+  </data>
+  <data name="num_linelength.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 20</value>
   </data>
   <data name="CHK_speechArmedOnly.TabIndex" type="System.Int32, mscorlib">
     <value>124</value>
   </data>
-  <data name="&gt;&gt;label107.ZOrder" xml:space="preserve">
-    <value>47</value>
+  <data name="&gt;&gt;chk_displayradius.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 16</value>
+    <value>45, 13</value>
   </data>
   <data name="CMB_rateattitude.Location" type="System.Drawing.Point, System.Drawing">
     <value>166, 251</value>
@@ -1834,10 +2041,10 @@
     <value>52</value>
   </data>
   <data name="CHK_beta.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 527</value>
+    <value>228, 577</value>
   </data>
   <data name="&gt;&gt;BUT_Joystick.ZOrder" xml:space="preserve">
-    <value>76</value>
+    <value>87</value>
   </data>
   <data name="&gt;&gt;CHK_speecharmdisarm.Name" xml:space="preserve">
     <value>CHK_speecharmdisarm</value>
@@ -1851,8 +2058,11 @@
   <data name="num_gcsid.Location" type="System.Drawing.Point, System.Drawing">
     <value>107, 475</value>
   </data>
-  <data name="CHK_mavdebug.TabIndex" type="System.Int32, mscorlib">
-    <value>47</value>
+  <data name="BUT_logdirbrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>496, 393</value>
+  </data>
+  <data name="label10.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="&gt;&gt;label7.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1860,14 +2070,23 @@
   <data name="&gt;&gt;CHK_speechwaypoint.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="CMB_ratesensors.Items14" xml:space="preserve">
+    <value>100</value>
+  </data>
   <data name="&gt;&gt;chk_ADSB.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CMB_severity.Name" xml:space="preserve">
     <value>CMB_severity</value>
   </data>
+  <data name="chk_displaynavbearing.Text" xml:space="preserve">
+    <value>Display Nav Bearing</value>
+  </data>
   <data name="label104.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="chk_displaytooltip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>663, 501</value>
   </data>
   <data name="&gt;&gt;label23.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1875,17 +2094,26 @@
   <data name="chk_analytics.TabIndex" type="System.Int32, mscorlib">
     <value>102</value>
   </data>
-  <data name="label26.Text" xml:space="preserve">
-    <value>Video Format</value>
+  <data name="label11.TabIndex" type="System.Int32, mscorlib">
+    <value>84</value>
   </data>
   <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>42</value>
   </data>
   <data name="&gt;&gt;label23.Name" xml:space="preserve">
     <value>label23</value>
   </data>
   <data name="label33.Text" xml:space="preserve">
     <value>Sensor</value>
+  </data>
+  <data name="&gt;&gt;label11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechaltwarning.Name" xml:space="preserve">
+    <value>CHK_speechaltwarning</value>
+  </data>
+  <data name="CMB_rateattitude.Items11" xml:space="preserve">
+    <value>10</value>
   </data>
   <data name="CMB_raterc.TabIndex" type="System.Int32, mscorlib">
     <value>49</value>
@@ -1899,11 +2127,14 @@
   <data name="chk_tfr.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;CHK_hudshow.ZOrder" xml:space="preserve">
-    <value>73</value>
+  <data name="&gt;&gt;txt_log_dir.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="CHK_speechaltwarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>671, 89</value>
+  <data name="&gt;&gt;CHK_hudshow.ZOrder" xml:space="preserve">
+    <value>84</value>
+  </data>
+  <data name="cmb_secondarydisplaystyle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
   </data>
   <data name="&gt;&gt;CMB_Layout.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1920,8 +2151,11 @@
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
   </data>
+  <data name="&gt;&gt;chk_displaynavbearing.Name" xml:space="preserve">
+    <value>chk_displaynavbearing</value>
+  </data>
   <data name="&gt;&gt;BUT_logdirbrowse.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>35</value>
   </data>
   <data name="&gt;&gt;CMB_videosources.Parent" xml:space="preserve">
     <value>$this</value>
@@ -1930,13 +2164,13 @@
     <value>False</value>
   </data>
   <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 20</value>
+    <value>80, 17</value>
   </data>
   <data name="&gt;&gt;chk_ADSB.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="CMB_theme.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 421</value>
+  <data name="chk_displaycog.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="CHK_mavdebug.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 17</value>
@@ -1948,13 +2182,22 @@
     <value>Params Download in BackGround</value>
   </data>
   <data name="&gt;&gt;CMB_altunits.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>40</value>
+  </data>
+  <data name="&gt;&gt;chk_displayradius.ZOrder" xml:space="preserve">
+    <value>22</value>
   </data>
   <data name="CHK_params_bg.TabIndex" type="System.Int32, mscorlib">
     <value>122</value>
+  </data>
+  <data name="&gt;&gt;chk_temp.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_disttohomeflightdata.ZOrder" xml:space="preserve">
+    <value>39</value>
   </data>
   <data name="&gt;&gt;BUT_videostop.Type" xml:space="preserve">
     <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
@@ -1965,17 +2208,23 @@
   <data name="label24.TabIndex" type="System.Int32, mscorlib">
     <value>82</value>
   </data>
+  <data name="chk_displayheading.Location" type="System.Drawing.Point, System.Drawing">
+    <value>199, 501</value>
+  </data>
   <data name="CMB_theme.TabIndex" type="System.Int32, mscorlib">
     <value>97</value>
   </data>
   <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;BUT_logdirbrowse.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  <data name="chk_norcreceiver.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.Name" xml:space="preserve">
+    <value>cmb_secondarydisplaystyle</value>
   </data>
   <data name="&gt;&gt;chk_norcreceiver.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="label96.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1987,13 +2236,13 @@
     <value>46</value>
   </data>
   <data name="CHK_AutoParamCommit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>598, 528</value>
+    <value>598, 578</value>
   </data>
   <data name="chk_ADSB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 20</value>
+    <value>55, 17</value>
   </data>
   <data name="&gt;&gt;chk_shownofly.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;CHK_loadwponconnect.Name" xml:space="preserve">
     <value>CHK_loadwponconnect</value>
@@ -2007,14 +2256,14 @@
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="CMB_rateposition.Items10" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;label24.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CHK_beta.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>28</value>
   </data>
   <data name="CMB_altunits.TabIndex" type="System.Int32, mscorlib">
     <value>119</value>
@@ -2026,7 +2275,7 @@
     <value>118</value>
   </data>
   <data name="&gt;&gt;chk_slowMachine.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2046,20 +2295,23 @@
   <data name="&gt;&gt;label108.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;num_linelength.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="CHK_speechcustom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="&gt;&gt;chk_ADSB.Name" xml:space="preserve">
     <value>chk_ADSB</value>
   </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
   <data name="&gt;&gt;CMB_osdcolor.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="label98.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="num_gcsid.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 20</value>
+  </data>
+  <data name="CMB_rateattitude.TabIndex" type="System.Int32, mscorlib">
+    <value>56</value>
   </data>
   <data name="CMB_ratesensors.Items11" xml:space="preserve">
     <value>10</value>
@@ -2076,32 +2328,38 @@
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
     <value>249, 198</value>
   </data>
-  <data name="&gt;&gt;CMB_videosources.ZOrder" xml:space="preserve">
-    <value>75</value>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="&gt;&gt;label5.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;chk_displaynavbearing.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="chk_slowMachine.TabIndex" type="System.Int32, mscorlib">
+    <value>123</value>
+  </data>
   <data name="&gt;&gt;CHK_mavdebug.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="CMB_severity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 111</value>
-  </data>
-  <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>121</value>
-  </data>
-  <data name="label95.AutoSize" type="System.Boolean, mscorlib">
+  <data name="label98.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="CMB_language.TabIndex" type="System.Int32, mscorlib">
     <value>70</value>
   </data>
   <data name="chk_ADSB.Location" type="System.Drawing.Point, System.Drawing">
-    <value>598, 504</value>
+    <value>598, 554</value>
+  </data>
+  <data name="chk_displaynavbearing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 20</value>
+    <value>91, 17</value>
   </data>
   <data name="CMB_rateattitude.Items12" xml:space="preserve">
     <value>50</value>
@@ -2118,8 +2376,8 @@
   <data name="label7.Text" xml:space="preserve">
     <value>GCS ID</value>
   </data>
-  <data name="&gt;&gt;label108.Name" xml:space="preserve">
-    <value>label108</value>
+  <data name="CMB_osdcolor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
   </data>
   <data name="&gt;&gt;CMB_speedunits.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -2128,10 +2386,13 @@
     <value>label33</value>
   </data>
   <data name="&gt;&gt;label97.ZOrder" xml:space="preserve">
-    <value>58</value>
+    <value>69</value>
   </data>
-  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 20</value>
+  <data name="CHK_maprotation.TabIndex" type="System.Int32, mscorlib">
+    <value>90</value>
+  </data>
+  <data name="CMB_severity.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 111</value>
   </data>
   <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2158,7 +2419,7 @@
     <value>86</value>
   </data>
   <data name="CMB_ratesensors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 24</value>
+    <value>40, 21</value>
   </data>
   <data name="label94.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 65</value>
@@ -2173,13 +2434,19 @@
     <value>67</value>
   </data>
   <data name="&gt;&gt;CHK_AutoParamCommit.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="BUT_videostop.Text" xml:space="preserve">
     <value>Stop</value>
   </data>
   <data name="CHK_speechArmedOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;chk_displayradius.Name" xml:space="preserve">
+    <value>chk_displayradius</value>
   </data>
   <data name="&gt;&gt;CHK_resetapmonconnect.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -2190,8 +2457,11 @@
   <data name="chk_norcreceiver.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="chk_displaytooltip.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="chk_tfr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 20</value>
+    <value>54, 17</value>
   </data>
   <data name="&gt;&gt;chk_analytics.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2212,7 +2482,7 @@
     <value>label7</value>
   </data>
   <data name="label101.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 16</value>
+    <value>84, 13</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -2233,10 +2503,10 @@
     <value>Password Protect Config</value>
   </data>
   <data name="&gt;&gt;CHK_params_bg.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;CMB_videoresolutions.ZOrder" xml:space="preserve">
-    <value>36</value>
+    <value>45</value>
   </data>
   <data name="&gt;&gt;label98.Name" xml:space="preserve">
     <value>label98</value>
@@ -2245,13 +2515,13 @@
     <value>txt_log_dir</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 16</value>
+    <value>61, 13</value>
   </data>
-  <data name="CHK_speechcustom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>469, 89</value>
-  </data>
-  <data name="label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="label107.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="chk_displaynavbearing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 17</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
     <value>180, 303</value>
@@ -2265,8 +2535,14 @@
   <data name="&gt;&gt;CHK_enablespeech.Name" xml:space="preserve">
     <value>CHK_enablespeech</value>
   </data>
-  <data name="&gt;&gt;CMB_videoresolutions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>121</value>
+  </data>
+  <data name="CHK_showairports.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displayheading.Text" xml:space="preserve">
+    <value>Display Heading</value>
   </data>
   <data name="label103.Text" xml:space="preserve">
     <value>Position</value>
@@ -2293,19 +2569,19 @@
     <value>True</value>
   </data>
   <data name="chk_analytics.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 527</value>
+    <value>107, 577</value>
   </data>
   <data name="label101.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 254</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;CMB_rateattitude.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;num_gcsid.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;NUM_tracklength.Type" xml:space="preserve">
     <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -2313,8 +2589,11 @@
   <data name="CHK_speechlowspeed.Location" type="System.Drawing.Point, System.Drawing">
     <value>853, 89</value>
   </data>
-  <data name="CMB_raterc.Items10" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;label103.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
+    <value>Arm/Disarm</value>
   </data>
   <data name="label97.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 198</value>
@@ -2323,7 +2602,7 @@
     <value>True</value>
   </data>
   <data name="&gt;&gt;CHK_resetapmonconnect.ZOrder" xml:space="preserve">
-    <value>45</value>
+    <value>56</value>
   </data>
   <data name="&gt;&gt;CHK_speechmode.Name" xml:space="preserve">
     <value>CHK_speechmode</value>
@@ -2356,16 +2635,19 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CHK_speechbattery.ZOrder" xml:space="preserve">
-    <value>63</value>
+    <value>74</value>
   </data>
-  <data name="CHK_GDIPlus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>220, 17</value>
+  <data name="&gt;&gt;label10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
+    <value>841, 502</value>
   </data>
   <data name="CHK_maprotation.Size" type="System.Drawing.Size, System.Drawing">
     <value>205, 17</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>34</value>
   </data>
   <data name="&gt;&gt;BUT_videostop.Name" xml:space="preserve">
     <value>BUT_videostop</value>
@@ -2373,23 +2655,23 @@
   <data name="&gt;&gt;label12.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;CMB_ratestatus.ZOrder" xml:space="preserve">
-    <value>53</value>
+  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="BUT_logdirbrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 393</value>
+  <data name="&gt;&gt;CMB_ratestatus.ZOrder" xml:space="preserve">
+    <value>64</value>
   </data>
   <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 20</value>
+    <value>104, 17</value>
   </data>
   <data name="label97.Text" xml:space="preserve">
     <value>Dist Units</value>
   </data>
-  <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
-    <value>Arm/Disarm</value>
+  <data name="CMB_distunits.TabIndex" type="System.Int32, mscorlib">
+    <value>61</value>
   </data>
   <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 20</value>
+    <value>71, 17</value>
   </data>
   <data name="CHK_speechlowspeed.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2402,6 +2684,12 @@
   </data>
   <data name="CHK_speechaltwarning.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
+  </data>
+  <data name="label95.TabIndex" type="System.Int32, mscorlib">
+    <value>63</value>
+  </data>
+  <data name="chk_displaycog.Text" xml:space="preserve">
+    <value>Display COG</value>
   </data>
   <data name="chk_analytics.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2416,16 +2704,16 @@
     <value>$this</value>
   </data>
   <data name="CMB_ratestatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 24</value>
+    <value>40, 21</value>
   </data>
-  <data name="label107.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="CHK_speechaltwarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>671, 89</value>
   </data>
   <data name="&gt;&gt;chk_norcreceiver.Name" xml:space="preserve">
     <value>chk_norcreceiver</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>37</value>
   </data>
   <data name="CMB_rateposition.Items3" xml:space="preserve">
     <value>2</value>
@@ -2434,7 +2722,7 @@
     <value>CHK_speechlowspeed</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 16</value>
+    <value>40, 13</value>
   </data>
   <data name="label104.Text" xml:space="preserve">
     <value>Mode/Status</value>
@@ -2454,14 +2742,14 @@
   <data name="CMB_ratestatus.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
   </data>
-  <data name="CMB_ratestatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>415, 251</value>
-  </data>
   <data name="CHK_speecharmdisarm.TabIndex" type="System.Int32, mscorlib">
     <value>99</value>
   </data>
   <data name="&gt;&gt;CHK_speechcustom.Parent" xml:space="preserve">
     <value>$this</value>
+  </data>
+  <data name="chk_displaynavbearing.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="&gt;&gt;CHK_AutoParamCommit.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2482,7 +2770,7 @@
     <value>No Fly</value>
   </data>
   <data name="&gt;&gt;CMB_language.ZOrder" xml:space="preserve">
-    <value>70</value>
+    <value>81</value>
   </data>
   <data name="&gt;&gt;label4.Name" xml:space="preserve">
     <value>label4</value>
@@ -2490,14 +2778,11 @@
   <data name="&gt;&gt;label99.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;BUT_videostart.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
   <data name="label98.Text" xml:space="preserve">
     <value>Speed Units</value>
   </data>
   <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 16</value>
+    <value>69, 13</value>
   </data>
   <data name="&gt;&gt;CMB_ratestatus.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -2517,14 +2802,23 @@
   <data name="chk_temp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
+  <data name="&gt;&gt;chk_displaycog.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="&gt;&gt;CHK_disttohomeflightdata.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 16</value>
+    <value>44, 13</value>
+  </data>
+  <data name="CMB_theme.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 421</value>
   </data>
   <data name="&gt;&gt;chk_norcreceiver.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;num_linelength.ZOrder" xml:space="preserve">
+    <value>52</value>
   </data>
   <data name="CHK_showairports.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2546,6 +2840,6 @@
     <value>True</value>
   </metadata>
   <metadata name="$this.Language" type="System.Globalization.CultureInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>ko-KR</value>
+    <value>zh-TW</value>
   </metadata>
 </root>

--- a/GCSViews/ConfigurationView/ConfigPlanner.ru-KZ.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.ru-KZ.resx
@@ -117,50 +117,57 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CHK_maprotation.Text" xml:space="preserve">
-    <value>Карта след. за БПЛА</value>
+  <data name="label33.Text" xml:space="preserve">
+    <value>Датч.</value>
   </data>
-  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
-    <value>Пред.Выс.</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 13</value>
   </data>
-  <data name="BUT_videostop.Text" xml:space="preserve">
-    <value>Стоп</value>
+  <data name="label26.Text" xml:space="preserve">
+    <value>Формат видео</value>
   </data>
-  <data name="CHK_speechbattery.Text" xml:space="preserve">
-    <value>Пред.батареи</value>
+  <data name="CHK_GDIPlus.Text" xml:space="preserve">
+    <value>GDI + (старый тип)</value>
   </data>
-  <data name="CHK_enablespeech.Text" xml:space="preserve">
-    <value>Включить речь</value>
-  </data>
-  <data name="CHK_Password.Text" xml:space="preserve">
-    <value>Защита паролем</value>
-  </data>
-  <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
-    <value>Автоматически фиксировать Параметры</value>
-  </data>
-  <data name="chk_analytics.Text" xml:space="preserve">
-    <value>Стат. OptOut Anon</value>
-  </data>
-  <data name="chk_norcreceiver.Text" xml:space="preserve">
-    <value>Нет RC-приемника</value>
-  </data>
-  <data name="label23.Text" xml:space="preserve">
-    <value>Длина трека</value>
+  <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 13</value>
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>Маршрут.точ.</value>
   </data>
-  <data name="CHK_speechcustom.Text" xml:space="preserve">
-    <value>Инт. 30 с</value>
+  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
+    <value>Загр. МТ при подключении.</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Раст. до Дома</value>
+  <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 13</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Путевой журнал</value>
+  <data name="label23.Text" xml:space="preserve">
+    <value>Длина трека</value>
   </data>
-  <data name="label26.Text" xml:space="preserve">
-    <value>Формат видео</value>
+  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 17</value>
+  </data>
+  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
+    <value>Пред.Выс.</value>
+  </data>
+  <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
+  </data>
+  <data name="label108.Text" xml:space="preserve">
+    <value>Сброс APM</value>
+  </data>
+  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
+    <value>Сброс через USB</value>
+  </data>
+  <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
+    <value>106, 621</value>
+  </data>
+  <data name="CHK_mavdebug.Text" xml:space="preserve">
+    <value>Отл. сообщ. Mavlink</value>
+  </data>
+  <data name="label104.Text" xml:space="preserve">
+    <value>Реж/Сост</value>
   </data>
   <data name="label103.Text" xml:space="preserve">
     <value>Поз.</value>
@@ -168,97 +175,187 @@
   <data name="label102.Text" xml:space="preserve">
     <value>Пол.</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Карта двигаться</value>
+  <data name="label99.Text" xml:space="preserve">
+    <value>Вкладка «Конфигурация» НЕ отображает эти ед., так как это необр. значения.</value>
   </data>
-  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
-    <value>Низкая скорость</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>Выс. изм.</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Тема</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>Отображение</value>
-  </data>
-  <data name="label104.Text" xml:space="preserve">
-    <value>Реж/Сост</value>
-  </data>
-  <data name="CHK_hudshow.Text" xml:space="preserve">
-    <value>Включить наложение HUD</value>
-  </data>
-  <data name="label108.Text" xml:space="preserve">
-    <value>Сброс APM</value>
-  </data>
-  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
-    <value>Загр. МТ при подключении.</value>
-  </data>
-  <data name="CHK_beta.Text" xml:space="preserve">
-    <value>Бета-обновление</value>
+  <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 13</value>
   </data>
   <data name="label98.Text" xml:space="preserve">
     <value>Ед. Скорости</value>
   </data>
-  <data name="CHK_speechwaypoint.Text" xml:space="preserve">
-    <value>Марш.точ.</value>
-  </data>
-  <data name="label99.Text" xml:space="preserve">
-    <value>Вкладка «Конфигурация» НЕ отображает эти ед., так как это необр. значения.</value>
-  </data>
-  <data name="label92.Text" xml:space="preserve">
-    <value>Видеоустройство</value>
-  </data>
-  <data name="label93.Text" xml:space="preserve">
-    <value>Язык интерфейса</value>
-  </data>
-  <data name="label96.Text" xml:space="preserve">
-    <value>Джойстик</value>
-  </data>
-  <data name="CHK_GDIPlus.Text" xml:space="preserve">
-    <value>GDI + (старый тип)</value>
-  </data>
-  <data name="label94.Text" xml:space="preserve">
-    <value>Цвет OSD</value>
-  </data>
-  <data name="label33.Text" xml:space="preserve">
-    <value>Датч.</value>
+  <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 13</value>
   </data>
   <data name="label97.Text" xml:space="preserve">
     <value>Ед. измерения</value>
   </data>
-  <data name="CHK_showairports.Text" xml:space="preserve">
-    <value>Показ. аэропорт.</value>
+  <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
   </data>
-  <data name="BUT_themecustom.Text" xml:space="preserve">
-    <value>Своя</value>
+  <data name="label96.Text" xml:space="preserve">
+    <value>Джойстик</value>
+  </data>
+  <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
+    <value>31, 13</value>
   </data>
   <data name="label95.Text" xml:space="preserve">
     <value>Речь</value>
   </data>
-  <data name="BUT_Joystick.Text" xml:space="preserve">
-    <value>Настройка джойстика</value>
+  <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 17</value>
   </data>
-  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
-    <value>Пок. в Пол. данн.</value>
+  <data name="CHK_speechbattery.Text" xml:space="preserve">
+    <value>Пред.батареи</value>
   </data>
-  <data name="CHK_mavdebug.Text" xml:space="preserve">
-    <value>Отл. сообщ. Mavlink</value>
+  <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 17</value>
   </data>
-  <data name="chk_temp.Text" xml:space="preserve">
-    <value>Экран тестирования</value>
+  <data name="CHK_speechcustom.Text" xml:space="preserve">
+    <value>Инт. 30 с</value>
   </data>
-  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
-    <value>Сброс через USB</value>
+  <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 17</value>
   </data>
   <data name="CHK_speechmode.Text" xml:space="preserve">
     <value>Режим</value>
   </data>
-  <data name="BUT_logdirbrowse.Text" xml:space="preserve">
-    <value>Просмотр</value>
+  <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 17</value>
+  </data>
+  <data name="CHK_speechwaypoint.Text" xml:space="preserve">
+    <value>Марш.точ.</value>
+  </data>
+  <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="label94.Text" xml:space="preserve">
+    <value>Цвет OSD</value>
+  </data>
+  <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 13</value>
+  </data>
+  <data name="label93.Text" xml:space="preserve">
+    <value>Язык интерфейса</value>
+  </data>
+  <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="CHK_enablespeech.Text" xml:space="preserve">
+    <value>Включить речь</value>
+  </data>
+  <data name="CHK_hudshow.Text" xml:space="preserve">
+    <value>Включить наложение HUD</value>
+  </data>
+  <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 13</value>
+  </data>
+  <data name="label92.Text" xml:space="preserve">
+    <value>Видеоустройство</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>92, 13</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Карта двигаться</value>
+  </data>
+  <data name="CHK_maprotation.Text" xml:space="preserve">
+    <value>Карта след. за БПЛА</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Раст. до Дома</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
+    <value>Пок. в Пол. данн.</value>
+  </data>
+  <data name="BUT_Joystick.Text" xml:space="preserve">
+    <value>Настройка джойстика</value>
+  </data>
+  <data name="BUT_videostop.Text" xml:space="preserve">
+    <value>Стоп</value>
   </data>
   <data name="BUT_videostart.Text" xml:space="preserve">
     <value>Начать</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 13</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Путевой журнал</value>
+  </data>
+  <data name="BUT_logdirbrowse.Text" xml:space="preserve">
+    <value>Просмотр</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 13</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Тема</value>
+  </data>
+  <data name="BUT_themecustom.Text" xml:space="preserve">
+    <value>Своя</value>
+  </data>
+  <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 17</value>
+  </data>
+  <data name="chk_analytics.Text" xml:space="preserve">
+    <value>Стат. OptOut Anon</value>
+  </data>
+  <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 17</value>
+  </data>
+  <data name="CHK_beta.Text" xml:space="preserve">
+    <value>Бета-обновление</value>
+  </data>
+  <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 17</value>
+  </data>
+  <data name="CHK_Password.Text" xml:space="preserve">
+    <value>Защита паролем</value>
+  </data>
+  <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 17</value>
+  </data>
+  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
+    <value>Низкая скорость</value>
+  </data>
+  <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 17</value>
+  </data>
+  <data name="CHK_showairports.Text" xml:space="preserve">
+    <value>Показ. аэропорт.</value>
+  </data>
+  <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 621</value>
+  </data>
+  <data name="chk_temp.Text" xml:space="preserve">
+    <value>Экран тестирования</value>
+  </data>
+  <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 17</value>
+  </data>
+  <data name="chk_norcreceiver.Text" xml:space="preserve">
+    <value>Нет RC-приемника</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 13</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Отображение</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>236, 17</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
+    <value>Автоматически фиксировать Параметры</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 13</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>Выс. изм.</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>982, 641</value>
   </data>
 </root>

--- a/GCSViews/ConfigurationView/ConfigPlanner.uk.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.uk.resx
@@ -117,59 +117,63 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CHK_maprotation.Text" xml:space="preserve">
-    <value>Карту повернуто, щоб прослідкувати за площиною</value>
+  <data name="label33.Text" xml:space="preserve">
+    <value>Датчик</value>
   </data>
-  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
-    <value>Попередження Alt</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 13</value>
+  </data>
+  <data name="label26.Text" xml:space="preserve">
+    <value>Формат відео</value>
+  </data>
+  <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
   </data>
   <data name="label12.Text" xml:space="preserve">
     <value>Інтерфейс</value>
   </data>
-  <data name="BUT_videostop.Text" xml:space="preserve">
-    <value>Зупинити</value>
+  <data name="CHK_GDIPlus.Text" xml:space="preserve">
+    <value>GDI+ (старий тип/без апаратного прискорення)</value>
   </data>
-  <data name="CHK_speechbattery.Text" xml:space="preserve">
-    <value>Сповіщення акумулятора</value>
-  </data>
-  <data name="CHK_enablespeech.Text" xml:space="preserve">
-    <value>Увімкнути мовлення</value>
-  </data>
-  <data name="CHK_Password.Text" xml:space="preserve">
-    <value>Конфігурація захисту пароля</value>
-  </data>
-  <data name="chk_slowMachine.Text" xml:space="preserve">
-    <value>Працює на повільному комп'ютері</value>
-  </data>
-  <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
-    <value>Авто фіксації Параметри</value>
-  </data>
-  <data name="chk_analytics.Text" xml:space="preserve">
-    <value>Статистика заборони анонса</value>
-  </data>
-  <data name="chk_norcreceiver.Text" xml:space="preserve">
-    <value>Немає RC приймача</value>
-  </data>
-  <data name="label23.Text" xml:space="preserve">
-    <value>Довжина пісні</value>
-  </data>
-  <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
-    <value>Броня /Знешкодження</value>
+  <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 13</value>
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>Точки</value>
   </data>
-  <data name="CHK_speechcustom.Text" xml:space="preserve">
-    <value>30-ті інтервал</value>
+  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
+    <value>Завантажувати точки при підключенні?</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Віддати до дому</value>
+  <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Шлях до лог файлу</value>
+  <data name="label23.Text" xml:space="preserve">
+    <value>Довжина пісні</value>
   </data>
-  <data name="label26.Text" xml:space="preserve">
-    <value>Формат відео</value>
+  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 17</value>
+  </data>
+  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
+    <value>Попередження Alt</value>
+  </data>
+  <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 13</value>
+  </data>
+  <data name="label108.Text" xml:space="preserve">
+    <value>Скинути налаштування підключення</value>
+  </data>
+  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
+    <value>Скинути на USB підключення (перемкнути DTR)</value>
+  </data>
+  <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
+    <value>106, 622</value>
+  </data>
+  <data name="CHK_mavdebug.Text" xml:space="preserve">
+    <value>Налагодження повідомлень Mavlink</value>
+  </data>
+  <data name="label104.Text" xml:space="preserve">
+    <value>Режим/Статус</value>
   </data>
   <data name="label103.Text" xml:space="preserve">
     <value>Позиція</value>
@@ -177,119 +181,236 @@
   <data name="label102.Text" xml:space="preserve">
     <value>Відношення</value>
   </data>
-  <data name="BUT_Vario.Text" xml:space="preserve">
-    <value>Запустити/Зупинити варіант</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Слідкувати за картою</value>
+  <data name="label101.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 13</value>
   </data>
   <data name="label101.Text" xml:space="preserve">
     <value>Телеметрії</value>
-  </data>
-  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
-    <value>Низька швидкість</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>Альтернативні одиниці</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Тема</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>Макет</value>
-  </data>
-  <data name="label104.Text" xml:space="preserve">
-    <value>Режим/Статус</value>
-  </data>
-  <data name="CHK_hudshow.Text" xml:space="preserve">
-    <value>Увімкнути HUD накладення</value>
-  </data>
-  <data name="label108.Text" xml:space="preserve">
-    <value>Скинути налаштування підключення</value>
-  </data>
-  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
-    <value>Завантажувати точки при підключенні?</value>
-  </data>
-  <data name="CHK_beta.Text" xml:space="preserve">
-    <value>Бета-оновлення</value>
-  </data>
-  <data name="chk_ADSB.Text" xml:space="preserve">
-    <value>АДСБ</value>
-  </data>
-  <data name="label98.Text" xml:space="preserve">
-    <value>Одиниці швидкості</value>
-  </data>
-  <data name="CHK_speechwaypoint.Text" xml:space="preserve">
-    <value>Шляхова Точка</value>
   </data>
   <data name="label99.Text" xml:space="preserve">
     <value>ПРИМІТКА: Вкладка Конфігурація НЕ відображатиме ці одиниці, оскільки це необроблені значення.
 </value>
   </data>
-  <data name="label92.Text" xml:space="preserve">
-    <value>Відео пристрій</value>
+  <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 13</value>
   </data>
-  <data name="label93.Text" xml:space="preserve">
-    <value>Мова інтерфейсу</value>
+  <data name="label98.Text" xml:space="preserve">
+    <value>Одиниці швидкості</value>
   </data>
-  <data name="label96.Text" xml:space="preserve">
-    <value>Джойстик</value>
-  </data>
-  <data name="CHK_GDIPlus.Text" xml:space="preserve">
-    <value>GDI+ (старий тип/без апаратного прискорення)</value>
-  </data>
-  <data name="chk_tfr.Text" xml:space="preserve">
-    <value>TFR</value>
-  </data>
-  <data name="label94.Text" xml:space="preserve">
-    <value>Колір OSD</value>
-  </data>
-  <data name="label33.Text" xml:space="preserve">
-    <value>Датчик</value>
+  <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 13</value>
   </data>
   <data name="label97.Text" xml:space="preserve">
     <value>Одиниці виміру</value>
   </data>
-  <data name="CHK_showairports.Text" xml:space="preserve">
-    <value>Показати аеропорти</value>
+  <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
   </data>
-  <data name="BUT_themecustom.Text" xml:space="preserve">
-    <value>Користувацька</value>
+  <data name="label96.Text" xml:space="preserve">
+    <value>Джойстик</value>
+  </data>
+  <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 13</value>
   </data>
   <data name="label95.Text" xml:space="preserve">
     <value>Мова</value>
   </data>
-  <data name="BUT_Joystick.Text" xml:space="preserve">
-    <value>Налаштування джойстика</value>
+  <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 17</value>
   </data>
-  <data name="CHK_params_bg.Text" xml:space="preserve">
-    <value>Завантаження парамів у BackGround</value>
+  <data name="CHK_speechbattery.Text" xml:space="preserve">
+    <value>Сповіщення акумулятора</value>
   </data>
-  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
-    <value>Показувати у Політданих</value>
+  <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 17</value>
   </data>
-  <data name="CHK_mavdebug.Text" xml:space="preserve">
-    <value>Налагодження повідомлень Mavlink</value>
+  <data name="CHK_speechcustom.Text" xml:space="preserve">
+    <value>30-ті інтервал</value>
   </data>
-  <data name="chk_temp.Text" xml:space="preserve">
-    <value>Екран тестування</value>
-  </data>
-  <data name="chk_shownofly.Text" xml:space="preserve">
-    <value>Без польоту</value>
-  </data>
-  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
-    <value>Скинути на USB підключення (перемкнути DTR)</value>
+  <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 17</value>
   </data>
   <data name="CHK_speechmode.Text" xml:space="preserve">
     <value>Режим </value>
   </data>
+  <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
+    <value>103, 17</value>
+  </data>
+  <data name="CHK_speechwaypoint.Text" xml:space="preserve">
+    <value>Шляхова Точка</value>
+  </data>
+  <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 13</value>
+  </data>
+  <data name="label94.Text" xml:space="preserve">
+    <value>Колір OSD</value>
+  </data>
+  <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 13</value>
+  </data>
+  <data name="label93.Text" xml:space="preserve">
+    <value>Мова інтерфейсу</value>
+  </data>
+  <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 17</value>
+  </data>
+  <data name="CHK_enablespeech.Text" xml:space="preserve">
+    <value>Увімкнути мовлення</value>
+  </data>
+  <data name="CHK_hudshow.Text" xml:space="preserve">
+    <value>Увімкнути HUD накладення</value>
+  </data>
+  <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 13</value>
+  </data>
+  <data name="label92.Text" xml:space="preserve">
+    <value>Відео пристрій</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 13</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Слідкувати за картою</value>
+  </data>
+  <data name="CHK_maprotation.Text" xml:space="preserve">
+    <value>Карту повернуто, щоб прослідкувати за площиною</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Віддати до дому</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
+    <value>Показувати у Політданих</value>
+  </data>
+  <data name="BUT_Joystick.Text" xml:space="preserve">
+    <value>Налаштування джойстика</value>
+  </data>
+  <data name="BUT_videostop.Text" xml:space="preserve">
+    <value>Зупинити</value>
+  </data>
+  <data name="BUT_videostart.Text" xml:space="preserve">
+    <value>Старт</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Шлях до лог файлу</value>
+  </data>
   <data name="BUT_logdirbrowse.Text" xml:space="preserve">
     <value>Переглянути</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 13</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Тема</value>
+  </data>
+  <data name="BUT_themecustom.Text" xml:space="preserve">
+    <value>Користувацька</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 17</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
+    <value>Броня /Знешкодження</value>
+  </data>
+  <data name="BUT_Vario.Text" xml:space="preserve">
+    <value>Запустити/Зупинити варіант</value>
+  </data>
+  <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 17</value>
+  </data>
+  <data name="chk_analytics.Text" xml:space="preserve">
+    <value>Статистика заборони анонса</value>
+  </data>
+  <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 17</value>
+  </data>
+  <data name="CHK_beta.Text" xml:space="preserve">
+    <value>Бета-оновлення</value>
+  </data>
+  <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
+    <value>172, 17</value>
+  </data>
+  <data name="CHK_Password.Text" xml:space="preserve">
+    <value>Конфігурація захисту пароля</value>
+  </data>
+  <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
+    <value>Низька швидкість</value>
+  </data>
+  <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 17</value>
+  </data>
+  <data name="CHK_showairports.Text" xml:space="preserve">
+    <value>Показати аеропорти</value>
+  </data>
+  <data name="chk_ADSB.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 17</value>
+  </data>
+  <data name="chk_ADSB.Text" xml:space="preserve">
+    <value>АДСБ</value>
+  </data>
+  <data name="chk_tfr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 17</value>
+  </data>
+  <data name="chk_tfr.Text" xml:space="preserve">
+    <value>TFR</value>
+  </data>
+  <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 622</value>
+  </data>
+  <data name="chk_temp.Text" xml:space="preserve">
+    <value>Екран тестування</value>
+  </data>
+  <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 17</value>
+  </data>
+  <data name="chk_norcreceiver.Text" xml:space="preserve">
+    <value>Немає RC приймача</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Макет</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 17</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
+    <value>Авто фіксації Параметри</value>
+  </data>
+  <data name="chk_shownofly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 17</value>
+  </data>
+  <data name="chk_shownofly.Text" xml:space="preserve">
+    <value>Без польоту</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 13</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>Альтернативні одиниці</value>
+  </data>
+  <data name="CHK_params_bg.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 17</value>
+  </data>
+  <data name="CHK_params_bg.Text" xml:space="preserve">
+    <value>Завантаження парамів у BackGround</value>
+  </data>
+  <data name="chk_slowMachine.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 17</value>
+  </data>
+  <data name="chk_slowMachine.Text" xml:space="preserve">
+    <value>Працює на повільному комп'ютері</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 17</value>
   </data>
   <data name="CHK_speechArmedOnly.Text" xml:space="preserve">
     <value>Тільки коли зброєний</value>
   </data>
-  <data name="BUT_videostart.Text" xml:space="preserve">
-    <value>Старт</value>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>949, 642</value>
   </data>
 </root>

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -931,6 +931,19 @@ namespace MissionPlanner.GCSViews
             BeginInvoke((Action) delegate { photosoverlay.Markers.Add(marker); });
         }
 
+        private void addMAVMarker(MAVState MAV)
+        {
+            this.BeginInvokeIfRequired(() =>
+            {
+                var marker = Common.getMAVMarker(MAV, routes);
+
+                if (marker == null || marker.Position.Lat == 0 && marker.Position.Lng == 0)
+                    return;
+
+                addMissionRouteMarker(marker);
+            });
+        }
+
         private void addMissionRouteMarker(GMapMarker marker)
         {
             if (marker == null) return;
@@ -4106,17 +4119,17 @@ namespace MissionPlanner.GCSViews
                                 // draw the mavs seen on this port
                                 foreach (var MAV in port.MAVlist)
                                 {
-                                    this.BeginInvokeIfRequired(() =>
+                                    if (MAV == MainV2.comPort?.MAV)
                                     {
-                                        var marker = Common.getMAVMarker(MAV, routes);
-
-                                        if (marker == null || marker.Position.Lat == 0 && marker.Position.Lng == 0)
-                                            return;
-
-                                        addMissionRouteMarker(marker);
-                                    });
+                                        // We will draw this last
+                                        continue;
+                                    }
+                                    addMAVMarker(MAV);
                                 }
                             }
+
+                            // Draw the active aircraft
+                            addMAVMarker(MainV2.comPort.MAV);
 
                             if (route.Points.Count == 0 || route.Points[route.Points.Count - 1].Lat != 0 &&
                                 (mapupdate.AddSeconds(3) < DateTime.Now) && CHK_autopan.Checked)

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -3849,11 +3849,16 @@ namespace MissionPlanner
             }
 
             GMapMarkerBase.length = Settings.Instance.GetInt32("GMapMarkerBase_length", 500);
-            GMapMarkerBase.DisplayCOG = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayCOG", true);
-            GMapMarkerBase.DisplayHeading = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayHeading", true);
-            GMapMarkerBase.DisplayNavBearing = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayNavBearing", true);
-            GMapMarkerBase.DisplayRadius = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayRadius", true);
-            GMapMarkerBase.DisplayTarget = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayTarget", true);
+            GMapMarkerBase.DisplayCOGSetting = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayCOG", true);
+            GMapMarkerBase.DisplayHeadingSetting = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayHeading", true);
+            GMapMarkerBase.DisplayNavBearingSetting = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayNavBearing", true);
+            GMapMarkerBase.DisplayRadiusSetting = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayRadius", true);
+            GMapMarkerBase.DisplayTargetSetting = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayTarget", true);
+            var inactiveDisplayStyle = GMapMarkerBase.InactiveDisplayStyleEnum.Normal;
+            string inactiveDisplayStyleStr = Settings.Instance.GetString("GMapMarkerBase_InactiveDisplayStyle", inactiveDisplayStyle.ToString());
+            Enum.TryParse(inactiveDisplayStyleStr, out inactiveDisplayStyle);
+            GMapMarkerBase.InactiveDisplayStyle = inactiveDisplayStyle;
+            Settings.Instance["GMapMarkerBase_InactiveDisplayStyle"] = inactiveDisplayStyle.ToString();
         }
 
         private void BGLogMessagesMetaData(object nothing)


### PR DESCRIPTION
This allows the user to select whether other MAVs, or other instances of the same MAV on redundant links, should be hidden from the map, or displayed as transparent to be less distracting, or displayed as normal. The setting defaults to normal.

Additionally, added settings on the Config > Planner page to allow control over settings that were previously only available with config hacking.

Shown below is the image of one aircraft coming in over three redundant links (Radio, LTE, and SatCom) using the `Transparent` display option.
![Screenshot 2023-12-22 164018](https://github.com/ArduPilot/MissionPlanner/assets/14059190/551f2c5f-4a83-41cc-b97f-7a0a617f1d72)

Screenshot of new config options
![Screenshot 2023-12-22 163050](https://github.com/ArduPilot/MissionPlanner/assets/14059190/5288c95d-cc21-402e-835f-197737ae08a5)

I had to do some funny naming nonsense for the Quad map marker. This was done keeping two things in mind:
1) Avoid constructing pens and brushes over and over assuming there is some performance penalty for that.
2) Avoid breaking plugins that might override the pen colors. Don't want to rename the existing `bluepen`, `greenpen`, or `greenbrush`.
