### PR TITLE
Plugin: Create Terrain DAT file for uploading

### DIFF
--- a/MissionPlanner.sln
+++ b/MissionPlanner.sln
@@ -3,14 +3,14 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MissionPlanner", "MissionPlanner.csproj", "{A2E22272-95FE-47B6-B050-9AE7E2055BF5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MissionPlanner", "MissionPlanner.csproj", "{A2E22272-95FE-47B6-B050-9AE7E2055BF5}"
 	ProjectSection(ProjectDependencies) = postProject
 		{DF86AFC2-CA79-4137-9BB5-70AA529C3B79} = {DF86AFC2-CA79-4137-9BB5-70AA529C3B79}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Updater", "Updater\Updater.csproj", "{E64A1A41-A5B0-458E-8284-BB63705354DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Updater", "Updater\Updater.csproj", "{E64A1A41-A5B0-458E-8284-BB63705354DA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "wix", "wix\wix.csproj", "{76374F95-C343-4ACC-B86F-7ECFDD668F46}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "wix", "wix\wix.csproj", "{76374F95-C343-4ACC-B86F-7ECFDD668F46}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Plugins", "Plugins", "{9B3AC501-5FCB-4A2A-A628-BE0985DB2BD4}"
 EndProject
@@ -83,7 +83,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtGuided", "ExtLibs\ExtGui
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibVLC.NET", "ExtLibs\LibVLC.NET\LibVLC.NET.csproj", "{BB06DFF7-4F41-4B9D-A3C3-3B6D2B8702B6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SikRadio", "SikRadio\SikRadio.csproj", "{B8943726-04B0-4477-BFDA-E156A0CD98A4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SikRadio", "SikRadio\SikRadio.csproj", "{B8943726-04B0-4477-BFDA-E156A0CD98A4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ManagedNativeWifi.Simple", "ExtLibs\ManagedNativeWifi.Simple\ManagedNativeWifi.Simple.csproj", "{CCE510F7-1DA6-40F2-8921-B86ED41BB85E}"
 EndProject
@@ -219,9 +219,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenDroneID_Plugin", "Plugi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bulb", "ExtLibs\LEDBulb\Bulb\Bulb.csproj", "{AF81C41B-06E6-4CA5-9FD4-A4E7042F1107}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MissionPlannerTests", "MissionPlannerTests\MissionPlannerTests.csproj", "{0B99EBF2-B964-4AAC-9EC5-76353610AAAE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MissionPlannerTests", "MissionPlannerTests\MissionPlannerTests.csproj", "{0B99EBF2-B964-4AAC-9EC5-76353610AAAE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MockDroneID", "ExtLibs\MockDroneID\MockDroneID.csproj", "{6D39C141-733B-4C4A-87AB-974637952D1B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerrainMakerPlugin", "Plugins\TerrainMakerPlugin\TerrainMakerPlugin.csproj", "{DDD2FEA8-801E-463B-8913-9CCCDA2D9429}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -550,6 +552,10 @@ Global
 		{6D39C141-733B-4C4A-87AB-974637952D1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D39C141-733B-4C4A-87AB-974637952D1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D39C141-733B-4C4A-87AB-974637952D1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDD2FEA8-801E-463B-8913-9CCCDA2D9429}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDD2FEA8-801E-463B-8913-9CCCDA2D9429}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDD2FEA8-801E-463B-8913-9CCCDA2D9429}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDD2FEA8-801E-463B-8913-9CCCDA2D9429}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -635,6 +641,7 @@ Global
 		{FBE658B3-684D-46E6-8668-50DEF0778538} = {9B3AC501-5FCB-4A2A-A628-BE0985DB2BD4}
 		{AF81C41B-06E6-4CA5-9FD4-A4E7042F1107} = {7E264F12-9EC3-4CDC-A187-6879C2B2BFCF}
 		{6D39C141-733B-4C4A-87AB-974637952D1B} = {0371886E-5A61-4626-B9E0-50A837ECE2DD}
+		{DDD2FEA8-801E-463B-8913-9CCCDA2D9429} = {9B3AC501-5FCB-4A2A-A628-BE0985DB2BD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FD2C9507-1A09-4F5B-98AB-B6B194A4B260}

--- a/Plugins/TerrainMakerPlugin/Location.cs
+++ b/Plugins/TerrainMakerPlugin/Location.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static IronPython.Modules.PythonThread;
+
+namespace TerrainMakerPlugin
+{
+    public class Location
+    {
+
+
+        const double LOCATION_SCALING_FACTOR = 0.011131884502145034;
+        const double LOCATION_SCALING_FACTOR_INV = 89.83204953368922;
+
+        // note that mission storage only stores 24 bits of altitude (~ +/- 83km)
+        public Int32 lat; // in 1E7 degrees
+        public Int32 lng; // in 1E7 degrees
+
+
+        public Location()
+        {
+            lat = 0;
+            lng = 0;
+        }
+
+        public Location(Int32 lat, Int32 lng)
+        {
+            this.lat = lat;
+            this.lng = lng;
+        }
+
+
+
+        // return horizontal distance in meters between two locations
+        public double get_distance(Location loc2)
+        {
+            double dlat = (double)(loc2.lat - lat);
+            double dlng = ((double)diff_longitude(loc2.lng, lng)) * longitude_scale((lat + loc2.lat) / 2);
+
+            return Math.Sqrt(dlat*dlat +  dlng*dlng) * LOCATION_SCALING_FACTOR;
+        }
+
+
+        public double longitude_scale(Int32 lat)
+        {
+
+            double scale = Math.Cos(lat * (1.0e-7 * (Math.PI / 180.0)));
+            return Math.Max(scale, 0.01);
+        }
+
+        /*
+          get lon1-lon2, wrapping at -180e7 to 180e7
+        */
+        public Int32 diff_longitude(Int32 lon1, Int32 lon2)
+        {
+            if ((lon1 & 0x80000000) == (lon2 & 0x80000000))
+            {
+                // common case of same sign
+                return lon1 - lon2;
+            }
+            long dlon = (long)lon1 - (long)lon2;
+            if (dlon > 1800000000L)
+            {
+                dlon -= 3600000000L;
+            }
+            else if (dlon < -1800000000L)
+            {
+                dlon += 3600000000L;
+            }
+            return (Int32)dlon;
+        }
+
+
+        /*
+          return the distance in meters in North/East plane as a N/E vector
+          from loc1 to loc2
+        */
+        public Vector2d get_distance_NE(Location loc2)
+        {
+
+            Vector2d retvect = new Vector2d((loc2.lat - lat) * LOCATION_SCALING_FACTOR,
+                    diff_longitude(loc2.lng, lng) * LOCATION_SCALING_FACTOR * longitude_scale((loc2.lat + lat) / 2));
+
+            return retvect;
+        }
+
+
+        // extrapolate latitude/longitude given distances (in meters) north and east
+        public Location add_offset_meters(double ofs_north, double ofs_east)
+        {
+            double dlat = ofs_north * LOCATION_SCALING_FACTOR_INV;
+            double dlng = (ofs_east * LOCATION_SCALING_FACTOR_INV) / longitude_scale((Int32)(lat + dlat / 2));
+
+            Location retval = new Location(lat + (Int32)dlat, (Int32)(dlng + lng));
+
+            return retval;
+
+        }
+
+
+    }
+
+
+    public class Vector2d
+    {
+        public double x;
+        public double y;
+
+
+        public Vector2d(double x, double y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+
+
+
+    }
+
+
+
+}

--- a/Plugins/TerrainMakerPlugin/TerrainDataFile.cs
+++ b/Plugins/TerrainMakerPlugin/TerrainDataFile.cs
@@ -1,0 +1,328 @@
+﻿using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace TerrainMakerPlugin
+{
+
+    public class TerrainDataFile
+    {
+
+        //Constants
+
+        // MAVLink sends 4x4 grids
+        public const int TERRAIN_GRID_MAVLINK_SIZE = 4;
+
+        // a 2k grid_block on disk contains 8x7 of the mavlink grids.  Each
+        // grid block overlaps by one with its neighbour. This ensures that
+        // the altitude at any point can be calculated from a single grid
+        // block
+        public const int TERRAIN_GRID_BLOCK_MUL_X = 7;
+        public const int TERRAIN_GRID_BLOCK_MUL_Y = 8;
+
+        // this is the spacing between 32x28 grid blocks, in grid_spacing units
+        public const int TERRAIN_GRID_BLOCK_SPACING_X = ((TERRAIN_GRID_BLOCK_MUL_X - 1) * TERRAIN_GRID_MAVLINK_SIZE);
+        public const int TERRAIN_GRID_BLOCK_SPACING_Y = ((TERRAIN_GRID_BLOCK_MUL_Y - 1) * TERRAIN_GRID_MAVLINK_SIZE);
+
+        //  giving a total grid size of a disk grid_block of 32x28
+        public const int TERRAIN_GRID_BLOCK_SIZE_X = (TERRAIN_GRID_MAVLINK_SIZE * TERRAIN_GRID_BLOCK_MUL_X);
+        public const int TERRAIN_GRID_BLOCK_SIZE_Y = (TERRAIN_GRID_MAVLINK_SIZE * TERRAIN_GRID_BLOCK_MUL_Y);
+
+        // format of grid on disk
+        public const int TERRAIN_GRID_FORMAT_VERSION = 1;
+
+        public const int IO_BLOCK_SIZE = 2048;
+        public const int IO_BLOCK_DATA_SIZE = 1821;
+        public const int IO_BLOCK_TRAILER_SIZE = IO_BLOCK_SIZE - IO_BLOCK_DATA_SIZE;
+
+        public static int GRID_SPACING = 100;
+
+
+
+        public static Int32 east_blocks(Location loc)
+        {
+            Location loc2 = loc.add_offset_meters(0, 2 * GRID_SPACING * TERRAIN_GRID_BLOCK_SIZE_Y);
+            loc2.lng = loc2.lng + 10 * 1000 * 1000;
+
+            Vector2d offset = loc.get_distance_NE(loc2);
+
+            return (Int32)(Math.Round(offset.y) / (GRID_SPACING * TERRAIN_GRID_BLOCK_SPACING_Y));
+
+        }
+
+
+        public static Location pos_from_file_offset(Int32 file_base_lat, Int32 file_base_lon, int file_offset)
+        {
+            Location ref_loc = new Location(file_base_lat * 10 * 1000 * 1000, file_base_lon * 10 * 1000 * 1000);
+
+            Int32 stride = east_blocks(ref_loc);
+
+            Int32 blocks = (Int32)Math.Floor((double)(file_offset / IO_BLOCK_SIZE));
+
+            Int32 grid_idx_x = (Int32)Math.Floor((double)(blocks / stride));
+
+            Int32 grid_idx_y = blocks % stride;
+
+
+
+            Int32 idx_x = grid_idx_x * TERRAIN_GRID_BLOCK_SPACING_X;
+            Int32 idx_y = grid_idx_y * TERRAIN_GRID_BLOCK_SPACING_Y;
+
+            Location loc = ref_loc.add_offset_meters(idx_x * GRID_SPACING, idx_y * GRID_SPACING);
+
+            grid_idx_x = (Int32)(idx_x / TERRAIN_GRID_BLOCK_SPACING_X);
+            grid_idx_y = (Int32)(idx_y / TERRAIN_GRID_BLOCK_SPACING_Y);
+
+            loc = ref_loc.add_offset_meters(grid_idx_x * TERRAIN_GRID_BLOCK_SPACING_X * GRID_SPACING, grid_idx_y * TERRAIN_GRID_BLOCK_SPACING_Y * GRID_SPACING);
+
+            return loc;
+
+        }
+
+        public class GridBlock
+        {
+            // bitmap of 4x4 grids filled in from GCS (56 bits are used)
+            public UInt64 Bitmap;
+
+            // south west corner of block in degrees*10^7
+            public int Lat;
+            public int Lon;
+            public Location blockTopLeft;
+
+            // crc of whole block, taken with crc=0
+            public ushort Crc;
+
+            // format version number
+            public ushort Version;
+
+            // grid spacing in meters
+            public ushort Spacing;
+
+            // heights in meters over a 32*28 grid
+            public short[] Height; // This should be initialized to a new short[TERRAIN_GRID_BLOCK_SIZE_X * TERRAIN_GRID_BLOCK_SIZE_Y]
+
+            // indices info 32x28 grids for this degree reference
+            public ushort GridIdxX;
+            public ushort GridIdxY;
+
+            // rounded latitude/longitude in degrees, of the whole dat file (like 41,11)
+            public short LonDegrees;
+            public sbyte LatDegrees;
+
+
+            //public long ref_lat, ref_lon;
+
+
+            //Constructor, pass the datafile location and location of the block left upper corner, plus spacing
+            public GridBlock(sbyte lat_int, short lon_int, Location blockLocation, ushort spacing)
+            {
+                Spacing = (ushort)GRID_SPACING;
+                Height = new short[TERRAIN_GRID_BLOCK_SIZE_X * TERRAIN_GRID_BLOCK_SIZE_Y];
+
+                Version = TERRAIN_GRID_FORMAT_VERSION;
+
+                LonDegrees = lon_int;
+                LatDegrees = lat_int;
+
+
+                Location ref_loc = new Location(lat_int * 10 * 1000 * 1000, lon_int * 10 * 1000 * 1000);
+                Vector2d offset = ref_loc.get_distance_NE(blockLocation);
+
+                long idx_x = (long)(Math.Round(offset.x) / GRID_SPACING);
+                long idx_y = (long)(Math.Round(offset.y) / GRID_SPACING);
+
+                GridIdxX = (ushort)Math.Floor(((double)idx_x / TERRAIN_GRID_BLOCK_SPACING_X));
+                GridIdxY = (ushort)Math.Floor(((double)idx_y / TERRAIN_GRID_BLOCK_SPACING_Y));
+
+                Location loc = ref_loc.add_offset_meters(GridIdxX * TERRAIN_GRID_BLOCK_SPACING_X * GRID_SPACING, GridIdxY * TERRAIN_GRID_BLOCK_SPACING_Y * GRID_SPACING);
+
+                Lat = loc.lat;
+                Lon = loc.lng;
+
+                blockTopLeft = new Location (Lat , Lon);
+            }
+
+
+            public long blocknum()
+            {
+                long stride = east_blocks(new Location(LatDegrees * 10 * 1000 * 1000, LonDegrees * 10 * 1000 * 1000));
+                return stride * GridIdxX + GridIdxY;
+            }
+
+
+            public bool isvalid(int x, int y)
+            {
+                // Check if a 4x4 block has any zero in it
+                bool valid = true;
+
+                if (GetHeight(x * 4, y * 4) == 0) valid = false;
+                if (GetHeight(x * 4 + 1, y * 4) == 0) valid = false;
+                if (GetHeight(x * 4 + 2, y * 4) == 0) valid = false;
+                if (GetHeight(x * 4 + 3, y * 4) == 0) valid = false;
+                if (GetHeight(x * 4, y * 4 + 1) == 0) valid = false;
+                if (GetHeight(x * 4 + 1, y * 4 + 1) == 0) valid = false;
+                if (GetHeight(x * 4 + 2, y * 4 + 1) == 0) valid = false;
+                if (GetHeight(x * 4 + 3, y * 4 + 1) == 0) valid = false;
+
+                if (GetHeight(x * 4, y * 4 + 2) == 0) valid = false;
+                if (GetHeight(x * 4 + 1, y * 4 + 2) == 0) valid = false;
+                if (GetHeight(x * 4 + 2, y * 4 + 2) == 0) valid = false;
+                if (GetHeight(x * 4 + 3, y * 4 + 2) == 0) valid = false;
+
+                if (GetHeight(x * 4, y * 4 + 3) == 0) valid = false;
+                if (GetHeight(x * 4 + 1, y * 4 + 3) == 0) valid = false;
+                if (GetHeight(x * 4 + 2, y * 4 + 3) == 0) valid = false;
+                if (GetHeight(x * 4 + 3, y * 4 + 3) == 0) valid = false;
+
+                return valid;
+            }
+
+            public void setBit(byte bitnumber)
+            {
+                if (bitnumber > 55) throw new Exception("Bit number out of range");
+                UInt64 mask = ((UInt64)1 << bitnumber);
+                Bitmap |= mask;
+
+                if (Bitmap > 0xffffffffffffff00)
+                {
+                    Console.WriteLine("Bitmap Overflow {0}", bitnumber);
+                    throw new Exception("Bitmap overflow");
+                }
+            }
+
+            public void clearBit(byte bitnumber)
+            {
+                Bitmap &= (UInt64)~(1 << bitnumber);
+            }
+
+            public bool getBit(byte bitnumber)
+            {
+                return (Bitmap & (ulong)(1 << bitnumber)) != 0;
+            }
+
+            public short GetHeight(int x, int y)
+            {
+                return Height[y * TERRAIN_GRID_BLOCK_SIZE_X + x];
+            }
+
+            public void SetHeight(int x, int y, short value)
+            {
+                Height[y * TERRAIN_GRID_BLOCK_SIZE_X + x] = value;
+            }
+
+
+            private byte[] Pack()
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    using (BinaryWriter writer = new BinaryWriter(ms))
+                    {
+                        writer.Write(BitConverter.GetBytes(Bitmap));
+                        writer.Write(BitConverter.GetBytes(Lat));
+                        writer.Write(BitConverter.GetBytes(Lon));
+                        writer.Write(BitConverter.GetBytes(Crc));
+                        writer.Write(BitConverter.GetBytes(Version));
+                        writer.Write(BitConverter.GetBytes(Spacing));
+
+
+                        for (int gx = 0; gx < TerrainDataFile.TERRAIN_GRID_BLOCK_SIZE_X; gx++)
+                        {
+                            for (int gy = 0; gy < TerrainDataFile.TERRAIN_GRID_BLOCK_SIZE_Y; gy++)
+                            {
+                                writer.Write(BitConverter.GetBytes(GetHeight(gx, gy)));
+
+                            }
+                        }
+
+
+                            //    foreach (var h in Height)
+                            //{
+                            //    writer.Write(BitConverter.GetBytes(h));
+                            //}
+
+
+                        writer.Write(BitConverter.GetBytes(GridIdxX));
+                        writer.Write(BitConverter.GetBytes(GridIdxY));
+                        writer.Write(BitConverter.GetBytes(LonDegrees));
+                        writer.Write(BitConverter.GetBytes(LatDegrees));
+
+                        for (int i = 1; i < IO_BLOCK_TRAILER_SIZE; i++)
+                        {
+                            writer.Write((byte)0);
+                        }
+                    }
+                    return ms.ToArray();
+                }
+            }
+
+            public byte[] getPackedBytes()
+            {
+                Crc = 0;
+                byte[] packed = Pack();
+                Crc = crc16(packed, IO_BLOCK_DATA_SIZE);
+                byte[] packedWithCRC = Pack();
+                return packedWithCRC;
+            }
+
+        }
+
+
+        /* CRC16 implementation according to CCITT standards */
+        static ushort[] crc16tab = new ushort[256] {
+                0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
+                0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
+                0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6,
+                0x9339, 0x8318, 0xB37B, 0xA35A, 0xD3BD, 0xC39C, 0xF3FF, 0xE3DE,
+                0x2462, 0x3443, 0x0420, 0x1401, 0x64E6, 0x74C7, 0x44A4, 0x5485,
+                0xA56A, 0xB54B, 0x8528, 0x9509, 0xE5EE, 0xF5CF, 0xC5AC, 0xD58D,
+                0x3653, 0x2672, 0x1611, 0x0630, 0x76D7, 0x66F6, 0x5695, 0x46B4,
+                0xB75B, 0xA77A, 0x9719, 0x8738, 0xF7DF, 0xE7FE, 0xD79D, 0xC7BC,
+                0x48C4, 0x58E5, 0x6886, 0x78A7, 0x0840, 0x1861, 0x2802, 0x3823,
+                0xC9CC, 0xD9ED, 0xE98E, 0xF9AF, 0x8948, 0x9969, 0xA90A, 0xB92B,
+                0x5AF5, 0x4AD4, 0x7AB7, 0x6A96, 0x1A71, 0x0A50, 0x3A33, 0x2A12,
+                0xDBFD, 0xCBDC, 0xFBBF, 0xEB9E, 0x9B79, 0x8B58, 0xBB3B, 0xAB1A,
+                0x6CA6, 0x7C87, 0x4CE4, 0x5CC5, 0x2C22, 0x3C03, 0x0C60, 0x1C41,
+                0xEDAE, 0xFD8F, 0xCDEC, 0xDDCD, 0xAD2A, 0xBD0B, 0x8D68, 0x9D49,
+                0x7E97, 0x6EB6, 0x5ED5, 0x4EF4, 0x3E13, 0x2E32, 0x1E51, 0x0E70,
+                0xFF9F, 0xEFBE, 0xDFDD, 0xCFFC, 0xBF1B, 0xAF3A, 0x9F59, 0x8F78,
+                0x9188, 0x81A9, 0xB1CA, 0xA1EB, 0xD10C, 0xC12D, 0xF14E, 0xE16F,
+                0x1080, 0x00A1, 0x30C2, 0x20E3, 0x5004, 0x4025, 0x7046, 0x6067,
+                0x83B9, 0x9398, 0xA3FB, 0xB3DA, 0xC33D, 0xD31C, 0xE37F, 0xF35E,
+                0x02B1, 0x1290, 0x22F3, 0x32D2, 0x4235, 0x5214, 0x6277, 0x7256,
+                0xB5EA, 0xA5CB, 0x95A8, 0x8589, 0xF56E, 0xE54F, 0xD52C, 0xC50D,
+                0x34E2, 0x24C3, 0x14A0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+                0xA7DB, 0xB7FA, 0x8799, 0x97B8, 0xE75F, 0xF77E, 0xC71D, 0xD73C,
+                0x26D3, 0x36F2, 0x0691, 0x16B0, 0x6657, 0x7676, 0x4615, 0x5634,
+                0xD94C, 0xC96D, 0xF90E, 0xE92F, 0x99C8, 0x89E9, 0xB98A, 0xA9AB,
+                0x5844, 0x4865, 0x7806, 0x6827, 0x18C0, 0x08E1, 0x3882, 0x28A3,
+                0xCB7D, 0xDB5C, 0xEB3F, 0xFB1E, 0x8BF9, 0x9BD8, 0xABBB, 0xBB9A,
+                0x4A75, 0x5A54, 0x6A37, 0x7A16, 0x0AF1, 0x1AD0, 0x2AB3, 0x3A92,
+                0xFD2E, 0xED0F, 0xDD6C, 0xCD4D, 0xBDAA, 0xAD8B, 0x9DE8, 0x8DC9,
+                0x7C26, 0x6C07, 0x5C64, 0x4C45, 0x3CA2, 0x2C83, 0x1CE0, 0x0CC1,
+                0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8,
+                0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
+        };
+
+
+
+        public static ushort crc16(byte[] data, int len)
+        {
+            ushort crc = 0;
+            for (int i = 0; i < len; i++)
+            {
+                crc = (ushort)((crc << 8) ^ crc16tab[((crc >> 8) ^ data[i]) & 0x00FF]);
+            }
+            return crc;
+        }
+
+
+    }
+
+
+
+}

--- a/Plugins/TerrainMakerPlugin/TerrainMakerPlugin.cs
+++ b/Plugins/TerrainMakerPlugin/TerrainMakerPlugin.cs
@@ -1,0 +1,295 @@
+﻿using MissionPlanner;
+using MissionPlanner.Plugin;
+using MissionPlanner.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows.Forms;
+using System.Diagnostics;
+using MissionPlanner.Controls.PreFlight;
+using MissionPlanner.Controls;
+using System.Linq;
+using GMap.NET.WindowsForms.Markers;
+using MissionPlanner.Maps;
+using GMap.NET;
+using GMap.NET.WindowsForms;
+using System.Globalization;
+using System.Drawing;
+using Microsoft.Win32;
+using System.Text;
+using System.Threading;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Security.RightsManagement;
+using Org.BouncyCastle.Utilities;
+using NetTopologySuite.Operation.Valid;
+using Org.BouncyCastle.Asn1.X509;
+
+namespace TerrainMakerPlugin
+{
+
+    public class TerrainMakerPlugin : Plugin
+    {
+
+
+        SplitContainer sc;
+        MissionPlanner.Controls.MyButton button1;
+
+        Stopwatch stopwatch = new Stopwatch();
+        public override string Name
+        {
+            get { return "TerrainMakerPlugin"; }
+        }
+
+        public override string Version
+        {
+            get { return "2.0"; }
+        }
+
+        public override string Author
+        {
+            get { return "Andras \"EosBandi\" Schaffer"; }
+        }
+
+        public override bool Init()
+        {
+            return true;	 // If it is false then plugin will not load
+        }
+
+        public override bool Loaded()
+        {
+
+            Host.FPMenuMap.Items.Add(new ToolStripMenuItem("Make Terrain DAT", null, MakeTerrainDAT));
+
+            return true;     //If it is false plugin will not start (loop will not called)
+        }
+
+
+        private int lat_int_togenerate = 0;
+        private int lon_int_togenerate = 0;
+        private ushort spacing_togenerate = 0;
+
+
+
+        private void MakeTerrainDAT(object sender, EventArgs e)
+        {
+            RectLatLng area = Host.FPGMapControl.SelectedArea;
+            if (area.IsEmpty)
+            {
+                var res = CustomMessageBox.Show("No area defined, use area displayed on screen?", "Terrain DAT",
+                    MessageBoxButtons.YesNo);
+                if (res == (int)DialogResult.Yes)
+                {
+                    area = Host.FPGMapControl.ViewArea;
+                }
+            }
+
+
+            if (!area.IsEmpty)
+            {
+                string spacingstring = "30";
+                if (InputBox.Show("SPACING", "Enter the grid spacing in meters (5-100).", ref spacingstring) !=
+                    DialogResult.OK)
+                    return;
+
+                int spacing = 30;
+                if (!int.TryParse(spacingstring, out spacing))
+                {
+                    CustomMessageBox.Show("Invalid Number", "ERROR");
+                    return;
+                }
+
+                if (spacing < 5 || spacing > 100)
+                {
+                    CustomMessageBox.Show("Spacing must be between 5 and 100 meters", "ERROR");
+                    return;
+                }
+
+
+
+                //Do it in the selected area with the selected spacing
+                int lat_start = (int)Math.Floor(area.Bottom);
+                int lat_end = (int)Math.Ceiling(area.Top);
+
+                int lon_start = (int)Math.Floor(area.Left);
+                int lon_end = (int)Math.Ceiling(area.Right);
+
+
+
+                for (int lat_int = lat_start; lat_int< lat_end; lat_int++)
+                {
+                    for (int lon_int = lon_start; lon_int < lon_end; lon_int++)
+                    {
+                        Console.WriteLine("Make Terrain DAT {0} {1}", lat_int, lon_int);
+
+                        lat_int_togenerate = lat_int;
+                        lon_int_togenerate = lon_int;
+                        spacing_togenerate = (ushort)spacing;
+
+
+
+                        IProgressReporterDialogue frmProgressReporter = new ProgressReporterDialogue
+                        {
+                            StartPosition = FormStartPosition.CenterScreen,
+                            Text = String.Format("Generate terrain data for Lat {0} Lon {1}", lat_int, lon_int)
+                        };
+
+                        frmProgressReporter.DoWork += createTerrainDataFile;
+                        frmProgressReporter.UpdateProgressAndStatus(-1, "Starting...");
+
+                        ThemeManager.ApplyThemeTo(frmProgressReporter);
+
+                        frmProgressReporter.RunBackgroundOperationAsync();
+
+                        frmProgressReporter.Dispose();
+
+                        CustomMessageBox.Show("Terrain DAT created in Documents/Mission Planner/TerrainDat folder", "Terrain DAT");
+
+
+                    }
+                }
+
+
+
+            }
+
+
+        }
+
+
+        private void createTerrainDataFile(IProgressReporterDialogue sender)
+        {
+
+            int lat_int = lat_int_togenerate;
+            int lon_int = lon_int_togenerate;
+            ushort spacing = spacing_togenerate;
+
+
+            stopwatch.Start();
+            TerrainDataFile.GRID_SPACING = spacing;
+
+            TerrainDataFile.GridBlock grid;
+            srtm.altresponce altresponce = new srtm.altresponce();
+
+            string ns, ew;
+            if (lat_int < 0) ns = "S"; else ns = "N";
+            if (lon_int <0 ) ew = "W"; else ew = "E";
+
+            string filename = string.Format("{0}{1:00}{2}{3:000}.DAT", ns, Math.Abs(lat_int), ew, Math.Abs(lon_int));
+            string path = Path.Combine(Settings.GetUserDataDirectory(), "TerrainData");
+            if (!Directory.Exists(path))
+            {
+                try
+                {
+                    Directory.CreateDirectory(path);
+                }
+                catch
+                {
+                    MessageBox.Show("Can't create directory: " + path);
+                    return;
+                }
+            }
+            string fullpath = Path.Combine(path, filename);
+
+            FileStream datafile = new FileStream(fullpath, FileMode.Create);
+            BinaryWriter datafileWriter = new BinaryWriter(datafile);
+
+            int a = TerrainDataFile.east_blocks(new Location(lat_int * 10 * 1000 * 1000, lon_int * 10 * 1000 * 1000));
+
+            Console.WriteLine("East Blocks {0}",a);
+
+            int n = -1;
+
+            while (true)
+            {
+                n += 1;
+
+                Location locOfBlock = TerrainDataFile.pos_from_file_offset(lat_int, lon_int, n * TerrainDataFile.IO_BLOCK_SIZE);
+                if (locOfBlock.lat * 1.0e-7 - lat_int >= 1.0) break;
+                grid = new TerrainDataFile.GridBlock((sbyte)lat_int, (short)lon_int, locOfBlock, spacing);
+                Console.WriteLine("{0} {1} {2} {3} {4} {5} {6}", a, grid.blocknum(), n * TerrainDataFile.IO_BLOCK_SIZE, grid.GridIdxX, grid.GridIdxY, grid.Lat, grid.Lon);
+            }
+
+            Console.WriteLine("Number of blocks in a dat file: {0}", n);
+
+            //We have the max block number in N
+            for (int blocknum = 0; blocknum < n; blocknum++)
+            {
+                string message = string.Format("Making block {0} of {1}", blocknum, n);
+                sender.UpdateProgressAndStatus((int)(100.0 * blocknum / n), message);
+                if (sender.doWorkArgs.CancelRequested)
+                {
+                    sender.doWorkArgs.CancelAcknowledged = true;
+                    datafileWriter.Close();
+                    datafile.Close();
+                    //delete the datafile sinc it is incomplete
+                    File.Delete(fullpath);
+                    return;
+                }
+
+                Location loc = TerrainDataFile.pos_from_file_offset(lat_int, lon_int, blocknum * TerrainDataFile.IO_BLOCK_SIZE);
+                grid = new TerrainDataFile.GridBlock((sbyte)lat_int, (short)lon_int, loc, spacing);
+
+
+                int valids = 0;
+
+                for (int gx = 0; gx < TerrainDataFile.TERRAIN_GRID_BLOCK_SIZE_X; gx++)
+                {
+                    for (int gy = 0; gy < TerrainDataFile.TERRAIN_GRID_BLOCK_SIZE_Y; gy++)
+                    {
+                        Location pointLoc = grid.blockTopLeft.add_offset_meters(gx * TerrainDataFile.GRID_SPACING, gy * TerrainDataFile.GRID_SPACING);
+                        //// Check elevation
+                        double lat = pointLoc.lat * 1.0e-7;
+                        double lon = pointLoc.lng * 1.0e-7;
+                        altresponce = srtm.getAltitude(lat, lon, 20); //get at max zoom
+
+                        if (altresponce.altsource == "GeoTiff") Console.WriteLine("GeoTiff {0} {1} {2}", lat, lon, altresponce.alt);
+                        if (altresponce.currenttype == srtm.tiletype.valid && altresponce.alt != 0)
+                        {
+                            valids++;
+                            grid.SetHeight(gx, gy, (short)Math.Round(altresponce.alt));
+                        }
+                        else
+                        {
+                            grid.SetHeight(gx, gy, 0);
+                        }
+
+                    }
+                }
+
+                //Check block validity and fill bitmap
+                grid.Bitmap = 0; // Clear bitmap
+
+                for (int x = 0; x < TerrainDataFile.TERRAIN_GRID_BLOCK_MUL_X; x++)
+                {
+                    for (int y = 0; y < TerrainDataFile.TERRAIN_GRID_BLOCK_MUL_Y; y++)
+                    {
+                        if (grid.isvalid(x, y))
+                        {
+                            grid.setBit((byte)(y + TerrainDataFile.TERRAIN_GRID_BLOCK_MUL_Y * x));
+                        }
+
+                    }
+                }
+
+                byte[] bytes = grid.getPackedBytes();
+                datafileWriter.Write(bytes);
+
+            }
+
+            stopwatch.Stop();
+            Console.WriteLine("Terrain Data Creator Time elapsed: {0}", stopwatch.Elapsed);
+            datafileWriter.Close();
+            datafile.Close();
+
+        }
+
+        public override bool Exit()
+        {
+            return true;
+        }
+
+
+    }
+}

--- a/Plugins/TerrainMakerPlugin/TerrainMakerPlugin.csproj
+++ b/Plugins/TerrainMakerPlugin/TerrainMakerPlugin.csproj
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DDD2FEA8-801E-463B-8913-9CCCDA2D9429}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>TerrainMakerPlugin</RootNamespace>
+    <AssemblyName>TerrainMakerPlugin</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>$(SolutionDir)bin\Debug\net461\plugins\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>$(SolutionDir)bin\Release\net461\plugins\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\BaseClasses\BaseClasses.csproj">
+      <Project>{2a8e8af5-74e7-49db-a42e-9360fa7a6cc4}</Project>
+      <Name>BaseClasses</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\BSE.Windows.Forms\BSE.Windows.Forms.csproj">
+      <Project>{9ca367b8-0b98-49d1-84fb-735e612e3ba9}</Project>
+      <Name>BSE.Windows.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Core\Core.csproj">
+      <Project>{59129078-7b12-4198-b93e-0aa08d0bb7ed}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Mavlink\MAVLink.csproj">
+      <Project>{13d2ec90-c41f-48a1-aada-859b6dc24edc}</Project>
+      <Name>MAVLink</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)MissionPlanner.csproj">
+      <Project>{a2e22272-95fe-47b6-b050-9ae7e2055bf5}</Project>
+      <Name>MissionPlanner</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\ArduPilot\MissionPlanner.ArduPilot.csproj">
+      <Project>{ca6345d3-7a6d-478b-a0ed-a58e50dcaa83}</Project>
+      <Name>MissionPlanner.ArduPilot</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Comms\MissionPlanner.Comms.csproj">
+      <Project>{825e7a10-390c-4a2b-b3a8-491d14966912}</Project>
+      <Name>MissionPlanner.Comms</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Controls\MissionPlanner.Controls.csproj">
+      <Project>{c8b88795-6d01-494d-83ad-6944bd4c5023}</Project>
+      <Name>MissionPlanner.Controls</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\GeoUtility\GeoUtility.csproj">
+      <Project>{7f7994ce-823f-4a04-bbea-d0a3808ff56d}</Project>
+      <Name>GeoUtility</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\GMap.NET.Core\GMap.NET.Core.csproj">
+      <Project>{d0c39d9d-bed0-418b-9a5e-713176caf40c}</Project>
+      <Name>GMap.NET.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\GMap.NET.WindowsForms\GMap.NET.WindowsForms.csproj">
+      <Project>{e06def77-f933-42fb-afd7-db2d0d8d6a98}</Project>
+      <Name>GMap.NET.WindowsForms</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Utilities\MissionPlanner.Utilities.csproj">
+      <Project>{1378a66c-38e4-46f5-a05f-dc04ef7d4d16}</Project>
+      <Name>MissionPlanner.Utilities</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\GMap.NET.Drawing\GMap.NET.Drawing.csproj">
+      <Project>{d773accd-9c2d-4e94-a967-faa7ea2d21cb}</Project>
+      <Name>GMap.NET.Drawing</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Interfaces\Interfaces.csproj">
+      <Project>{FD4D2994-9BEA-41A1-8C51-2E02D1E8503E}</Project>
+      <Name>Interfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\Maps\MissionPlanner.Maps.csproj">
+      <Project>{6c4ff9c3-7aff-4274-b8fc-4a93a1faadea}</Project>
+      <Name>MissionPlanner.Maps</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\MissionPlanner.Drawing\MissionPlanner.Drawing.csproj">
+      <Project>{6974d22c-ede6-4bb2-aad2-ff23ed6ec165}</Project>
+      <Name>MissionPlanner.Drawing</Name>
+      <Aliases>Drawing</Aliases>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)ExtLibs\SvgNet\SvgNet.csproj">
+      <Project>{bb4c8021-b5e1-4de2-82cb-14bdfb9837e4}</Project>
+      <Name>SvgNet</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Location.cs" />
+    <Compile Include="TerrainDataFile.cs" />
+    <Compile Include="TerrainMakerPlugin.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common">
+      <Version>4.7.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
You can create TERRAIN DAT files to copy to the FC's SD card from the terrain database available in Mission Planner
!Including loaded DEM files!
The resolution can be selected between 5 and 100 meters, if the available terrain data is lower resolution then the grid data will be averaged.
(less than 5 meter resolution is not possible due to a bug in Ardupilot, which prevents files larger than 2Gb on SD cards)

Use :
Go to FlightPlanner.
Select area with ALT+MouseCLICK and drag
Open context menu and select Make Terrain DAT

if no area is selected the actual displayed area is used.

Note: DAT files are always created for one by one degree area, the size depends on the resolution.