### PR TITLE
mavcmd: do-change-speed Type field includes possible values

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -193,7 +193,7 @@
       <Z></Z>
     </DO_AUX_FUNCTION>
     <DO_CHANGE_SPEED>
-      <P1>Type</P1>
+      <P1>Type (0:horiz,2:up,3:down)</P1>
       <P2>Speed m/s</P2>
       <P3></P3>
       <P4></P4>


### PR DESCRIPTION
This slightly changes what the Plan page shows in the command list for DO_CHANGE_SPEED for Copters by adding the available options 0, 2 and 3.  I think many users do not know about 2 and 3.

Below are before vs after shots of what the Type field looks like.  In the 2nd "AFTER" it shows what is displayed when the user hovers over the field.
![mp-plan-before-vs-after](https://github.com/ArduPilot/MissionPlanner/assets/1498098/324322cf-d243-4554-804f-d11b1aac5592)
