### PR TITLE
Increase "Change Alt Button" maximum

### DIFF
--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -862,7 +862,7 @@ namespace MissionPlanner.GCSViews
             0,
             0});
             this.modifyandSetAlt.Maximum = new decimal(new int[] {
-            1000,
+            10000,
             0,
             0,
             0});


### PR DESCRIPTION
This is my first Mission Planner pull request so please let me know if I have missed something. 
We have an ArduPilot Partner request that we increase the maximum limit (currently at 1000), of this button:
![image](https://github.com/user-attachments/assets/596a885a-7c75-4eda-9b7c-22421dab9bab)

I have increased it by an arbitrary number. 
