### PR TITLE
FlightData: Actions: add engine start/stop

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -2501,6 +2501,19 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
         }
 
         /// <summary>
+        /// Control ICE Engine
+        /// </summary>
+        /// <param name="onoff">true to enable, false to disable</param>
+        /// <returns></returns>
+        public bool doEngineControl(byte sysid, byte compid, bool onoff = false)
+        {
+            int param1 = onoff ? 1 : 0;
+
+            return doCommand(sysid, compid, MAV_CMD.DO_ENGINE_CONTROL,
+                    param1, 0, 0, 0, 0, 0, 0);
+        }
+
+        /// <summary>
         /// reboot the vehicle
         /// </summary>
         /// <param name="bootloadermode">reboot into bootloader mode?</param>

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -192,7 +192,9 @@ namespace MissionPlanner.GCSViews
             HighLatency_Enable,
             HighLatency_Disable,
             Toggle_Safety_Switch,
-            Do_Parachute
+            Do_Parachute,
+            Engine_Start,
+            Engine_Stop,
         }
 
         private Dictionary<int, string> NIC_table = new Dictionary<int, string>()
@@ -1765,6 +1767,18 @@ namespace MissionPlanner.GCSViews
                         var custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u;
                         var mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode, target_system = target_system };
                         MainV2.comPort.setMode(mode, MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
+                        ((Control)sender).Enabled = true;
+                        return;
+                    }
+                    if (CMB_action.Text == actions.Engine_Start.ToString())
+                    {
+                        MainV2.comPort.doEngineControl((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, true);
+                        ((Control)sender).Enabled = true;
+                        return;
+                    }
+                    if (CMB_action.Text == actions.Engine_Stop.ToString())
+                    {
+                        MainV2.comPort.doEngineControl((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, false);
                         ((Control)sender).Enabled = true;
                         return;
                     }


### PR DESCRIPTION
Allows IC Engines to be used without an RC switch.