### PR TITLE
prevent target_system=0 in toggle safety switch

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1692,8 +1692,13 @@ namespace MissionPlanner.GCSViews
                     }
                     if (CMB_action.Text == actions.Toggle_Safety_Switch.ToString())
                     {
+                        var target_system = (byte)MainV2.comPort.sysidcurrent;
+                        if (target_system == 0) {
+                            log.Info("Not toggling safety on sysid 0");
+                            return;
+                        }
                         var custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u;
-                        var mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode, target_system = (byte)MainV2.comPort.sysidcurrent };
+                        var mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode, target_system = target_system };
                         MainV2.comPort.setMode(mode, MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
                         ((Control)sender).Enabled = true;
                         return;


### PR DESCRIPTION
a user tried to toggle safety on an antenna tracker and MissionPlanner sent it to target_system=0, which resulted in toggling safety on a flying aircraft, causing it to crash
Note that we really should make it a separate on/off buttons, as per this issue: https://github.com/ArduPilot/MissionPlanner/issues/3268

This is what MissionPlanner sent:
```
2023-09-16 08:52:05.284 SET_MODE {target_system : 0, base_mode : 128, custom_mode : 1}
2023-09-16 08:52:05.308 SET_MODE {target_system : 0, base_mode : 128, custom_mode : 1}
```
I can only guess that MissionPlanner had not seen a SYS_STATUS from the antenna tracker when the button was pressed
