### PR TITLE
ConigInitialParams: Mot thrst calc changes as requested by Xfacta

### DIFF
--- a/GCSViews/ConfigurationView/ConfigInitialParams.cs
+++ b/GCSViews/ConfigurationView/ConfigInitialParams.cs
@@ -108,8 +108,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             atc_rat_yaw_fltt = Math.Max(10, ins_gyro_filter / 2);
 
             atc_thr_mix_man = 0.1;
-            ins_accel_filter = 20;
-            mot_thst_expo = Math.Round(0.1405 * Math.Log(prop_size) + 0.3254, 2);
+            ins_accel_filter = 10;
+            mot_thst_expo = Math.Round(0.15686 * Math.Log(prop_size) + 0.23693, 2);
             mot_thst_hover = 0.2;
 
             batt_arm_volt = (batt_cells - 1) * 0.1 + (batt_cell_min_voltage+0.3) * batt_cells;


### PR DESCRIPTION
The lower accel filter value is what we’ve been using for quite some time now due to Leonard Halls recommendation, and the initial parameters is the best way to get this into new builds without changing the default value or affecting upgrades of existing copters. Any other method will put extra work load on Randy.

The slightly different thrust expo calculation is derived from collected data and some experimentation. The biggest change is very large prop sizes will be limited to around 0.80 thrust expo instead of going unrealistically high. This does also give slightly lower thrust expo values for smaller props, but still fits with flight data.