### PR TITLE
DisplayView: Disable ConfigStandardParams and ConfigAdvancedParams 

### DIFF
--- a/ExtLibs/Utilities/DisplayView.cs
+++ b/ExtLibs/Utilities/DisplayView.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using org.mariuszgromada.math.mxparser.mathcollection;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -196,10 +197,10 @@ namespace MissionPlanner.Utilities
             //config tuning
             displayBasicTuning = true;
             displayExtendedTuning = true;
-            displayStandardParams = true;
+            displayStandardParams = false;
             displayAdvancedParams = false;
-            displayFullParamList = false;
-            displayFullParamTree = false;
+            displayFullParamList = true;
+            displayFullParamTree = true;
             displayParamCommitButton = false;
             displayBaudCMB = true;
             standardFlightModesOnly = false;
@@ -322,10 +323,10 @@ namespace MissionPlanner.Utilities
                  //config tuning
                 displayBasicTuning = true,
                 displayExtendedTuning = true,
-                displayStandardParams = true,
+                displayStandardParams = false,
                 displayAdvancedParams = false,
-                displayFullParamList = false,
-                displayFullParamTree = false,
+                displayFullParamList = true,
+                displayFullParamTree = true,
                 displayParamCommitButton = false,
                 displayBaudCMB = true,
                 displaySerialPortCMB = true,
@@ -404,8 +405,8 @@ namespace MissionPlanner.Utilities
                 //config tuning
                 displayBasicTuning = true,
                 displayExtendedTuning = true,
-                displayStandardParams = true,
-                displayAdvancedParams = true,
+                displayStandardParams = false,
+                displayAdvancedParams = false,
                 displayFullParamList = true,
                 displayFullParamTree = true,
                 displayParamCommitButton = false,

--- a/GCSViews/SoftwareConfig.cs
+++ b/GCSViews/SoftwareConfig.cs
@@ -94,7 +94,7 @@ namespace MissionPlanner.GCSViews
                             start = AddBackstageViewPage(typeof(ConfigAntennaTracker), Strings.ExtendedTuning);
                         }
 
-                        if (MainV2.DisplayConfiguration.displayBasicTuning)
+                        if (MainV2.DisplayConfiguration.displayStandardParams)
                         {
                             AddBackstageViewPage(typeof(ConfigFriendlyParams), Strings.StandardParams);
                         }
@@ -122,7 +122,7 @@ namespace MissionPlanner.GCSViews
                 if (MainV2.DisplayConfiguration.displayFullParamList)
                 {
                     if(!MainV2.comPort.BaseStream.IsOpen || gotAllParams)
-                        AddBackstageViewPage(typeof(ConfigRawParams), Strings.FullParameterList, null, true);
+                        AddBackstageViewPage(typeof(ConfigRawParams), Strings.FullParameterList, null, false);
                 }
                 if (MainV2.comPort.BaseStream.IsOpen)
                 {

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -974,6 +974,10 @@ namespace MissionPlanner
                 try
                 {
                     DisplayConfiguration = Settings.Instance.GetDisplayView("displayview");
+                    //Force new view in case of saved view in config.xml 
+                    DisplayConfiguration.displayAdvancedParams = false;
+                    DisplayConfiguration.displayStandardParams = false;
+                    DisplayConfiguration.displayFullParamList = true;
                 }
                 catch
                 {


### PR DESCRIPTION
Disable Standard and Advanced Param view and enables FullParamList in basic and advanced views.
custom layouts not impacted, if needed Advanced and Standard param pages can be enabled.
This fixes #3270
