### PR TITLE
GCSViews: Config DroneCAN allow with no SLCAN port

### DIFF
--- a/GCSViews/ConfigurationView/ConfigDroneCAN.cs
+++ b/GCSViews/ConfigurationView/ConfigDroneCAN.cs
@@ -31,7 +31,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             uAVCANModelBindingSource.DataSource = allnodes;
 
             if (MainV2.comPort.BaseStream.IsOpen && !MainV2.comPort.MAV.param.ContainsKey("CAN_SLCAN_TIMOUT"))
-                this.Enabled = false;
+                but_slcanmode1.Enabled = false;
         }
 
         List<DroneCANModel> allnodes = new List<DroneCANModel>();
@@ -39,7 +39,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         public void Activate()
         {
             if (MainV2.comPort.MAV.param.Count > 5 && !MainV2.comPort.MAV.param.ContainsKey("CAN_SLCAN_TIMOUT"))
-                this.Enabled = false;
+                but_slcanmode1.Enabled = false;
 
             timer = new Timer();
             timer.Interval = 1000;


### PR DESCRIPTION
Now we have MAVCAN slcan is not required, this allows the config page to still be used, only the SLCAN button is disabled. 

This allows me to use the page in SITL where the is no `CAN_SLCAN_TIMOUT`.

![image](https://github.com/ArduPilot/MissionPlanner/assets/33176108/15e8c60e-6a32-4e29-8daf-2cb197b42465)
