### PR TITLE
Fix Warning Repeat Time

### DIFF
--- a/ExtLibs/Utilities/Warnings/CustomWarning.cs
+++ b/ExtLibs/Utilities/Warnings/CustomWarning.cs
@@ -183,40 +183,45 @@ namespace MissionPlanner.Warnings
             if (userepeattime && DateTime.Now < lastrepeat.AddSeconds(RepeatTime))
                 return false;
 
-            lastrepeat = DateTime.Now;
+            bool condition = false;
 
             switch (ConditionType)
             {
                 case Conditional.EQ:
                     if (GetValue == Warning)
-                        return true;
+                        condition = true;
                     break;
                 case Conditional.GT:
                     if (GetValue > Warning)
-                        return true;
+                        condition = true;
                     break;
                 case Conditional.GTEQ:
                     if (GetValue >= Warning)
-                        return true;
+                        condition = true;
                     break;
                 case Conditional.LT:
                     if (GetValue < Warning)
-                        return true;
+                        condition = true;
                     break;
                 case Conditional.LTEQ:
                     if (GetValue <= Warning)
-                        return true;
+                        condition = true;
                     break;
                 case Conditional.NEQ:
                     if (GetValue != Warning)
-                        return true;
+                        condition = true;
                     break;
                 case Conditional.NONE:
 
                     break;
             }
 
-            return false;
+            if (condition)
+            {
+                lastrepeat = DateTime.Now;
+            }
+
+            return condition;
         }
 
 

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -747,12 +747,6 @@ namespace MissionPlanner
             {
             }
 
-            Warnings.CustomWarning.defaultsrc = comPort.MAV.cs;
-            Warnings.WarningEngine.Start(speechEnable ? speechEngine : null);
-            Warnings.WarningEngine.WarningMessage += (sender, s) => { MainV2.comPort.MAV.cs.messageHigh = s; };
-
-            Warnings.WarningEngine.QuickPanelColoring += WarningEngine_QuickPanelColoring;
-
             // proxy loader - dll load now instead of on config form load
             new Transition(new TransitionType_EaseInEaseOut(2000));
 
@@ -1020,6 +1014,11 @@ namespace MissionPlanner
             catch
             {
             }
+
+            Warnings.CustomWarning.defaultsrc = comPort.MAV.cs;
+            Warnings.WarningEngine.Start(speechEnable ? speechEngine : null);
+            Warnings.WarningEngine.WarningMessage += (sender, s) => { MainV2.comPort.MAV.cs.messageHigh = s; };
+            Warnings.WarningEngine.QuickPanelColoring += WarningEngine_QuickPanelColoring;
 
             if (CurrentState.rateattitudebackup == 0) // initilised to 10, configured above from save
             {


### PR DESCRIPTION
The RepeatTime setting was also the worst-case detection time

As implemented, no matter what, the condition is checked every `RepeatTime` seconds. At the default time of 10, this means it could take up to 10s before the warning manager tells you that something bad happened. On average it takes 5.

This fixes it so the last repeat time only gets recorded when the check returns true. So, after this function returns true, it will not check again for another `RepeatTime` seconds.

Also a driveby fix of the initialization of the `_speech` member of the warning engine. It was always initializing to null due to being initialized before the user's speech settings were loaded.