### PR TITLE
ExtLibs: add SCHA63T to imu types of device ids

### DIFF
--- a/ExtLibs/Utilities/Device.cs
+++ b/ExtLibs/Utilities/Device.cs
@@ -160,6 +160,7 @@ namespace MissionPlanner.Utilities
                 DEVTYPE_INS_BMI085 = 0x39,
                 DEVTYPE_INS_ICM42670 = 0x3A,
                 DEVTYPE_INS_ICM45686 = 0x3B,
+                DEVTYPE_INS_SCHA63T = 0x3C,
             };
 
 


### PR DESCRIPTION
added SCHA63T to imu types in Device.cs.
https://github.com/ArduPilot/ardupilot/pull/26871