### PR TITLE
FlighData : Relay display name start from 1

### DIFF
--- a/Controls/RelayOptions.cs
+++ b/Controls/RelayOptions.cs
@@ -18,7 +18,7 @@ namespace MissionPlanner.Controls
 
             thisrelay = relay;
 
-            TXT_rcchannel.Text = "Relay " + thisrelay.ToString();
+            TXT_rcchannel.Text = "Relay " + (thisrelay+1).ToString();
 
             loadSettings();
 

--- a/GCSViews/FlightData.resx
+++ b/GCSViews/FlightData.resx
@@ -3649,6 +3649,9 @@
   <data name="flowLayoutPanelServos.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <data name="flowLayoutPanelServos.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
+    <value>TopDown</value>
+  </data>
   <data name="flowLayoutPanelServos.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>


### PR DESCRIPTION
As asked in #3380  Relays display name starts from 1 instead of zero
Change the flow of controls in servoTab for a tidier look.