### PR TITLE
for sprung throttles the user should center the throttle

### DIFF
--- a/GCSViews/ConfigurationView/ConfigRadioInput.cs
+++ b/GCSViews/ConfigurationView/ConfigRadioInput.cs
@@ -328,7 +328,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 return;
             }
 
-            CustomMessageBox.Show("Ensure all your sticks are centered and throttle is down, and click ok to continue");
+            CustomMessageBox.Show("Ensure all your sticks are centered and throttle is down, and click ok to continue\nIf you have a sprung throttle then center it and click ok");
 
             MainV2.comPort.MAV.cs.UpdateCurrentSettings(currentStateBindingSource.UpdateDataSource(MainV2.comPort.MAV.cs), true, MainV2.comPort);
 


### PR DESCRIPTION
it would be even better if there was a tick-box for sprung throttle and it automatically set the right option bit for the vehicle type. For example, on plane you would set FLIGHT_OPTIONS bit 10.