### PR TITLE
ConfigRawParams: When setting a parameter changes the number of parameters, do a full refresh. and check if reboot is needed

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -271,7 +271,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             //}
 
             int error = 0;
-
+            bool reboot = false;
             foreach (string value in temp)
             {
                 try
@@ -283,7 +283,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     }
 
                     MainV2.comPort.setParam(value, (double)_changes[value]);
-
+                    //check if reboot required
+                    if (ParameterMetaDataRepository.GetParameterRebootRequired(value, MainV2.comPort.MAV.cs.firmware.ToString()))
+                    {
+                        reboot = true;
+                    }
                     try
                     {
                         // set control as well
@@ -325,14 +329,17 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 CustomMessageBox.Show("Not all parameters successfully saved.", "Saved");
             else
                 CustomMessageBox.Show("Parameters successfully saved.", "Saved");
-
+            //Check if reboot is required
+            if (reboot)
+            {
+               CustomMessageBox.Show("Reboot is required for some parameters to take effect.", "Reboot Required");
+            }
 
             if (MainV2.comPort.MAV.param.TotalReceived != MainV2.comPort.MAV.param.TotalReported)
             {
                 CustomMessageBox.Show("The number of available parameters changed. A full param refresh will be done to show all params.", "Params");
                 //Click on refresh button
                 BUT_rerequestparams_Click(BUT_rerequestparams, null);
-
             }
 
         }

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -263,15 +263,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             bool enable = temp.Any(a => a.EndsWith("_ENABLE"));
 
-            //if (enable)
-            //{
-            //    CustomMessageBox.Show(
-            //        "You have changed an Enable parameter. You may need to do a full param refresh to show all params",
-            //        "Params");
-            //}
-
             int error = 0;
             bool reboot = false;
+
             foreach (string value in temp)
             {
                 try
@@ -329,19 +323,28 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 CustomMessageBox.Show("Not all parameters successfully saved.", "Saved");
             else
                 CustomMessageBox.Show("Parameters successfully saved.", "Saved");
+
             //Check if reboot is required
             if (reboot)
             {
                CustomMessageBox.Show("Reboot is required for some parameters to take effect.", "Reboot Required");
             }
 
-            if (MainV2.comPort.MAV.param.TotalReceived != MainV2.comPort.MAV.param.TotalReported)
+            if (MainV2.comPort.MAV.param.TotalReceived != MainV2.comPort.MAV.param.TotalReported )
             {
-                CustomMessageBox.Show("The number of available parameters changed. A full param refresh will be done to show all params.", "Params");
-                //Click on refresh button
-                BUT_rerequestparams_Click(BUT_rerequestparams, null);
+                if (MainV2.comPort.MAV.cs.armed)
+                {
+                    CustomMessageBox.Show("The number of available parameters changed, until full param refresh is done, some parameters will not be available.", "Params");
+                    //Hack the number of reported params to keep params list available
+                    MainV2.comPort.MAV.param.TotalReported = MainV2.comPort.MAV.param.TotalReceived;
+                }
+                else
+                {
+                    CustomMessageBox.Show("The number of available parameters changed. A full param refresh will be done to show all params.", "Params");
+                    //Click on refresh button
+                    BUT_rerequestparams_Click(BUT_rerequestparams, null);
+                }
             }
-
         }
 
         private void BUT_compare_Click(object sender, EventArgs e)

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -263,12 +263,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             bool enable = temp.Any(a => a.EndsWith("_ENABLE"));
 
-            if (enable)
-            {
-                CustomMessageBox.Show(
-                    "You have changed an Enable parameter. You may need to do a full param refresh to show all params",
-                    "Params");
-            }
+            //if (enable)
+            //{
+            //    CustomMessageBox.Show(
+            //        "You have changed an Enable parameter. You may need to do a full param refresh to show all params",
+            //        "Params");
+            //}
 
             int error = 0;
 
@@ -325,6 +325,15 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 CustomMessageBox.Show("Not all parameters successfully saved.", "Saved");
             else
                 CustomMessageBox.Show("Parameters successfully saved.", "Saved");
+
+
+            if (MainV2.comPort.MAV.param.TotalReceived != MainV2.comPort.MAV.param.TotalReported)
+            {
+                CustomMessageBox.Show("The number of available parameters changed. A full param refresh will be done to show all params.", "Params");
+                //Click on refresh button
+                BUT_rerequestparams_Click(BUT_rerequestparams, null);
+
+            }
 
         }
 


### PR DESCRIPTION
If a param change causing the change in the number of parameters, the parameter subsystem could stuck in a "downloading is in progress" state. This pr:
removes the name check, since not only _enable parameters can change the number of parameters
Add a check at the end of Write Params and if the reported param number not equals with the current number, it notify the user and do a param refresh.
This fixes #3198 