### PR TITLE
paramcompare: remove double inequality check

### DIFF
--- a/Controls/paramcompare.cs
+++ b/Controls/paramcompare.cs
@@ -41,7 +41,7 @@ namespace MissionPlanner.Controls
                     if (param.ContainsKey(value) && param2.ContainsKey(value))
                     {
                         // check double != double
-                        if (param[value] != param2[value])
+                        if (param[value].ToString() != param2[value].ToString())
                         // this will throw is there is no matching key
                         {
                             Console.WriteLine("{0} {1} vs {2}", value, param[value], param2[value]);


### PR DESCRIPTION
Fixes bug reported by Alex/ARACE on Discord:
![image](https://github.com/user-attachments/assets/601ff758-ffb1-43ee-9fbf-aac37939c819)

There might be a more efficient way to do a double compare that accounts for epsilon differences, but this works.