### PR TITLE
MavLinkParam: Fix error when float param value is larger than decimal.MaxValue

### DIFF
--- a/ExtLibs/Mavlink/MAVLinkParam.cs
+++ b/ExtLibs/Mavlink/MAVLinkParam.cs
@@ -128,8 +128,18 @@ item.float_value
 0.8
 (double)item.float_value
 0.800000011920929
- */
-                    return (double)(decimal)float_value;
+ */                 {
+                        //In case of very large numbers, decimal conversion could fail. In that case fall back to straight double conversion
+                        try
+                        {
+                            return (double)(decimal)float_value;
+
+                        }
+                        catch
+                        {
+                            return (double)float_value;
+                        }
+                    }
             }
 
             throw new FormatException("invalid type");


### PR DESCRIPTION
Fix exception, when a float parameter has value larger than decimal.MaxValue.
(The only possible case when flt_max is used in the AP code for a parameter value...)
This fix : https://github.com/ArduPilot/MissionPlanner/issues/3264
