### PR TITLE
CurrentState: handle GIMBAL_DEVICE_ATTITUDE_STATUS message

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -3644,6 +3644,16 @@ namespace MissionPlanner
 
                         }
                         break;
+                    case (uint)MAVLink.MAVLINK_MSG_ID.GIMBAL_DEVICE_ATTITUDE_STATUS:
+                        {
+                            var status = mavLinkMessage.ToStructure<MAVLink.mavlink_gimbal_device_attitude_status_t>();
+                            Quaternion q = new Quaternion(status.q[0], status.q[1], status.q[2], status.q[3]);
+                            campointa = (float)(q.get_euler_pitch() * (180.0 / Math.PI));
+                            campointb = (float)(q.get_euler_roll() * (180.0 / Math.PI)); 
+                            campointc = (float)(q.get_euler_yaw() * (180.0 / Math.PI));
+                            if (campointc < 0) campointc += 360; //normalization
+                        }
+                        break;
                     case (uint)MAVLink.MAVLINK_MSG_ID.UAVIONIX_ADSB_OUT_STATUS:
                         {
                             var status = mavLinkMessage.ToStructure<MAVLink.mavlink_uavionix_adsb_out_status_t>();


### PR DESCRIPTION
This PR updates the gimbal attitude with the GIMBAL_DEVICE_ATTITUDE_STATUS MAVLink message, alongside the existing MOUNT_STATUS message.
AP uses the GIMBAL_DEVICE_ATTITUDE_STATUS message instead of the older ardupilot specific MOUNT_STATUS message by [this](https://github.com/ArduPilot/ardupilot/pull/21243).


![image](https://github.com/ArduPilot/MissionPlanner/assets/16643069/34a38e9d-3068-4623-a4bd-65cdd28cac90)
![image](https://github.com/ArduPilot/MissionPlanner/assets/16643069/98f89e39-0bde-4189-a064-ba4c42ecf70b)
![image](https://github.com/ArduPilot/MissionPlanner/assets/16643069/fb5cb25e-6975-4fc0-91e4-89c5950580b8)
