### PR TITLE
ConfigSerialInjectGPS.cs: Fix Septentrio config error while connected to ublox and changing away from the config RTK/GPS screen.

### DIFF
--- a/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
+++ b/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
@@ -1480,7 +1480,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             try
             {
-                if (comPort.IsOpen)
+                if (comPort.IsOpen && comboBoxConfigType.Text == "Septentrio")
                 {
                     await UpdateSeptentrioRTCMSettings();
                 }


### PR DESCRIPTION
Fix Septentrio config error while connected to ublox and changing away from the config RTK/GPS screen.
if "SerialInjectGPS_SeptentrioRTCMLevel" is not set, then the combo box is set to 1, which triggers the update....