### PR TITLE
Settings:Fix RemoveList to remove last item in the setting

### DIFF
--- a/ExtLibs/Utilities/Settings.cs
+++ b/ExtLibs/Utilities/Settings.cs
@@ -185,7 +185,17 @@ namespace MissionPlanner.Utilities
         public void RemoveList(string key, string item)
         {
             var list = GetList(key).ToList().Where(a => a != item);
-            SetList(key, list);
+            //if the list is empty remove the key
+            if (list == null || list.Count() == 0)
+            {
+                if (config.ContainsKey(key))
+                    config.Remove(key);
+                return;
+            }
+            else
+            {
+                SetList(key, list);
+            }
         }
 
         public int GetInt32(string key, int defaulti = 0)


### PR DESCRIPTION
Fixes when RemoveList tries to remoce the last item in a list. It calls SetList, but it returns without setting the key if the list is empty. So the last item is not cleared from a list.