### PR TITLE
Fix ADSB Squawk back to decimal

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -4083,7 +4083,7 @@ namespace MissionPlanner.GCSViews
 
                                     adsbplane.ToolTipText = "ICAO: " + pllau.Tag + "\n" +
                                                             "Callsign: " + pllau.CallSign + "\n" +
-                                                            "Squawk: " + pllau.Squawk.ToString("X4") + "\n" +
+                                                            "Squawk: " + pllau.Squawk.ToString("0") + "\n" +
                                                             "Alt: " + (pllau.Alt * CurrentState.multiplieralt).ToString("0") + " " + CurrentState.AltUnit + "\n" +
                                                             "Speed: " + (pllau.Speed / 100 /* cm to m */ * CurrentState.multiplierspeed).ToString("0") + " " + CurrentState.SpeedUnit + "\n" +
                                                             "VSpeed: " + (pllau.VerticalSpeed / 100 /* cm to m */ * CurrentState.multiplierspeed).ToString("F1") + " " + CurrentState.SpeedUnit + "\n" +


### PR DESCRIPTION
This [commit](https://github.com/ArduPilot/MissionPlanner/commit/eefd2167358c5c121c61b58f0eab4f85034d5ef8#diff-14ff4d1be768ca629959b5d1f5efdb8058bd7b9c448b74681ef87c509eac4c89R4074) by @MUSTARDTIGERFPV changed the squawk text to be shown in Hex. I'm not sure why, maybe he knows? I've never seen it expressed as a decimal. Technically it's an octal number but decimal is the normal conversion.