### PR TITLE
MSI: Update installer.bat

### DIFF
--- a/Msi/installer.bat
+++ b/Msi/installer.bat
@@ -4,7 +4,7 @@ for /f %%f in ('dir /a-d /b ..\bin\Release\net461\plugins') do if exist ..\bin\R
 
 powershell -command "cd..; ls plugins -recurse | ForEach-Object { if (Test-Path ($_.fullname -replace '\\plugins\\','\') -PathType Leaf) { $_.fullname }} | ForEach-Object { del $_ }"
 
-wix.exe ..\bin\release\net461\
+.\net472\wix.exe ..\bin\release\net461\
 
 pause
 


### PR DESCRIPTION
From 1.3.82 wix.exe is generated in the net472 subfolder instead in the msi folder...