### PR TITLE
Config Planner - Choose how to access the map tiles : server, cache or both

### DIFF
--- a/ExtLibs/Utilities/srtm.cs
+++ b/ExtLibs/Utilities/srtm.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Net.Http;
 using System.Threading.Tasks;
 using log4net;
+using GMap.NET;
 
 namespace MissionPlanner.Utilities
 {
@@ -388,16 +389,18 @@ namespace MissionPlanner.Utilities
                         if (!Directory.Exists(datadirectory))
                             Directory.CreateDirectory(datadirectory);
 
-                        lock (objlock)
+                        if (GMaps.Instance.Mode != AccessMode.CacheOnly)
                         {
-                            if (!queue.Contains(filename))
+                            lock (objlock)
                             {
-                                log.Info("Getting " + filename);
-                                queue.Add(filename);
-                                requestSemaphore.Release();
+                                if (!queue.Contains(filename))
+                                {
+                                    log.Info("Getting " + filename);
+                                    queue.Add(filename);
+                                    requestSemaphore.Release();
+                                }
                             }
                         }
-
                     }
                 }
             }

--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -119,6 +119,9 @@
             this.num_linelength = new System.Windows.Forms.NumericUpDown();
             this.label11 = new System.Windows.Forms.Label();
             this.chk_displaytooltip = new System.Windows.Forms.CheckBox();
+            this.CMB_mapCache = new System.Windows.Forms.ComboBox();
+            this.label13 = new System.Windows.Forms.Label();
+            this.BUT_mapCacheDir = new MissionPlanner.Controls.MyButton();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_gcsid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_linelength)).BeginInit();
@@ -859,6 +862,26 @@
             this.chk_displaytooltip.UseVisualStyleBackColor = true;
             this.chk_displaytooltip.CheckedChanged += new System.EventHandler(this.chk_displaytooltip_CheckedChanged);
             // 
+            // CMB_mapCache
+            // 
+            this.CMB_mapCache.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CMB_mapCache.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_mapCache, "CMB_mapCache");
+            this.CMB_mapCache.Name = "CMB_mapCache";
+            this.CMB_mapCache.SelectedIndexChanged += new System.EventHandler(this.CMB_mapCache_SelectedIndexChanged);
+            // 
+            // label13
+            // 
+            resources.ApplyResources(this.label13, "label13");
+            this.label13.Name = "label13";
+            // 
+            // BUT_mapCacheDir
+            // 
+            resources.ApplyResources(this.BUT_mapCacheDir, "BUT_mapCacheDir");
+            this.BUT_mapCacheDir.Name = "BUT_mapCacheDir";
+            this.BUT_mapCacheDir.UseVisualStyleBackColor = true;
+            this.BUT_mapCacheDir.Click += new System.EventHandler(this.BUT_mapCacheDir_Click);
+            // 
             // ConfigPlanner
             // 
             resources.ApplyResources(this, "$this");
@@ -952,6 +975,9 @@
             this.Controls.Add(this.BUT_Joystick);
             this.Controls.Add(this.BUT_videostop);
             this.Controls.Add(this.BUT_videostart);
+            this.Controls.Add(this.label13);
+            this.Controls.Add(this.CMB_mapCache);
+            this.Controls.Add(this.BUT_mapCacheDir);
             this.Name = "ConfigPlanner";
             this.Load += new System.EventHandler(this.ConfigPlanner_Load);
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).EndInit();
@@ -1054,5 +1080,8 @@
         private System.Windows.Forms.NumericUpDown num_linelength;
         private System.Windows.Forms.Label label11;
         private System.Windows.Forms.CheckBox chk_displaytooltip;
+        private System.Windows.Forms.Label label13;
+        public System.Windows.Forms.ComboBox CMB_mapCache;
+        private Controls.MyButton BUT_mapCacheDir;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -1,9 +1,11 @@
 ﻿using DirectShowLib;
 using MissionPlanner.Controls;
 using MissionPlanner.Joystick;
+using MissionPlanner.Maps;
 using MissionPlanner.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -239,6 +241,15 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             chk_displaytarget.Checked = Settings.Instance.GetBoolean("GMapMarkerBase_DisplayTarget", true);
             chk_displaytooltip.Checked = Settings.Instance.GetString("mapicondesc", "") != "";
             num_linelength.Value = Settings.Instance.GetInt32("GMapMarkerBase_Length", 500);
+
+            CMB_mapCache.DataSource = Enum.GetNames(typeof(GMap.NET.AccessMode));
+            try
+            {
+                CMB_mapCache.SelectedIndex = CMB_mapCache.Items.IndexOf(Settings.Instance["mapCache"] ?? GMap.NET.GMaps.Instance.Mode.ToString());
+            }
+            catch
+            {
+            }
 
             startup = false;
         }
@@ -1123,6 +1134,39 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 Settings.Instance["GMapMarkerBase_InactiveDisplayStyle"] = Maps.GMapMarkerBase.InactiveDisplayStyleEnum.Normal.ToString();
                 Maps.GMapMarkerBase.InactiveDisplayStyle = Maps.GMapMarkerBase.InactiveDisplayStyleEnum.Normal;
+            }
+        }
+
+        private void CMB_mapCache_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (startup)
+                return;
+            Settings.Instance["mapCache"] = CMB_mapCache.Text;
+            GMap.NET.GMaps.Instance.Mode = (GMap.NET.AccessMode)Enum.Parse(typeof(GMap.NET.AccessMode), Settings.Instance["mapCache"].ToString());
+        }
+
+        private void BUT_mapCacheDir_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                string folderPath = MyImageCache.Instance.CacheLocation;
+                if (Directory.Exists(folderPath))
+                {
+                    ProcessStartInfo startInfo = new ProcessStartInfo
+                    {
+                        Arguments = folderPath,
+                        FileName = "explorer.exe"
+                    };
+
+                    Process.Start(startInfo);
+                }
+                else
+                {
+                    MessageBox.Show(string.Format("{0} Directory does not exist!", folderPath));
+                }
+            }
+            catch (Exception)
+            {
             }
         }
     }

--- a/GCSViews/ConfigurationView/ConfigPlanner.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.resx
@@ -256,7 +256,7 @@
     <value>NOTE: Set the low level of SEVERITY to speak</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>949, 643</value>
+    <value>949, 693</value>
   </data>
   <data name="CMB_raterc.Items14" xml:space="preserve">
     <value>50</value>
@@ -2836,10 +2836,85 @@
   <data name="CMB_rateattitude.Items1" xml:space="preserve">
     <value>0</value>
   </data>
+	<data name="CMB_mapCache.Location" type="System.Drawing.Point, System.Drawing">
+		<value>107, 653</value>
+	</data>
+	<data name="CMB_mapCache.Size" type="System.Drawing.Size, System.Drawing">
+		<value>138, 21</value>
+	</data>
+	<data name="CMB_mapCache.TabIndex" type="System.Int32, mscorlib">
+		<value>127</value>
+	</data>
+	<data name="&gt;&gt;CMB_mapCache.Name" xml:space="preserve">
+    <value>CMB_mapCache</value>
+  </data>
+	<data name="&gt;&gt;CMB_mapCache.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+	<data name="&gt;&gt;CMB_mapCache.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+	<data name="&gt;&gt;CMB_mapCache.ZOrder" xml:space="preserve">
+    <value>80</value>
+  </data>
+	<data name="label13.AutoSize" type="System.Boolean, mscorlib">
+		<value>True</value>
+	</data>
+	<data name="label13.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+		<value>NoControl</value>
+	</data>
+	<data name="label13.Location" type="System.Drawing.Point, System.Drawing">
+		<value>9, 656</value>
+	</data>
+	<data name="label13.Size" type="System.Drawing.Size, System.Drawing">
+		<value>96, 13</value>
+	</data>
+	<data name="label13.TabIndex" type="System.Int32, mscorlib">
+		<value>50</value>
+	</data>
+	<data name="label13.Text" xml:space="preserve">
+    <value>Map Access Mode</value>
+  </data>
+	<data name="&gt;&gt;label13.Name" xml:space="preserve">
+    <value>label13</value>
+  </data>
+	<data name="&gt;&gt;label13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+	<data name="&gt;&gt;label13.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+	<data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
+    <value>79</value>
+  </data>
+	<data name="BUT_mapCacheDir.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+		<value>NoControl</value>
+	</data>
+	<data name="BUT_mapCacheDir.Location" type="System.Drawing.Point, System.Drawing">
+		<value>251, 653</value>
+	</data>
+	<data name="BUT_mapCacheDir.Size" type="System.Drawing.Size, System.Drawing">
+		<value>94, 21</value>
+	</data>
+	<data name="BUT_mapCacheDir.TabIndex" type="System.Int32, mscorlib">
+		<value>95</value>
+	</data>
+	<data name="BUT_mapCacheDir.Text" xml:space="preserve">
+    <value>Open Map Cache</value>
+  </data>
+	<data name="&gt;&gt;BUT_mapCacheDir.Name" xml:space="preserve">
+    <value>BUT_mapCacheDir</value>
+  </data>
+	<data name="&gt;&gt;BUT_mapCacheDir.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+	<data name="&gt;&gt;BUT_mapCacheDir.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+	<data name="&gt;&gt;BUT_mapCacheDir.ZOrder" xml:space="preserve">
+    <value>81</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
-  </metadata>
-  <metadata name="$this.Language" type="System.Globalization.CultureInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>zh-TW</value>
   </metadata>
 </root>

--- a/Program.cs
+++ b/Program.cs
@@ -316,6 +316,11 @@ namespace MissionPlanner
             Console.WriteLine("Setup GMaps 1");
             // set the cache provider to my custom version
             GMap.NET.GMaps.Instance.PrimaryCache = new Maps.MyImageCache();
+            if (Settings.Instance["mapCache"] != null)
+            {
+                GMap.NET.GMaps.Instance.Mode = (GMap.NET.AccessMode)Enum.Parse(typeof(GMap.NET.AccessMode), Settings.Instance["mapCache"].ToString());
+                log.Info("Map access mode set to : " + GMap.NET.GMaps.Instance.Mode.ToString());
+            }
             Console.WriteLine("Setup GMaps 2");
             // add my custom map providers
             GMap.NET.MapProviders.GMapProviders.List.Add(Maps.WMSProvider.Instance);


### PR DESCRIPTION
- Add ComboBox in ConfigPlanner to choose if map is loaded from cache only, server only or cache and server (default). This setting is saved in the config.xml

- Add button in ConfigPlanner to Open Map Cache Folder

- SRTM files are downloaded if GMaps Access Mode is not CacheOnly

![image](https://github.com/ArduPilot/MissionPlanner/assets/8499666/f5375f74-fb8f-4b7c-9ba1-89d805e26bca)

This greatly reduces cpu load and unnecessary network access in case of using an offline GCS.

I don't know if i need to modify all ConfigPlanner.resx file's language as well ?