### PR TITLE
FlighPlanner: Fix map moving to 0,0 when HomeLocation clicked 

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -7998,7 +7998,15 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
 
         private void zoomToHomeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            MainMap.Position = MainV2.comPort.MAV.cs.HomeLocation;
+            if (MainV2.comPort.MAV.cs.HomeLocation.Lat != 0 && MainV2.comPort.MAV.cs.HomeLocation.Lng != 0)
+            {
+                MainMap.Position = MainV2.comPort.MAV.cs.HomeLocation;
+            }
+            else if (MainV2.comPort.MAV.cs.PlannedHomeLocation.Lat != 0 && MainV2.comPort.MAV.cs.PlannedHomeLocation.Lat != 0)
+            {
+                MainMap.Position = MainV2.comPort.MAV.cs.PlannedHomeLocation;
+            }
+
             if (MainMap.Zoom < 17)
                 MainMap.Zoom = 17;
         }


### PR DESCRIPTION
If the vehicle does not have a Home Location yet and user click on the Home Location link to the right side, zoomToHome moves to the map to 0,0. Now it check if there is a valid Home Location or Planned Home location and use that .