### PR TITLE
Add interface for plugins to add HW and SW config pages

### DIFF
--- a/GCSViews/InitialSetup.cs
+++ b/GCSViews/InitialSetup.cs
@@ -6,6 +6,7 @@ using MissionPlanner.GCSViews.ConfigurationView;
 using MissionPlanner.Radio;
 using MissionPlanner.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Resources;
 using System.Windows.Forms;
@@ -16,6 +17,44 @@ namespace MissionPlanner.GCSViews
     {
         internal static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private static string lastpagename = "";
+
+        [Flags]
+        public enum pageOptions
+        {
+            none = 0,
+            isConnected = 1,
+            isDisConnected = 2,
+            isTracker = 4,
+            isCopter = 8,
+            isCopter35plus = 16,
+            isHeli = 32,
+            isQuadPlane = 64,
+            isPlane = 128,
+            isRover = 256,
+            gotAllParams = 512
+        }
+
+        public class pluginPage
+        {
+            public Type page;
+            public string headerText;
+            public pageOptions options;
+
+            public pluginPage(Type page, string headerText, pageOptions options)
+            {
+                this.page = page;
+                this.headerText = headerText;
+                this.options = options;
+            }
+        }
+
+
+        private static List<pluginPage> pluginViewPages = new List<pluginPage>();
+        public static void AddPluginViewPage(Type page, string headerText, pageOptions options = pageOptions.none)
+        {
+            pluginViewPages.Add(new pluginPage(page, headerText, options));
+        }
+
 
         public InitialSetup()
         {
@@ -92,7 +131,7 @@ namespace MissionPlanner.GCSViews
             }
         }
 
-        private BackstageViewPage AddBackstageViewPage(Type userControl, string headerText, bool enabled = true,
+        public BackstageViewPage AddBackstageViewPage(Type userControl, string headerText, bool enabled = true,
     BackstageViewPage Parent = null, bool advanced = false)
         {
             try
@@ -138,7 +177,7 @@ namespace MissionPlanner.GCSViews
 
             AddBackstageViewPage(typeof(ConfigSecureAP), "Secure",
                 isDisConnected);
-         
+
 
             var mand = AddBackstageViewPage(typeof(ConfigMandatory), rm.GetString("backstageViewPagemand.Text"), isConnected && gotAllParams);
 
@@ -307,6 +346,35 @@ namespace MissionPlanner.GCSViews
                 {
                     AddBackstageViewPage(typeof(ConfigREPL), "Script REPL", isConnected, adv);
                 }
+            }
+
+
+            foreach (var item in pluginViewPages)
+            {
+
+                // go through all options
+                if (item.options.HasFlag(pageOptions.isConnected) && !isConnected)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isDisConnected) && !isDisConnected)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isTracker) && !isTracker)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isCopter) && !isCopter)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isCopter35plus) && !isCopter35plus)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isHeli) && !isHeli)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isQuadPlane) && !isQuadPlane)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isPlane) && !isPlane)
+                    continue;
+                if (item.options.HasFlag(pageOptions.isRover) && !isRover)
+                    continue;
+                if (item.options.HasFlag(pageOptions.gotAllParams) && !gotAllParams)
+                    continue;
+
+                AddBackstageViewPage(item.page, item.headerText);
             }
 
             // remeber last page accessed

--- a/GCSViews/SoftwareConfig.cs
+++ b/GCSViews/SoftwareConfig.cs
@@ -5,6 +5,7 @@ using MissionPlanner.Controls.BackstageView;
 using MissionPlanner.GCSViews.ConfigurationView;
 using MissionPlanner.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Windows.Forms;
 
@@ -14,6 +15,92 @@ namespace MissionPlanner.GCSViews
     {
         internal static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private static string lastpagename = "";
+        [Flags]
+        public enum pageOptions
+        {
+            none = 0,
+            isConnected = 1,
+            isDisConnected = 2,
+            isTracker = 4,
+            isCopter = 8,
+            isCopter35plus = 16,
+            isHeli = 32,
+            isQuadPlane = 64,
+            isPlane = 128,
+            isRover = 256,
+            gotAllParams = 512
+        }
+
+        public class pluginPage
+        {
+            public Type page;
+            public string headerText;
+            public pageOptions options;
+
+            public pluginPage(Type page, string headerText, pageOptions options)
+            {
+                this.page = page;
+                this.headerText = headerText;
+                this.options = options;
+            }
+        }
+
+
+        private static List<pluginPage> pluginViewPages = new List<pluginPage>();
+
+        public static void AddPluginViewPage(Type page, string headerText, pageOptions options = pageOptions.none)
+        {
+            pluginViewPages.Add(new pluginPage(page, headerText, options));
+        }
+        public bool isConnected
+        {
+            get { return MainV2.comPort.BaseStream.IsOpen; }
+        }
+        public bool isTracker
+        {
+            get { return isConnected && MainV2.comPort.MAV.cs.firmware == Firmwares.ArduTracker; }
+        }
+
+        public bool isCopter
+        {
+            get { return isConnected && MainV2.comPort.MAV.cs.firmware == Firmwares.ArduCopter2; }
+        }
+
+        public bool isCopter35plus
+        {
+            get { return MainV2.comPort.MAV.cs.version >= Version.Parse("3.5"); }
+        }
+
+        public bool isHeli
+        {
+            get { return isConnected && MainV2.comPort.MAV.aptype == MAVLink.MAV_TYPE.HELICOPTER; }
+        }
+
+        public bool isQuadPlane
+        {
+            get
+            {
+                return isConnected && isPlane &&
+                       MainV2.comPort.MAV.param.ContainsKey("Q_ENABLE") &&
+                       (MainV2.comPort.MAV.param["Q_ENABLE"].Value == 1.0);
+            }
+        }
+
+        public bool isPlane
+        {
+            get
+            {
+                return isConnected &&
+                       (MainV2.comPort.MAV.cs.firmware == Firmwares.ArduPlane ||
+                        MainV2.comPort.MAV.cs.firmware == Firmwares.Ateryx);
+            }
+        }
+
+        public bool isRover
+        {
+            get { return isConnected && MainV2.comPort.MAV.cs.firmware == Firmwares.ArduRover; }
+        }
+
 
         public bool gotAllParams
         {
@@ -38,7 +125,7 @@ namespace MissionPlanner.GCSViews
         {
         }
 
-        private BackstageViewPage AddBackstageViewPage(Type userControl, string headerText,
+        public BackstageViewPage AddBackstageViewPage(Type userControl, string headerText,
             BackstageViewPage Parent = null, bool advanced = false)
         {
             try
@@ -170,6 +257,35 @@ namespace MissionPlanner.GCSViews
                         start = AddBackstageViewPage(typeof(ConfigPlanner), Strings.Planner);
                     }
                 }
+
+                // Add custrom pages set up by plugins
+                foreach (var item in pluginViewPages)
+                {
+
+                    // go through all options expect disconnected since there is no meaning for sw config in disconnected state
+                    if (item.options.HasFlag(pageOptions.isConnected) && !isConnected)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isTracker) && !isTracker)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isCopter) && !isCopter)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isCopter35plus) && !isCopter35plus)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isHeli) && !isHeli)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isQuadPlane) && !isQuadPlane)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isPlane) && !isPlane)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.isRover) && !isRover)
+                        continue;
+                    if (item.options.HasFlag(pageOptions.gotAllParams) && !gotAllParams)
+                        continue;
+
+                    AddBackstageViewPage(item.page, item.headerText);
+                }
+
+
 
                 // apply theme before trying to display it
                 ThemeManager.ApplyThemeTo(this);


### PR DESCRIPTION
It makes possible for a plugin to add pages to the SETUP and the CONFIG pages.

 Simply create a MyUserControl based form and then add it via
` SoftwareConfig.AddPluginViewPage(typeof(pageclass), "pagename");`
or 
` InitialSetup.AddPluginViewPage(typeof(pageclass, "pagename");`

