### PR TITLE
Revert "Fix ADSB Squawk back to decimal"

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -4083,7 +4083,7 @@ namespace MissionPlanner.GCSViews
 
                                     adsbplane.ToolTipText = "ICAO: " + pllau.Tag + "\n" +
                                                             "Callsign: " + pllau.CallSign + "\n" +
-                                                            "Squawk: " + pllau.Squawk.ToString("0") + "\n" +
+                                                            "Squawk: " + pllau.Squawk.ToString("X4") + "\n" +
                                                             "Alt: " + (pllau.Alt * CurrentState.multiplieralt).ToString("0") + " " + CurrentState.AltUnit + "\n" +
                                                             "Speed: " + (pllau.Speed / 100 /* cm to m */ * CurrentState.multiplierspeed).ToString("0") + " " + CurrentState.SpeedUnit + "\n" +
                                                             "VSpeed: " + (pllau.VerticalSpeed / 100 /* cm to m */ * CurrentState.multiplierspeed).ToString("F1") + " " + CurrentState.SpeedUnit + "\n" +


### PR DESCRIPTION
Reverts ArduPilot/MissionPlanner#3452

See https://github.com/ArduPilot/MissionPlanner/pull/3452#issuecomment-2499089874 for rationale; a 4-digit hex representation is the aviation-standard way to display octal squawk codes.