### PR TITLE
Travelled Distance Calculation Fix (Update CurrentState.cs)

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -1139,7 +1139,8 @@ namespace MissionPlanner
 
         [DisplayFieldName("distTraveled.Field")]
         [DisplayText("Dist Traveled (dist)")][GroupText("Position")] public float distTraveled { get; set; }
-
+  	public string distTravelledUnit = CurrentState.DistanceUnit;  // added by Mir 30112024
+      
         [DisplayText("Time in Air (sec)")][GroupText("Position")] public float timeSinceArmInAir { get; set; }
 
         [DisplayFieldName("timeInAir.Field")]
@@ -4416,6 +4417,18 @@ namespace MissionPlanner
                             if (mavinterface.BaseStream != null && !mavinterface.BaseStream.IsOpen &&
                                 !mavinterface.logreadmode)
                                 distTraveled = 0;
+
+                            // added by Mir 30112024
+                            if (distTravelledUnit != CurrentState.DistanceUnit)  // did distance unit change?
+                            {
+                                distTravelledUnit = CurrentState.DistanceUnit;  // set the new unit
+                                if(distTravelledUnit == "m") // changed to meters (was feets)
+                                    distTraveled = (float)(distTraveled / 3.28084); //Fix disttravelled
+                                else // changed to feets (was meters)
+                                    distTraveled = (float)(distTraveled * 3.28084); //Fix disttravelled
+
+                            } // end of my added
+                            
 
                             distTraveled += (float)lastpos.GetDistance(new PointLatLngAlt(lat, lng, 0, "")) *
                                             multiplierdist;


### PR DESCRIPTION
 Hello, this is my first pull request for Mission Planner or GitHub in general. Hence, I hope I am doing this correctly.
 
I noticed some of the Current State (MAV.cs) parameters are calculated inside Mission Planner (Travelled Distance and Time in Air), which sometimes leads to mistakes in calculations (for example, if the link got disconnected for sometime or the Mission Planner was restarted while UAV is flying).
Hopefully we can find a solution to solve this issue.

For now, I found a bug when **changing the Distance Unit while the UAV is flying**, the travelled distance calculation goes wrong. I found that the variable "disttravelled" is accumulated from previous value regardless of the distance unit (meters or feet).

I Updated CurrentState.cs  as shown in my commit, perhaps there is a better way that you can think of.