### PR TITLE
Grid: max altitude increased to 99999m to allow HAPS to use the calculation

### DIFF
--- a/Grid/GridUI.Designer.cs
+++ b/Grid/GridUI.Designer.cs
@@ -1320,7 +1320,7 @@
             0});
             resources.ApplyResources(this.NUM_altitude, "NUM_altitude");
             this.NUM_altitude.Maximum = new decimal(new int[] {
-            9999,
+            99999,
             0,
             0,
             0});


### PR DESCRIPTION
This is a straightforward change: we work with high-altitude balloons intending to do aerial photogrammetry. We need to set flight altitudes of 15km to 35km.

I've tried out the solution and the calculations using this higher altitude seem to be correct.