### PR TITLE
FlighData: Fix rotated map not displaying vehicle

### DIFF
--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapControl.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapControl.cs
@@ -1439,7 +1439,6 @@ namespace GMap.NET.WindowsForms
         {
             {
                 e.Clear(EmptyMapBackground);
-
 #if !PocketPC
                 if (MapRenderTransform.HasValue)
                 {
@@ -1507,8 +1506,9 @@ namespace GMap.NET.WindowsForms
                         }
 #endif
                         DrawMap(e);
-                        OnPaintOverlays(e);
                     }
+                    OnPaintOverlays(e);
+
                 }
             }
 

--- a/ExtLibs/Maps/GMapMarkerQuad.cs
+++ b/ExtLibs/Maps/GMapMarkerQuad.cs
@@ -47,8 +47,8 @@ namespace MissionPlanner.Maps
         {
             var temp = g.Transform;
             g.TranslateTransform(LocalPosition.X, LocalPosition.Y);
-            // set centerpoint as 0,0
             g.TranslateTransform(-Offset.X, -Offset.Y);
+            g.RotateTransform(-Overlay.Control.Bearing);
 
             // anti NaN
             try

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -720,6 +720,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (startup)
                 return;
             Settings.Instance["CHK_maprotation"] = CHK_maprotation.Checked.ToString();
+            if (CHK_maprotation.Checked)
+            {
+                chk_shownofly.Checked = false;
+            }
             FlightData.instance.gMapControl1.Bearing = 0;
         }
 
@@ -987,6 +991,10 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private void chk_shownofly_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Instance["ShowNoFly"] = chk_shownofly.Checked.ToString();
+            if (chk_shownofly.Checked)
+            {
+                CHK_maprotation.Checked = false;
+            }
         }
 
         private void CMB_altunits_SelectedIndexChanged(object sender, EventArgs e)

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -3588,8 +3588,16 @@ namespace MissionPlanner.GCSViews
 
                         if (Settings.Instance.GetBoolean("CHK_maprotation"))
                         {
-                            // dont holdinvalidation here
+                            ////Check if we have more than one vehicle connected and disable CHK_maprotation if so
+                            if (MainV2.comPort.MAVlist.Count > 1)
+                            {
+                                Settings.Instance["CHK_maprotation"] = "false";
+                                //And set maprotation to zero
+                                BeginInvoke((Action)delegate { gMapControl1.Bearing = 0; });
+                            }
+                            //gMapControl1.HoldInvalidation = true;
                             setMapBearing();
+
                         }
 
                         if (route == null)


### PR DESCRIPTION
When rotate map with plane checked, the vehicle overlays was not displayed.
Also add a cross check to disable showing nofly zones when rotating map, (and vica versa) since rotating and displaying nofly overlay is very time consuming and grinds the UI to halt.
This fixes #3191 