### PR TITLE
FlightPlanner : tweak prefetch, Resolves #2591, resolves #2483

### DIFF
--- a/ExtLibs/GMap.NET.Core/GMap.NET/GMaps.cs
+++ b/ExtLibs/GMap.NET.Core/GMap.NET/GMaps.cs
@@ -817,6 +817,31 @@ namespace GMap.NET
 
       readonly Exception noDataException = new Exception("No data in local tile cache...");
 
+      public bool CheckImageExist(GMapProvider provider, GPoint pos, int zoom, out Exception result)
+      {
+         result = null;
+         try
+         {
+            if (Mode != AccessMode.ServerOnly && !provider.BypassCache)
+            {
+               if (PrimaryCache != null)
+               {
+                  return PrimaryCache.CheckImageFromCache(provider.DbId, pos, zoom);
+               }
+
+               if (SecondaryCache != null)
+               {
+                  return SecondaryCache.CheckImageFromCache(provider.DbId, pos, zoom);
+               }
+            }
+         }
+         catch (Exception ex)
+         {
+            Debug.WriteLine("CheckImageExist: " + ex.ToString());
+         }
+         return false;
+      }
+
 #if !PocketPC
       TileHttpHost host;
 

--- a/ExtLibs/GMap.NET.Core/GMap.NET/PureImageCache.cs
+++ b/ExtLibs/GMap.NET.Core/GMap.NET/PureImageCache.cs
@@ -35,5 +35,14 @@ namespace GMap.NET
       /// <param name="type">provider dbid or null to use all providers</param>
       /// <returns>The number of deleted tiles.</returns>
       int DeleteOlderThan(DateTime date, int ? type);
+
+      /// <summary>
+      /// check if image exist on db
+      /// </summary>
+      /// <param name="type"></param>
+      /// <param name="pos"></param>
+      /// <param name="zoom"></param>
+      /// <returns>True if Image Exist, false otherwise</returns>
+      bool CheckImageFromCache(int type, GPoint pos, int zoom);
    }
 }

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
@@ -185,16 +185,22 @@ namespace GMap.NET
          foreach(var pr in provider.Overlays)
          {
             Exception ex;
-            PureImage img;
+            PureImage img = null;
 
             // tile number inversion(BottomLeft -> TopLeft)
             if(pr.InvertedAxisY)
             {
-               img = GMaps.Instance.GetImageFrom(pr, new GPoint(p.X, maxOfTiles.Height - p.Y), zoom, out ex);
+               if (GMaps.Instance.CheckImageExist(pr, new GPoint(p.X, maxOfTiles.Height - p.Y), zoom, out ex))
+                  return true;
+               else
+                  img = GMaps.Instance.GetImageFrom(pr, new GPoint(p.X, maxOfTiles.Height - p.Y), zoom, out ex);
             }
             else // ok
             {
-               img = GMaps.Instance.GetImageFrom(pr, p, zoom, out ex);
+               if (GMaps.Instance.CheckImageExist(pr, p, zoom, out ex))
+                  return true;
+               else
+                  img = GMaps.Instance.GetImageFrom(pr, p, zoom, out ex);
             }
 
             if(img != null)
@@ -295,8 +301,10 @@ namespace GMap.NET
 
       void worker_ProgressChanged(object sender, ProgressChangedEventArgs e)
       {
+         try{
          this.label1.Text = "Fetching tile at zoom (" + zoom + "): " + ((int)e.UserState).ToString() + " of " + all + ", complete: " + e.ProgressPercentage.ToString() + "%";
-         this.progressBarDownload.Value = e.ProgressPercentage;
+         int percent = Math.Max(0, Math.Min(100, e.ProgressPercentage));    
+         this.progressBarDownload.Value = percent;
 
          if (Overlay != null)
          {
@@ -322,6 +330,10 @@ namespace GMap.NET
                  GMapMarkerTile m = new GMapMarkerTile(p, (int)(Overlay.Control.MapProvider.Projection.TileSize.Width / sizeDiff));
                  Overlay.Markers.Add(m);
              }
+         }
+         }
+         catch (Exception)
+         {
          }
       }
 

--- a/ExtLibs/Maps/MyImageCache.cs
+++ b/ExtLibs/Maps/MyImageCache.cs
@@ -183,6 +183,37 @@ namespace MissionPlanner.Maps
             return affectedRows;
         }
 
+        public bool CheckImageFromCache(int type, GPoint pos, int zoom)
+        {
+            bool ret = false;
+            if (Created)
+            {
+                try
+                {
+                    string file = CacheLocation + Path.DirectorySeparatorChar + GMapProviders.TryGetProvider(type).Name +
+                                  Path.DirectorySeparatorChar + zoom + Path.DirectorySeparatorChar + pos.Y +
+                                  Path.DirectorySeparatorChar + pos.X + ".jpg";
+                    if (File.Exists(file))
+                    {
+                        ret = true;
+                    }
+                    else
+                    {
+                        ret = false;
+                    }
+                }
+                catch (Exception ex)
+                {
+#if MONO
+            Console.WriteLine("CheckImageFromCache: " + ex.ToString());
+#endif
+                    Debug.WriteLine("CheckImageFromCache: " + ex.ToString());
+                    ret = false;
+                }
+            }
+            return ret;
+        }
+
         #endregion
     }
 }

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5016,7 +5016,28 @@ namespace MissionPlanner.GCSViews
 
                 maxzoom = Math.Min(maxzoom, MainMap.MaxZoom);
 
-                for (int i = 1; i <= maxzoom; i++)
+                string minzoomstring = "1";
+                if (InputBox.Show("min zoom", "Enter the min zoom to prefetch to.", ref minzoomstring) !=
+                    DialogResult.OK)
+                    return;
+
+                int minzoom = 20;
+                if (!int.TryParse(minzoomstring, out minzoom))
+                {
+                    CustomMessageBox.Show(Strings.InvalidNumberEntered, Strings.ERROR);
+                    return;
+                }
+                minzoom = Math.Max(minzoom, MainMap.MinZoom);
+
+                if (minzoom > maxzoom)
+                {
+                    CustomMessageBox.Show(Strings.InvalidNumberEntered, Strings.ERROR);
+                    return;
+                }
+
+                for (int i = minzoom; i <= maxzoom; i++)
+                {
+                    try
                 {
                     TilePrefetcher obj = new TilePrefetcher();
                     ThemeManager.ApplyThemeTo(obj);
@@ -5030,6 +5051,10 @@ namespace MissionPlanner.GCSViews
                     }
 
                     obj.Dispose();
+                }
+                    catch
+                    {
+                    }
                 }
             }
             else


### PR DESCRIPTION
When prefetching, do not download tile if file already exist
Add minZoom input in prefetch (like maxZoom)
![image](https://github.com/ArduPilot/MissionPlanner/assets/8499666/f64dd536-e400-4f65-b4f7-a52254b05c1d)

Use Parallel.For instead of For to get tiles faster !

Using original for loop to download world from zoom 5 to 1 :
![image](https://github.com/ArduPilot/MissionPlanner/assets/8499666/42d3f2f7-3c86-46e8-8802-ebd2917b65d7)
Middle of land at zoom 12 to 10 :
![image](https://github.com/ArduPilot/MissionPlanner/assets/8499666/7214593f-16b7-477d-ab07-e987c1063a58)

Using Parallel.For loop to download world from zoom 5 to 1 :
![image](https://github.com/ArduPilot/MissionPlanner/assets/8499666/4e731e61-8dc5-493e-9a59-d6b27d0afddd)
Middle of land at zoom 12 to 10 :
![image](https://github.com/ArduPilot/MissionPlanner/assets/8499666/a447c5e5-9837-4011-8e06-b501a02aca3e)

