### PR TITLE
mavcmd: add set-camera-source

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -165,6 +165,15 @@
       <Y></Y>
       <Z></Z>
     </SET_CAMERA_FOCUS>
+    <SET_CAMERA_SOURCE>
+      <P1>Id</P1>
+      <P2>Primary(1:RGB,2:IR,3:NDVI,4:Wide)</P2>
+      <P3>Secondary(1:RGB,2:IR,3:NDVI,4:Wide)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_SOURCE>
     <VIDEO_START_CAPTURE>
       <P1>StreamId</P1>
       <P2></P2>
@@ -582,6 +591,15 @@
       <Y></Y>
       <Z></Z>
     </SET_CAMERA_FOCUS>
+    <SET_CAMERA_SOURCE>
+      <P1>Id</P1>
+      <P2>Primary(1:RGB,2:IR,3:NDVI,4:Wide)</P2>
+      <P3>Secondary(1:RGB,2:IR,3:NDVI,4:Wide)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_SOURCE>
     <VIDEO_START_CAPTURE>
       <P1>StreamId</P1>
       <P2></P2>
@@ -999,6 +1017,15 @@
       <Y></Y>
       <Z></Z>
     </SET_CAMERA_FOCUS>
+    <SET_CAMERA_SOURCE>
+      <P1>Id</P1>
+      <P2>Primary(1:RGB,2:IR,3:NDVI,4:Wide)</P2>
+      <P3>Secondary(1:RGB,2:IR,3:NDVI,4:Wide)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_SOURCE>
     <VIDEO_START_CAPTURE>
       <P1>StreamId</P1>
       <P2></P2>


### PR DESCRIPTION
This adds the new SET_CAMERA_SOURCE mission command to the list of possible commands for copter, rover and plane.

This change requires this mavlink PR https://github.com/ArduPilot/mavlink/pull/351 to be merged which should happen at tomorrow's dev call (e.g. Mar 19th).

This has been lightly tested and seems OK to me.
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/567e97e3-aec5-4bce-8572-fd94d65782f8)

The only issue is that we get an invalid number error because the mavlink change hasn't gone in yet.
![image](https://github.com/ArduPilot/MissionPlanner/assets/1498098/52da4526-6b93-4af1-92db-0e14f9145aea)

