### PR TITLE
ConfigSerial: Update SerialOptionRules.json

### DIFF
--- a/SerialOptionRules.json
+++ b/SerialOptionRules.json
@@ -8,15 +8,5 @@
     "PresetBaudRate": -1,
     "PresetOptionsByte": 0,
     "Comment": "If connecting a Mavlink sensor, consider setting 'Do not forward Mavlink to/from'"
-  },
-  "10": {
-    "PresetBaudRate": -1,
-    "PresetOptionsByte": 7,
-    "Comment": "If not using inverter, remove 'Half Duplex' if not a H7 board remove 'invert Tx/RX' and add 'Pullup' if neccessary"
-  },
-  "23": {
-    "PresetBaudRate": -1,
-    "PresetOptionsByte": 7,
-    "Comment": "If not using inverter, remove 'Half Duplex' if not a H7 board remove 'invert Tx/RX' and add 'Pullup' if neccessary"
   }
 }


### PR DESCRIPTION
Remove rules for set tx/rx inversion on RCIN, since it is done automatically.