### PR TITLE
GNSS: support MAVLink GNSS receiver status information

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -392,6 +392,22 @@ namespace MissionPlanner
         [GroupText("Position")]
         public float gpsyaw { get; private set; }
 
+        [DisplayText("GPS System Errors")]
+        [GroupText("Position")]
+        public uint gpssystem_errors { get; private set; }
+
+        [DisplayText("GPS Authentication Status")]
+        [GroupText("Position")]
+        public byte gpsauthentication_state { get; private set; }
+
+        [DisplayText("GPS Jamming Status")]
+        [GroupText("Position")]
+        public byte gpsjamming_state { get; private set; }
+
+        [DisplayText("GPS Spoofing Status")]
+        [GroupText("Position")]
+        public byte gpsspoofing_state { get; private set; }
+
         [DisplayText("Latitude2 (dd)")]
         [GroupText("Position")]
         public double lat2 { get; set; }
@@ -3048,6 +3064,11 @@ namespace MissionPlanner
                                 gpshdg_acc = -1;
                                 gpsyaw = -1;
                             }
+
+                            gpssystem_errors = gps.system_errors;
+                            gpsauthentication_state = gps.authentication_state;
+                            gpsjamming_state = gps.jamming_state;
+                            gpsspoofing_state = gps.spoofing_state;
 
                             //MAVLink.packets[(byte)MAVLink.MSG_NAMES.GPS_RAW);
                         }

--- a/ExtLibs/Mavlink/Mavlink.cs
+++ b/ExtLibs/Mavlink/Mavlink.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 public partial class MAVLink
 {
-    public const string MAVLINK_BUILD_DATE = "Wed Jan 17 2024";
+    public const string MAVLINK_BUILD_DATE = "Thu May 02 2024";
     public const string MAVLINK_WIRE_PROTOCOL_VERSION = "2.0";
     public const int MAVLINK_MAX_PAYLOAD_LEN = 255;
 
@@ -37,6 +37,7 @@ public partial class MAVLink
         
     // msgid, name, crc, minlength, length, type
     public static message_info[] MAVLINK_MESSAGE_INFOS = new message_info[] {
+        new message_info(26900, "VIDEO_STREAM_INFORMATION99", 222, 246, 246, typeof( mavlink_video_stream_information99_t )),
         new message_info(1, "SYS_STATUS", 124, 31, 31, typeof( mavlink_sys_status_t )),
         new message_info(2, "SYSTEM_TIME", 137, 12, 12, typeof( mavlink_system_time_t )),
         new message_info(4, "PING", 237, 14, 14, typeof( mavlink_ping_t )),
@@ -48,7 +49,7 @@ public partial class MAVLink
         new message_info(21, "PARAM_REQUEST_LIST", 159, 2, 2, typeof( mavlink_param_request_list_t )),
         new message_info(22, "PARAM_VALUE", 220, 25, 25, typeof( mavlink_param_value_t )),
         new message_info(23, "PARAM_SET", 168, 23, 23, typeof( mavlink_param_set_t )),
-        new message_info(24, "GPS_RAW_INT", 24, 30, 52, typeof( mavlink_gps_raw_int_t )),
+        new message_info(24, "GPS_RAW_INT", 24, 30, 59, typeof( mavlink_gps_raw_int_t )),
         new message_info(25, "GPS_STATUS", 23, 101, 101, typeof( mavlink_gps_status_t )),
         new message_info(26, "SCALED_IMU", 170, 22, 24, typeof( mavlink_scaled_imu_t )),
         new message_info(27, "RAW_IMU", 144, 26, 29, typeof( mavlink_raw_imu_t )),
@@ -328,12 +329,11 @@ public partial class MAVLink
         new message_info(50005, "CUBEPILOT_FIRMWARE_UPDATE_RESP", 152, 6, 6, typeof( mavlink_cubepilot_firmware_update_resp_t )),
         new message_info(52000, "AIRLINK_AUTH", 13, 100, 100, typeof( mavlink_airlink_auth_t )),
         new message_info(52001, "AIRLINK_AUTH_RESPONSE", 239, 1, 1, typeof( mavlink_airlink_auth_response_t )),
-        new message_info(26900, "VIDEO_STREAM_INFORMATION99", 222, 246, 246, typeof( mavlink_video_stream_information99_t )),
         new message_info(0, "HEARTBEAT", 50, 9, 9, typeof( mavlink_heartbeat_t )),
 
     };
 
-    public const byte MAVLINK_VERSION = 2;
+    public const byte MAVLINK_VERSION = 3;
 
     public const byte MAVLINK_IFLAG_SIGNED=  0x01;
     public const byte MAVLINK_IFLAG_MASK   = 0x01;
@@ -366,6 +366,7 @@ public partial class MAVLink
     public enum MAVLINK_MSG_ID 
     {
 
+        VIDEO_STREAM_INFORMATION99 = 26900,
         SYS_STATUS = 1,
         SYSTEM_TIME = 2,
         PING = 4,
@@ -657,9 +658,9 @@ public partial class MAVLink
         CUBEPILOT_FIRMWARE_UPDATE_RESP = 50005,
         AIRLINK_AUTH = 52000,
         AIRLINK_AUTH_RESPONSE = 52001,
-        VIDEO_STREAM_INFORMATION99 = 26900,
         HEARTBEAT = 0,
     }
+    
     
     
     ///<summary>  </summary>
@@ -2471,7 +2472,6 @@ public partial class MAVLink
         OSD_PARAM_INVALID_PARAMETER=3, 
         
     };
-    
     
     
     ///<summary> These values define the type of firmware release.  These values indicate the first version or release of this type.  For example the first alpha release would be 64, the second would be 65. </summary>
@@ -5811,6 +5811,91 @@ public partial class MAVLink
         
     };
     
+    ///<summary> Flags indicating errors in a GPS receiver. </summary>
+    [Flags]
+	public enum GPS_SYSTEM_ERROR_FLAGS: uint
+    {
+        ///<summary> There are no errors in the GPS receiver. | </summary>
+        [Description("There are no errors in the GPS receiver.")]
+        GPS_SYSTEM_ERROR_NONE=0, 
+        ///<summary> There are problems with incoming correction streams. | </summary>
+        [Description("There are problems with incoming correction streams.")]
+        GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS=1, 
+        ///<summary> There are problems with the configuration. | </summary>
+        [Description("There are problems with the configuration.")]
+        GPS_SYSTEM_ERROR_CONFIGURATION=2, 
+        ///<summary> There are problems with the software on the GPS receiver. | </summary>
+        [Description("There are problems with the software on the GPS receiver.")]
+        GPS_SYSTEM_ERROR_SOFTWARE=4, 
+        ///<summary> There are problems with an antenna connected to the GPS receiver. | </summary>
+        [Description("There are problems with an antenna connected to the GPS receiver.")]
+        GPS_SYSTEM_ERROR_ANTENNA=8, 
+        ///<summary> There are problems handling all incoming events. | </summary>
+        [Description("There are problems handling all incoming events.")]
+        GPS_SYSTEM_ERROR_EVENT_CONGESTION=16, 
+        ///<summary> The GPS receiver CPU is overloaded. | </summary>
+        [Description("The GPS receiver CPU is overloaded.")]
+        GPS_SYSTEM_ERROR_CPU_OVERLOAD=32, 
+        ///<summary> The GPS receiver is experiencing output congestion. | </summary>
+        [Description("The GPS receiver is experiencing output congestion.")]
+        GPS_SYSTEM_ERROR_OUTPUT_CONGESTION=64, 
+        
+    };
+    
+    ///<summary> Signal authentication state in a GPS receiver. </summary>
+    public enum GPS_AUTHENTICATION_STATE: byte
+    {
+        ///<summary> The GPS receiver does not provide GPS signal authentication info. | </summary>
+        [Description("The GPS receiver does not provide GPS signal authentication info.")]
+        UNKNOWN=0, 
+        ///<summary> The GPS receiver is initializing signal authentication. | </summary>
+        [Description("The GPS receiver is initializing signal authentication.")]
+        INITIALIZING=1, 
+        ///<summary> The GPS receiver encountered an error while initializing signal authentication. | </summary>
+        [Description("The GPS receiver encountered an error while initializing signal authentication.")]
+        ERROR=2, 
+        ///<summary> The GPS receiver has correctly authenticated all signals. | </summary>
+        [Description("The GPS receiver has correctly authenticated all signals.")]
+        OK=3, 
+        ///<summary> GPS signal authentication is disabled on the receiver. | </summary>
+        [Description("GPS signal authentication is disabled on the receiver.")]
+        DISABLED=4, 
+        
+    };
+    
+    ///<summary> Signal jamming state in a GPS receiver. </summary>
+    public enum GPS_JAMMING_STATE: byte
+    {
+        ///<summary> The GPS receiver does not provide GPS signal jamming info. | </summary>
+        [Description("The GPS receiver does not provide GPS signal jamming info.")]
+        UNKNOWN=0, 
+        ///<summary> The GPS receiver detected no signal jamming. | </summary>
+        [Description("The GPS receiver detected no signal jamming.")]
+        OK=1, 
+        ///<summary> The GPS receiver detected signal jamming. | </summary>
+        [Description("The GPS receiver detected signal jamming.")]
+        DETECTED=2, 
+        
+    };
+    
+    ///<summary> Signal spoofing state in a GPS receiver. </summary>
+    public enum GPS_SPOOFING_STATE: byte
+    {
+        ///<summary> The GPS receiver does not provide GPS signal spoofing info. | </summary>
+        [Description("The GPS receiver does not provide GPS signal spoofing info.")]
+        UNKNOWN=0, 
+        ///<summary> The GPS receiver detected no signal spoofing. | </summary>
+        [Description("The GPS receiver detected no signal spoofing.")]
+        OK=1, 
+        ///<summary> The GPS receiver detected signal spoofing. | </summary>
+        [Description("The GPS receiver detected signal spoofing.")]
+        DETECTED=2, 
+        ///<summary> The GPS receiver detected and mitigated signal spoofing. | </summary>
+        [Description("The GPS receiver detected and mitigated signal spoofing.")]
+        MITIGATED=3, 
+        
+    };
+    
     
     ///<summary> State flags for ADS-B transponder dynamic report </summary>
     public enum UAVIONIX_ADSB_OUT_DYNAMIC_STATE: ushort
@@ -6938,6 +7023,94 @@ public partial class MAVLink
         
     };
     
+    [Obsolete]
+    /// extensions_start 0
+    [StructLayout(LayoutKind.Sequential,Pack=1,Size=246)]
+    ///<summary> Information about video stream </summary>
+    public struct mavlink_video_stream_information99_t
+    {
+        /// packet ordered constructor
+        public mavlink_video_stream_information99_t(float framerate,uint bitrate,ushort resolution_h,ushort resolution_v,ushort rotation,byte camera_id,byte status,byte[] uri) 
+        {
+            this.framerate = framerate;
+            this.bitrate = bitrate;
+            this.resolution_h = resolution_h;
+            this.resolution_v = resolution_v;
+            this.rotation = rotation;
+            this.camera_id = camera_id;
+            this.status = status;
+            this.uri = uri;
+            
+        }
+        
+        /// packet xml order
+        public static mavlink_video_stream_information99_t PopulateXMLOrder(byte camera_id,byte status,float framerate,ushort resolution_h,ushort resolution_v,uint bitrate,ushort rotation,byte[] uri) 
+        {
+            var msg = new mavlink_video_stream_information99_t();
+
+            msg.camera_id = camera_id;
+            msg.status = status;
+            msg.framerate = framerate;
+            msg.resolution_h = resolution_h;
+            msg.resolution_v = resolution_v;
+            msg.bitrate = bitrate;
+            msg.rotation = rotation;
+            msg.uri = uri;
+            
+            return msg;
+        }
+        
+
+        /// <summary>Frame rate.  [Hz] </summary>
+        [Units("[Hz]")]
+        [Description("Frame rate.")]
+        //[FieldOffset(0)]
+        public  float framerate;
+
+        /// <summary>Bit rate.  [bits/s] </summary>
+        [Units("[bits/s]")]
+        [Description("Bit rate.")]
+        //[FieldOffset(4)]
+        public  uint bitrate;
+
+        /// <summary>Horizontal resolution.  [pix] </summary>
+        [Units("[pix]")]
+        [Description("Horizontal resolution.")]
+        //[FieldOffset(8)]
+        public  ushort resolution_h;
+
+        /// <summary>Vertical resolution.  [pix] </summary>
+        [Units("[pix]")]
+        [Description("Vertical resolution.")]
+        //[FieldOffset(10)]
+        public  ushort resolution_v;
+
+        /// <summary>Video image rotation clockwise.  [deg] </summary>
+        [Units("[deg]")]
+        [Description("Video image rotation clockwise.")]
+        //[FieldOffset(12)]
+        public  ushort rotation;
+
+        /// <summary>Video Stream ID (1 for first, 2 for second, etc.)   </summary>
+        [Units("")]
+        [Description("Video Stream ID (1 for first, 2 for second, etc.)")]
+        //[FieldOffset(14)]
+        public  byte camera_id;
+
+        /// <summary>Number of streams available.   </summary>
+        [Units("")]
+        [Description("Number of streams available.")]
+        //[FieldOffset(15)]
+        public  byte status;
+
+        /// <summary>Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).   </summary>
+        [Units("")]
+        [Description("Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).")]
+        //[FieldOffset(16)]
+        [MarshalAs(UnmanagedType.ByValArray,SizeConst=230)]
+		public byte[] uri;
+    };
+
     [Obsolete]
     /// extensions_start 0
     [StructLayout(LayoutKind.Sequential,Pack=1,Size=42)]
@@ -12245,94 +12418,6 @@ public partial class MAVLink
 		public byte[] temperature;
     };
 
-    [Obsolete]
-    /// extensions_start 0
-    [StructLayout(LayoutKind.Sequential,Pack=1,Size=246)]
-    ///<summary> Information about video stream </summary>
-    public struct mavlink_video_stream_information99_t
-    {
-        /// packet ordered constructor
-        public mavlink_video_stream_information99_t(float framerate,uint bitrate,ushort resolution_h,ushort resolution_v,ushort rotation,byte camera_id,byte status,byte[] uri) 
-        {
-            this.framerate = framerate;
-            this.bitrate = bitrate;
-            this.resolution_h = resolution_h;
-            this.resolution_v = resolution_v;
-            this.rotation = rotation;
-            this.camera_id = camera_id;
-            this.status = status;
-            this.uri = uri;
-            
-        }
-        
-        /// packet xml order
-        public static mavlink_video_stream_information99_t PopulateXMLOrder(byte camera_id,byte status,float framerate,ushort resolution_h,ushort resolution_v,uint bitrate,ushort rotation,byte[] uri) 
-        {
-            var msg = new mavlink_video_stream_information99_t();
-
-            msg.camera_id = camera_id;
-            msg.status = status;
-            msg.framerate = framerate;
-            msg.resolution_h = resolution_h;
-            msg.resolution_v = resolution_v;
-            msg.bitrate = bitrate;
-            msg.rotation = rotation;
-            msg.uri = uri;
-            
-            return msg;
-        }
-        
-
-        /// <summary>Frame rate.  [Hz] </summary>
-        [Units("[Hz]")]
-        [Description("Frame rate.")]
-        //[FieldOffset(0)]
-        public  float framerate;
-
-        /// <summary>Bit rate.  [bits/s] </summary>
-        [Units("[bits/s]")]
-        [Description("Bit rate.")]
-        //[FieldOffset(4)]
-        public  uint bitrate;
-
-        /// <summary>Horizontal resolution.  [pix] </summary>
-        [Units("[pix]")]
-        [Description("Horizontal resolution.")]
-        //[FieldOffset(8)]
-        public  ushort resolution_h;
-
-        /// <summary>Vertical resolution.  [pix] </summary>
-        [Units("[pix]")]
-        [Description("Vertical resolution.")]
-        //[FieldOffset(10)]
-        public  ushort resolution_v;
-
-        /// <summary>Video image rotation clockwise.  [deg] </summary>
-        [Units("[deg]")]
-        [Description("Video image rotation clockwise.")]
-        //[FieldOffset(12)]
-        public  ushort rotation;
-
-        /// <summary>Video Stream ID (1 for first, 2 for second, etc.)   </summary>
-        [Units("")]
-        [Description("Video Stream ID (1 for first, 2 for second, etc.)")]
-        //[FieldOffset(14)]
-        public  byte camera_id;
-
-        /// <summary>Number of streams available.   </summary>
-        [Units("")]
-        [Description("Number of streams available.")]
-        //[FieldOffset(15)]
-        public  byte status;
-
-        /// <summary>Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).   </summary>
-        [Units("")]
-        [Description("Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).")]
-        //[FieldOffset(16)]
-        [MarshalAs(UnmanagedType.ByValArray,SizeConst=230)]
-		public byte[] uri;
-    };
-
     
     /// extensions_start 0
     [StructLayout(LayoutKind.Sequential,Pack=1,Size=31)]
@@ -12961,12 +13046,12 @@ public partial class MAVLink
 
     
     /// extensions_start 10
-    [StructLayout(LayoutKind.Sequential,Pack=1,Size=52)]
+    [StructLayout(LayoutKind.Sequential,Pack=1,Size=59)]
     ///<summary> The global position, as returned by the Global Positioning System (GPS). This is                 NOT the global position estimate of the system, but rather a RAW sensor value. See message GLOBAL_POSITION for the global position estimate. </summary>
     public struct mavlink_gps_raw_int_t
     {
         /// packet ordered constructor
-        public mavlink_gps_raw_int_t(ulong time_usec,int lat,int lon,int alt,ushort eph,ushort epv,ushort vel,ushort cog,/*GPS_FIX_TYPE*/byte fix_type,byte satellites_visible,int alt_ellipsoid,uint h_acc,uint v_acc,uint vel_acc,uint hdg_acc,ushort yaw) 
+        public mavlink_gps_raw_int_t(ulong time_usec,int lat,int lon,int alt,ushort eph,ushort epv,ushort vel,ushort cog,/*GPS_FIX_TYPE*/byte fix_type,byte satellites_visible,int alt_ellipsoid,uint h_acc,uint v_acc,uint vel_acc,uint hdg_acc,ushort yaw,/*GPS_SYSTEM_ERROR_FLAGS*/uint system_errors,/*GPS_AUTHENTICATION_STATE*/byte authentication_state,/*GPS_JAMMING_STATE*/byte jamming_state,/*GPS_SPOOFING_STATE*/byte spoofing_state) 
         {
             this.time_usec = time_usec;
             this.lat = lat;
@@ -12984,11 +13069,15 @@ public partial class MAVLink
             this.vel_acc = vel_acc;
             this.hdg_acc = hdg_acc;
             this.yaw = yaw;
+            this.system_errors = system_errors;
+            this.authentication_state = authentication_state;
+            this.jamming_state = jamming_state;
+            this.spoofing_state = spoofing_state;
             
         }
         
         /// packet xml order
-        public static mavlink_gps_raw_int_t PopulateXMLOrder(ulong time_usec,/*GPS_FIX_TYPE*/byte fix_type,int lat,int lon,int alt,ushort eph,ushort epv,ushort vel,ushort cog,byte satellites_visible,int alt_ellipsoid,uint h_acc,uint v_acc,uint vel_acc,uint hdg_acc,ushort yaw) 
+        public static mavlink_gps_raw_int_t PopulateXMLOrder(ulong time_usec,/*GPS_FIX_TYPE*/byte fix_type,int lat,int lon,int alt,ushort eph,ushort epv,ushort vel,ushort cog,byte satellites_visible,int alt_ellipsoid,uint h_acc,uint v_acc,uint vel_acc,uint hdg_acc,ushort yaw,/*GPS_SYSTEM_ERROR_FLAGS*/uint system_errors,/*GPS_AUTHENTICATION_STATE*/byte authentication_state,/*GPS_JAMMING_STATE*/byte jamming_state,/*GPS_SPOOFING_STATE*/byte spoofing_state) 
         {
             var msg = new mavlink_gps_raw_int_t();
 
@@ -13008,6 +13097,10 @@ public partial class MAVLink
             msg.vel_acc = vel_acc;
             msg.hdg_acc = hdg_acc;
             msg.yaw = yaw;
+            msg.system_errors = system_errors;
+            msg.authentication_state = authentication_state;
+            msg.jamming_state = jamming_state;
+            msg.spoofing_state = spoofing_state;
             
             return msg;
         }
@@ -13108,6 +13201,30 @@ public partial class MAVLink
         [Description("Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.")]
         //[FieldOffset(50)]
         public  ushort yaw;
+
+        /// <summary>Errors in the GPS system GPS_SYSTEM_ERROR_FLAGS  bitmask</summary>
+        [Units("")]
+        [Description("Errors in the GPS system")]
+        //[FieldOffset(52)]
+        public  /*GPS_SYSTEM_ERROR_FLAGS*/uint system_errors;
+
+        /// <summary>Signal authentication state of the GPS system GPS_AUTHENTICATION_STATE  </summary>
+        [Units("")]
+        [Description("Signal authentication state of the GPS system")]
+        //[FieldOffset(56)]
+        public  /*GPS_AUTHENTICATION_STATE*/byte authentication_state;
+
+        /// <summary>Signal jamming state of the GPS system GPS_JAMMING_STATE  </summary>
+        [Units("")]
+        [Description("Signal jamming state of the GPS system")]
+        //[FieldOffset(57)]
+        public  /*GPS_JAMMING_STATE*/byte jamming_state;
+
+        /// <summary>Signal spoofing state of the GPS system GPS_SPOOFING_STATE  </summary>
+        [Units("")]
+        [Description("Signal spoofing state of the GPS system")]
+        //[FieldOffset(58)]
+        public  /*GPS_SPOOFING_STATE*/byte spoofing_state;
     };
 
     

--- a/ExtLibs/Mavlink/mavlink.lua
+++ b/ExtLibs/Mavlink/mavlink.lua
@@ -20,6 +20,7 @@ protocolVersions = {
 }
 
 messageName = {
+    [26900] = 'VIDEO_STREAM_INFORMATION99',
     [150] = 'SENSOR_OFFSETS',
     [151] = 'SET_MAG_OFFSETS',
     [152] = 'MEMINFO',
@@ -92,7 +93,6 @@ messageName = {
     [11042] = 'ESC_TELEMETRY_21_TO_24',
     [11043] = 'ESC_TELEMETRY_25_TO_28',
     [11044] = 'ESC_TELEMETRY_29_TO_32',
-    [26900] = 'VIDEO_STREAM_INFORMATION99',
     [1] = 'SYS_STATUS',
     [2] = 'SYSTEM_TIME',
     [4] = 'PING',
@@ -2003,6 +2003,34 @@ local enumEntryName = {
         [4] = "MISSION_STATE_PAUSED",
         [5] = "MISSION_STATE_COMPLETE",
     },
+    ["GPS_SYSTEM_ERROR_FLAGS"] = {
+        [0] = "GPS_SYSTEM_ERROR_NONE",
+        [1] = "GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS",
+        [2] = "GPS_SYSTEM_ERROR_CONFIGURATION",
+        [4] = "GPS_SYSTEM_ERROR_SOFTWARE",
+        [8] = "GPS_SYSTEM_ERROR_ANTENNA",
+        [16] = "GPS_SYSTEM_ERROR_EVENT_CONGESTION",
+        [32] = "GPS_SYSTEM_ERROR_CPU_OVERLOAD",
+        [64] = "GPS_SYSTEM_ERROR_OUTPUT_CONGESTION",
+    },
+    ["GPS_AUTHENTICATION_STATE"] = {
+        [0] = "GPS_AUTHENTICATION_STATE_UNKNOWN",
+        [1] = "GPS_AUTHENTICATION_STATE_INITIALIZING",
+        [2] = "GPS_AUTHENTICATION_STATE_ERROR",
+        [3] = "GPS_AUTHENTICATION_STATE_OK",
+        [4] = "GPS_AUTHENTICATION_STATE_DISABLED",
+    },
+    ["GPS_JAMMING_STATE"] = {
+        [0] = "GPS_JAMMING_STATE_UNKNOWN",
+        [1] = "GPS_JAMMING_STATE_OK",
+        [2] = "GPS_JAMMING_STATE_DETECTED",
+    },
+    ["GPS_SPOOFING_STATE"] = {
+        [0] = "GPS_SPOOFING_STATE_UNKNOWN",
+        [1] = "GPS_SPOOFING_STATE_OK",
+        [2] = "GPS_SPOOFING_STATE_DETECTED",
+        [3] = "GPS_SPOOFING_STATE_MITIGATED",
+    },
     ["UAVIONIX_ADSB_OUT_DYNAMIC_STATE"] = {
         [1] = "UAVIONIX_ADSB_OUT_DYNAMIC_STATE_INTENT_CHANGE",
         [2] = "UAVIONIX_ADSB_OUT_DYNAMIC_STATE_AUTOPILOT_ENABLED",
@@ -3061,6 +3089,15 @@ f.cmd_MAV_CMD_EXTERNAL_POSITION_ESTIMATE_param5 = ProtoField.new("param5: Latitu
 f.cmd_MAV_CMD_EXTERNAL_POSITION_ESTIMATE_param6 = ProtoField.new("param6: Longitude (float)", "mavlink_proto.cmd_MAV_CMD_EXTERNAL_POSITION_ESTIMATE_param6", ftypes.FLOAT, nil)
 f.cmd_MAV_CMD_EXTERNAL_POSITION_ESTIMATE_param7 = ProtoField.new("param7: Altitude (float)", "mavlink_proto.cmd_MAV_CMD_EXTERNAL_POSITION_ESTIMATE_param7", ftypes.FLOAT, nil)
 
+
+f.VIDEO_STREAM_INFORMATION99_camera_id = ProtoField.new("camera_id (uint8_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_camera_id", ftypes.UINT8, nil)
+f.VIDEO_STREAM_INFORMATION99_status = ProtoField.new("status (uint8_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_status", ftypes.UINT8, nil)
+f.VIDEO_STREAM_INFORMATION99_framerate = ProtoField.new("framerate (float)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_framerate", ftypes.FLOAT, nil)
+f.VIDEO_STREAM_INFORMATION99_resolution_h = ProtoField.new("resolution_h (uint16_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_resolution_h", ftypes.UINT16, nil)
+f.VIDEO_STREAM_INFORMATION99_resolution_v = ProtoField.new("resolution_v (uint16_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_resolution_v", ftypes.UINT16, nil)
+f.VIDEO_STREAM_INFORMATION99_bitrate = ProtoField.new("bitrate (uint32_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_bitrate", ftypes.UINT32, nil)
+f.VIDEO_STREAM_INFORMATION99_rotation = ProtoField.new("rotation (uint16_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_rotation", ftypes.UINT16, nil)
+f.VIDEO_STREAM_INFORMATION99_uri = ProtoField.new("uri (char)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_uri", ftypes.STRING, nil)
 
 f.SENSOR_OFFSETS_mag_ofs_x = ProtoField.new("mag_ofs_x (int16_t)", "mavlink_proto.SENSOR_OFFSETS_mag_ofs_x", ftypes.INT16, nil)
 f.SENSOR_OFFSETS_mag_ofs_y = ProtoField.new("mag_ofs_y (int16_t)", "mavlink_proto.SENSOR_OFFSETS_mag_ofs_y", ftypes.INT16, nil)
@@ -4887,15 +4924,6 @@ f.ESC_TELEMETRY_29_TO_32_count_1 = ProtoField.new("count[1] (uint16_t)", "mavlin
 f.ESC_TELEMETRY_29_TO_32_count_2 = ProtoField.new("count[2] (uint16_t)", "mavlink_proto.ESC_TELEMETRY_29_TO_32_count_2", ftypes.UINT16, nil)
 f.ESC_TELEMETRY_29_TO_32_count_3 = ProtoField.new("count[3] (uint16_t)", "mavlink_proto.ESC_TELEMETRY_29_TO_32_count_3", ftypes.UINT16, nil)
 
-f.VIDEO_STREAM_INFORMATION99_camera_id = ProtoField.new("camera_id (uint8_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_camera_id", ftypes.UINT8, nil)
-f.VIDEO_STREAM_INFORMATION99_status = ProtoField.new("status (uint8_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_status", ftypes.UINT8, nil)
-f.VIDEO_STREAM_INFORMATION99_framerate = ProtoField.new("framerate (float)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_framerate", ftypes.FLOAT, nil)
-f.VIDEO_STREAM_INFORMATION99_resolution_h = ProtoField.new("resolution_h (uint16_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_resolution_h", ftypes.UINT16, nil)
-f.VIDEO_STREAM_INFORMATION99_resolution_v = ProtoField.new("resolution_v (uint16_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_resolution_v", ftypes.UINT16, nil)
-f.VIDEO_STREAM_INFORMATION99_bitrate = ProtoField.new("bitrate (uint32_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_bitrate", ftypes.UINT32, nil)
-f.VIDEO_STREAM_INFORMATION99_rotation = ProtoField.new("rotation (uint16_t)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_rotation", ftypes.UINT16, nil)
-f.VIDEO_STREAM_INFORMATION99_uri = ProtoField.new("uri (char)", "mavlink_proto.VIDEO_STREAM_INFORMATION99_uri", ftypes.STRING, nil)
-
 f.SYS_STATUS_onboard_control_sensors_present = ProtoField.new("onboard_control_sensors_present (MAV_SYS_STATUS_SENSOR)", "mavlink_proto.SYS_STATUS_onboard_control_sensors_present", ftypes.UINT32, nil)
 f.SYS_STATUS_onboard_control_sensors_present_flagMAV_SYS_STATUS_SENSOR_3D_GYRO = ProtoField.bool("mavlink_proto.SYS_STATUS_onboard_control_sensors_present.MAV_SYS_STATUS_SENSOR_3D_GYRO", "MAV_SYS_STATUS_SENSOR_3D_GYRO", 31, nil, 1)
 f.SYS_STATUS_onboard_control_sensors_present_flagMAV_SYS_STATUS_SENSOR_3D_ACCEL = ProtoField.bool("mavlink_proto.SYS_STATUS_onboard_control_sensors_present.MAV_SYS_STATUS_SENSOR_3D_ACCEL", "MAV_SYS_STATUS_SENSOR_3D_ACCEL", 31, nil, 2)
@@ -5062,6 +5090,17 @@ f.GPS_RAW_INT_v_acc = ProtoField.new("v_acc (uint32_t)", "mavlink_proto.GPS_RAW_
 f.GPS_RAW_INT_vel_acc = ProtoField.new("vel_acc (uint32_t)", "mavlink_proto.GPS_RAW_INT_vel_acc", ftypes.UINT32, nil)
 f.GPS_RAW_INT_hdg_acc = ProtoField.new("hdg_acc (uint32_t)", "mavlink_proto.GPS_RAW_INT_hdg_acc", ftypes.UINT32, nil)
 f.GPS_RAW_INT_yaw = ProtoField.new("yaw (uint16_t)", "mavlink_proto.GPS_RAW_INT_yaw", ftypes.UINT16, nil)
+f.GPS_RAW_INT_system_errors = ProtoField.new("system_errors (GPS_SYSTEM_ERROR_FLAGS)", "mavlink_proto.GPS_RAW_INT_system_errors", ftypes.UINT32, nil)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_INCOMING_CORRECTIONS = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS", "GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS", 7, nil, 1)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_CONFIGURATION = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_CONFIGURATION", "GPS_SYSTEM_ERROR_CONFIGURATION", 7, nil, 2)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_SOFTWARE = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_SOFTWARE", "GPS_SYSTEM_ERROR_SOFTWARE", 7, nil, 4)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_ANTENNA = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_ANTENNA", "GPS_SYSTEM_ERROR_ANTENNA", 7, nil, 8)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_EVENT_CONGESTION = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_EVENT_CONGESTION", "GPS_SYSTEM_ERROR_EVENT_CONGESTION", 7, nil, 16)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_CPU_OVERLOAD = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_CPU_OVERLOAD", "GPS_SYSTEM_ERROR_CPU_OVERLOAD", 7, nil, 32)
+f.GPS_RAW_INT_system_errors_flagGPS_SYSTEM_ERROR_OUTPUT_CONGESTION = ProtoField.bool("mavlink_proto.GPS_RAW_INT_system_errors.GPS_SYSTEM_ERROR_OUTPUT_CONGESTION", "GPS_SYSTEM_ERROR_OUTPUT_CONGESTION", 7, nil, 64)
+f.GPS_RAW_INT_authentication_state = ProtoField.new("authentication_state (GPS_AUTHENTICATION_STATE)", "mavlink_proto.GPS_RAW_INT_authentication_state", ftypes.UINT8, enumEntryName.GPS_AUTHENTICATION_STATE)
+f.GPS_RAW_INT_jamming_state = ProtoField.new("jamming_state (GPS_JAMMING_STATE)", "mavlink_proto.GPS_RAW_INT_jamming_state", ftypes.UINT8, enumEntryName.GPS_JAMMING_STATE)
+f.GPS_RAW_INT_spoofing_state = ProtoField.new("spoofing_state (GPS_SPOOFING_STATE)", "mavlink_proto.GPS_RAW_INT_spoofing_state", ftypes.UINT8, enumEntryName.GPS_SPOOFING_STATE)
 
 f.GPS_STATUS_satellites_visible = ProtoField.new("satellites_visible (uint8_t)", "mavlink_proto.GPS_STATUS_satellites_visible", ftypes.UINT8, nil)
 f.GPS_STATUS_satellite_prn_0 = ProtoField.new("satellite_prn[0] (uint8_t)", "mavlink_proto.GPS_STATUS_satellite_prn_0", ftypes.UINT8, nil)
@@ -11093,6 +11132,16 @@ function dissect_flags_MAV_WINCH_STATUS_FLAG(tree, name, tvbrange, value)
     tree:add_le(f[name .. "_flagMAV_WINCH_STATUS_CLUTCH_ENGAGED"], tvbrange, value)
 end
 -- dissect flag field
+function dissect_flags_GPS_SYSTEM_ERROR_FLAGS(tree, name, tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_INCOMING_CORRECTIONS"], tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_CONFIGURATION"], tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_SOFTWARE"], tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_ANTENNA"], tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_EVENT_CONGESTION"], tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_CPU_OVERLOAD"], tvbrange, value)
+    tree:add_le(f[name .. "_flagGPS_SYSTEM_ERROR_OUTPUT_CONGESTION"], tvbrange, value)
+end
+-- dissect flag field
 function dissect_flags_UAVIONIX_ADSB_OUT_DYNAMIC_STATE(tree, name, tvbrange, value)
     tree:add_le(f[name .. "_flagUAVIONIX_ADSB_OUT_DYNAMIC_STATE_INTENT_CHANGE"], tvbrange, value)
     tree:add_le(f[name .. "_flagUAVIONIX_ADSB_OUT_DYNAMIC_STATE_AUTOPILOT_ENABLED"], tvbrange, value)
@@ -11165,6 +11214,41 @@ function dissect_flags_MAV_MODE_FLAG_DECODE_POSITION(tree, name, tvbrange, value
     tree:add_le(f[name .. "_flagMAV_MODE_FLAG_DECODE_POSITION_HIL"], tvbrange, value)
     tree:add_le(f[name .. "_flagMAV_MODE_FLAG_DECODE_POSITION_MANUAL"], tvbrange, value)
     tree:add_le(f[name .. "_flagMAV_MODE_FLAG_DECODE_POSITION_SAFETY"], tvbrange, value)
+end
+-- dissect payload of message type VIDEO_STREAM_INFORMATION99
+function payload_fns.payload_26900(buffer, tree, msgid, offset, limit, pinfo)
+    local padded, field_offset, value, subtree, tvbrange
+    if (offset + 246 > limit) then
+        padded = buffer(0, limit):bytes()
+        padded:set_size(offset + 246)
+        padded = padded:tvb("Untruncated payload")
+    else
+        padded = buffer
+    end
+    tvbrange = padded(offset + 14, 1)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_camera_id, tvbrange, value)
+    tvbrange = padded(offset + 15, 1)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_status, tvbrange, value)
+    tvbrange = padded(offset + 0, 4)
+    value = tvbrange:le_float()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_framerate, tvbrange, value)
+    tvbrange = padded(offset + 8, 2)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_resolution_h, tvbrange, value)
+    tvbrange = padded(offset + 10, 2)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_resolution_v, tvbrange, value)
+    tvbrange = padded(offset + 4, 4)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_bitrate, tvbrange, value)
+    tvbrange = padded(offset + 12, 2)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_rotation, tvbrange, value)
+    tvbrange = padded(offset + 16, 230)
+    value = tvbrange:string()
+    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_uri, tvbrange, value)
 end
 -- dissect payload of message type SENSOR_OFFSETS
 function payload_fns.payload_150(buffer, tree, msgid, offset, limit, pinfo)
@@ -17151,41 +17235,6 @@ function payload_fns.payload_11044(buffer, tree, msgid, offset, limit, pinfo)
     value = tvbrange:le_uint()
     subtree = tree:add_le(f.ESC_TELEMETRY_29_TO_32_count_3, tvbrange, value)
 end
--- dissect payload of message type VIDEO_STREAM_INFORMATION99
-function payload_fns.payload_26900(buffer, tree, msgid, offset, limit, pinfo)
-    local padded, field_offset, value, subtree, tvbrange
-    if (offset + 246 > limit) then
-        padded = buffer(0, limit):bytes()
-        padded:set_size(offset + 246)
-        padded = padded:tvb("Untruncated payload")
-    else
-        padded = buffer
-    end
-    tvbrange = padded(offset + 14, 1)
-    value = tvbrange:le_uint()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_camera_id, tvbrange, value)
-    tvbrange = padded(offset + 15, 1)
-    value = tvbrange:le_uint()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_status, tvbrange, value)
-    tvbrange = padded(offset + 0, 4)
-    value = tvbrange:le_float()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_framerate, tvbrange, value)
-    tvbrange = padded(offset + 8, 2)
-    value = tvbrange:le_uint()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_resolution_h, tvbrange, value)
-    tvbrange = padded(offset + 10, 2)
-    value = tvbrange:le_uint()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_resolution_v, tvbrange, value)
-    tvbrange = padded(offset + 4, 4)
-    value = tvbrange:le_uint()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_bitrate, tvbrange, value)
-    tvbrange = padded(offset + 12, 2)
-    value = tvbrange:le_uint()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_rotation, tvbrange, value)
-    tvbrange = padded(offset + 16, 230)
-    value = tvbrange:string()
-    subtree = tree:add_le(f.VIDEO_STREAM_INFORMATION99_uri, tvbrange, value)
-end
 -- dissect payload of message type SYS_STATUS
 function payload_fns.payload_1(buffer, tree, msgid, offset, limit, pinfo)
     local padded, field_offset, value, subtree, tvbrange
@@ -17451,9 +17500,9 @@ end
 -- dissect payload of message type GPS_RAW_INT
 function payload_fns.payload_24(buffer, tree, msgid, offset, limit, pinfo)
     local padded, field_offset, value, subtree, tvbrange
-    if (offset + 52 > limit) then
+    if (offset + 59 > limit) then
         padded = buffer(0, limit):bytes()
-        padded:set_size(offset + 52)
+        padded:set_size(offset + 59)
         padded = padded:tvb("Untruncated payload")
     else
         padded = buffer
@@ -17506,6 +17555,19 @@ function payload_fns.payload_24(buffer, tree, msgid, offset, limit, pinfo)
     tvbrange = padded(offset + 50, 2)
     value = tvbrange:le_uint()
     subtree = tree:add_le(f.GPS_RAW_INT_yaw, tvbrange, value)
+    tvbrange = padded(offset + 52, 4)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.GPS_RAW_INT_system_errors, tvbrange, value)
+    dissect_flags_GPS_SYSTEM_ERROR_FLAGS(subtree, "GPS_RAW_INT_system_errors", tvbrange, value)
+    tvbrange = padded(offset + 56, 1)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.GPS_RAW_INT_authentication_state, tvbrange, value)
+    tvbrange = padded(offset + 57, 1)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.GPS_RAW_INT_jamming_state, tvbrange, value)
+    tvbrange = padded(offset + 58, 1)
+    value = tvbrange:le_uint()
+    subtree = tree:add_le(f.GPS_RAW_INT_spoofing_state, tvbrange, value)
 end
 -- dissect payload of message type GPS_STATUS
 function payload_fns.payload_25(buffer, tree, msgid, offset, limit, pinfo)

--- a/ExtLibs/Mavlink/message_definitions/common.xml
+++ b/ExtLibs/Mavlink/message_definitions/common.xml
@@ -4123,6 +4123,78 @@
         <description>Mission has executed all mission items.</description>
       </entry>
     </enum>
+	  <enum name="GPS_SYSTEM_ERROR_FLAGS" bitmask="true">
+		  <description>Flags indicating errors in a GPS receiver.</description>
+		  <entry value="0" name="GPS_SYSTEM_ERROR_NONE">
+			  <description>There are no errors in the GPS receiver.</description>
+		  </entry>
+		  <entry value="1" name="GPS_SYSTEM_ERROR_INCOMING_CORRECTIONS">
+			  <description>There are problems with incoming correction streams.</description>
+		  </entry>
+		  <entry value="2" name="GPS_SYSTEM_ERROR_CONFIGURATION">
+			  <description>There are problems with the configuration.</description>
+		  </entry>
+		  <entry value="4" name="GPS_SYSTEM_ERROR_SOFTWARE">
+			  <description>There are problems with the software on the GPS receiver.</description>
+		  </entry>
+		  <entry value="8" name="GPS_SYSTEM_ERROR_ANTENNA">
+			  <description>There are problems with an antenna connected to the GPS receiver.</description>
+		  </entry>
+		  <entry value="16" name="GPS_SYSTEM_ERROR_EVENT_CONGESTION">
+			  <description>There are problems handling all incoming events.</description>
+		  </entry>
+		  <entry value="32" name="GPS_SYSTEM_ERROR_CPU_OVERLOAD">
+			  <description>The GPS receiver CPU is overloaded.</description>
+		  </entry>
+		  <entry value="64" name="GPS_SYSTEM_ERROR_OUTPUT_CONGESTION">
+			  <description>The GPS receiver is experiencing output congestion.</description>
+		  </entry>
+	  </enum>
+	  <enum name="GPS_AUTHENTICATION_STATE">
+		  <description>Signal authentication state in a GPS receiver.</description>
+		  <entry value="0" name="GPS_AUTHENTICATION_STATE_UNKNOWN">
+			  <description>The GPS receiver does not provide GPS signal authentication info.</description>
+		  </entry>
+		  <entry value="1" name="GPS_AUTHENTICATION_STATE_INITIALIZING">
+			  <description>The GPS receiver is initializing signal authentication.</description>
+		  </entry>
+		  <entry value="2" name="GPS_AUTHENTICATION_STATE_ERROR">
+			  <description>The GPS receiver encountered an error while initializing signal authentication.</description>
+		  </entry>
+		  <entry value="3" name="GPS_AUTHENTICATION_STATE_OK">
+			  <description>The GPS receiver has correctly authenticated all signals.</description>
+		  </entry>
+		  <entry value="4" name="GPS_AUTHENTICATION_STATE_DISABLED">
+			  <description>GPS signal authentication is disabled on the receiver.</description>
+		  </entry>
+	  </enum>
+	  <enum name="GPS_JAMMING_STATE">
+		  <description>Signal jamming state in a GPS receiver.</description>
+		  <entry value="0" name="GPS_JAMMING_STATE_UNKNOWN">
+			  <description>The GPS receiver does not provide GPS signal jamming info.</description>
+		  </entry>
+		  <entry value="1" name="GPS_JAMMING_STATE_OK">
+			  <description>The GPS receiver detected no signal jamming.</description>
+		  </entry>
+		  <entry value="2" name="GPS_JAMMING_STATE_DETECTED">
+			  <description>The GPS receiver detected signal jamming.</description>
+		  </entry>
+	  </enum>
+	  <enum name="GPS_SPOOFING_STATE">
+		  <description>Signal spoofing state in a GPS receiver.</description>
+		  <entry value="0" name="GPS_SPOOFING_STATE_UNKNOWN">
+			  <description>The GPS receiver does not provide GPS signal spoofing info.</description>
+		  </entry>
+		  <entry value="1" name="GPS_SPOOFING_STATE_OK">
+			  <description>The GPS receiver detected no signal spoofing.</description>
+		  </entry>
+		  <entry value="2" name="GPS_SPOOFING_STATE_DETECTED">
+			  <description>The GPS receiver detected signal spoofing.</description>
+		  </entry>
+		  <entry value="3" name="GPS_SPOOFING_STATE_MITIGATED">
+			  <description>The GPS receiver detected and mitigated signal spoofing.</description>
+		  </entry>
+	  </enum>
   </enums>
   <messages>
     <message id="1" name="SYS_STATUS">
@@ -4230,6 +4302,10 @@
       <field type="uint32_t" name="vel_acc" units="mm">Speed uncertainty.</field>
       <field type="uint32_t" name="hdg_acc" units="degE5">Heading / track uncertainty</field>
       <field type="uint16_t" name="yaw" units="cdeg">Yaw in earth frame from north. Use 0 if this GPS does not provide yaw. Use 65535 if this GPS is configured to provide yaw and is currently unable to provide it. Use 36000 for north.</field>
+	  <field type="uint32_t" name="system_errors" enum="GPS_SYSTEM_ERROR_FLAGS" display="bitmask">Errors in the GPS system</field>
+	  <field type="uint8_t" name="authentication_state" enum="GPS_AUTHENTICATION_STATE">Signal authentication state of the GPS system</field>
+	  <field type="uint8_t" name="jamming_state" enum="GPS_JAMMING_STATE">Signal jamming state of the GPS system</field>
+	  <field type="uint8_t" name="spoofing_state" enum="GPS_SPOOFING_STATE">Signal spoofing state of the GPS system</field>
     </message>
     <message id="25" name="GPS_STATUS">
       <description>The positioning status, as reported by GPS. This message is intended to display status information about each satellite visible to the receiver. See message GLOBAL_POSITION for the global position estimate. This message can contain information for up to 20 satellites.</description>


### PR DESCRIPTION
Add support for GNSS status information from MAVLink, which includes authentication, errors and interference status.