### PR TITLE
Download: fix getFilefromNet for slow downloads

### DIFF
--- a/ExtLibs/Utilities/Download.cs
+++ b/ExtLibs/Utilities/Download.cs
@@ -350,7 +350,7 @@ namespace MissionPlanner.Utilities
 
                 RequestModification?.Invoke(url, request);
 
-                using (var response = await client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await client.SendAsync(request, completionOption: HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
                 {
                     lock (log)
                         log.Info(url + " " +(response).StatusCode.ToString());
@@ -458,7 +458,7 @@ namespace MissionPlanner.Utilities
                 client.Timeout = TimeSpan.FromSeconds(30);
 
                 // Get the response.
-                var response = client.GetAsync(url).Result;
+                var response = client.GetAsync(url, completionOption: HttpCompletionOption.ResponseHeadersRead).Result;
                 // Display the status.
                 lock (log)
                     log.Info(response.ReasonPhrase);


### PR DESCRIPTION
Files that took more than 30s to download were failing.

This change makes GetAsync/SendAsync return the response as soon as the header comes in, which makes the progress bar/ETA work as intended. Previously, the entire file would be downloaded before the response could even be checked, causing timeouts for large files or slow connections.

I can't get GStreamer to install itself at my appartment without this.