### PR TITLE
ADSB: uAvionix Transponder Updates

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -6252,8 +6252,8 @@ namespace MissionPlanner.GCSViews
                                                              !Mode_clb.GetItemChecked(2) &&
                                                              !Mode_clb.GetItemChecked(3)) ? FontStyle.Bold : FontStyle.Regular);
                     ON_btn.Font   = new Font(ON_btn.Font,   ( Mode_clb.GetItemChecked(0) &&
-                                                              Mode_clb.GetItemChecked(1) &&
-                                                             !Mode_clb.GetItemChecked(2) &&
+                                                             !Mode_clb.GetItemChecked(1) &&
+                                                              Mode_clb.GetItemChecked(2) &&
                                                               Mode_clb.GetItemChecked(3)) ? FontStyle.Bold : FontStyle.Regular);
                     ALT_btn.Font  = new Font(ALT_btn.Font,  ( Mode_clb.GetItemChecked(0) &&
                                                               Mode_clb.GetItemChecked(1) &&

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -6231,9 +6231,16 @@ namespace MissionPlanner.GCSViews
 
         private void updateTransponder()
         {
+            static neverConnected = true;
             MainV2.comPort.MAV.cs.xpdr_status_pending = false;
             if (!MainV2.comPort.MAV.cs.xpdr_status_unavail)
             {
+                if (neverConnected)
+                {
+                    // subscribe to status message on first connection
+                    MainV2.comPort.doCommand(MAVLink.MAV_CMD.SET_MESSAGE_INTERVAL, (float) MAVLink.MAVLINK_MSG_ID.UAVIONIX_ADSB_OUT_STATUS, (float) 1000000.0, 0, 0, 0, 0, 0);
+                }
+
                 STBY_btn.Enabled = true;
                 ON_btn.Enabled = true;
                 ALT_btn.Enabled = true;


### PR DESCRIPTION
This PR contains updates to the interface with the ping200X in the Transponder tab. Co-requisite with the ArduPilot PR https://github.com/ArduPilot/ardupilot/pull/28419

Changes:

- Fix a display error where the "ON" button was not properly bolded when the transponder mode was set to "ON"
  - It should be bold when the status message indicates mode A, S, and 1090ES are on and mode C is off
- Requests the UAVIONIX_OUT_STATUS mavlink message at 1 Hz when it first gets that same message
  - This enables smarter timeout behavior; see next point
- Make controls/display more responsive to connection errors with the transponder
  - Display "Transponder Offline" when status message is received but the flag `UAVIONIX_ADSB_OUT_STATUS_FAULT_STATUS_MESSAGE_UNAVAIL` is set.
  - Display "Transponder Status Lost" if the GCS had previously received a UAVIONIX_OUT_STATUS message but 5 seconds pass without seeing another one. 
    - This usually happens if the AP is power cycled (thus resetting the UAVIONIX_OUT_STATUS request)