### PR TITLE
KML overlay: Fix missing default color or width linestyle errors

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5176,9 +5176,15 @@ namespace MissionPlanner.GCSViews
                 {
                     if (((Style)style).Line != null)
                     {
-                        int color = ((Style)style).Line.Color.Value.Abgr;
+                        int color;
+                        if (((Style)style).Line.Color != null)
+                        {
+                            color = ((Style)style).Line.Color.Value.Abgr;
+                            color = (int)((color & 0xFF00FF00) | ((color & 0x00FF0000) >> 16) | ((color & 0x000000FF) << 16));
+
+                        }
+                        else color = Color.White.ToArgb();
                         // convert color from ABGR to ARGB
-                        color = (int)((color & 0xFF00FF00) | ((color & 0x00FF0000) >> 16) | ((color & 0x000000FF) << 16));
 
                         if (((Style)style).Line.Width != null)
                         {

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5180,8 +5180,12 @@ namespace MissionPlanner.GCSViews
                         // convert color from ABGR to ARGB
                         color = (int)((color & 0xFF00FF00) | ((color & 0x00FF0000) >> 16) | ((color & 0x000000FF) << 16));
 
-                        // ABGR
-                        return (Color.FromArgb(color), (int)((Style)style).Line.Width.Value);
+                        if (((Style)style).Line.Width != null)
+                        {
+                            return (Color.FromArgb(color), (int)((Style)style).Line.Width.Value);
+                        }
+                        else
+                            return (Color.FromArgb(color), 2);
                     }
                 }
             }


### PR DESCRIPTION
Apparently Google Earth Pro produces malformed KMLs by skipping default values at least for colors and line widths.
And it caused KML overlay load fail.
Fixes Issue : https://github.com/ArduPilot/MissionPlanner/issues/3443
