### PR TITLE
Fix ESP32-C3 Dronebridge Reset on First connect on Windows

### DIFF
--- a/ExtLibs/Comms/CommsSerialPort.cs
+++ b/ExtLibs/Comms/CommsSerialPort.cs
@@ -145,6 +145,10 @@ namespace MissionPlanner.Comms
 
         public void Open()
         {
+            if (espFix && _baseport is WinSerialPort)
+            {
+                ((WinSerialPort)_baseport).espFix = true;
+            }
             _baseport.Open();
         }
 
@@ -193,6 +197,8 @@ namespace MissionPlanner.Comms
             _baseport.toggleDTR();
         }
 
+
+        public bool espFix = false;
 
         private static readonly object locker = new object();
 
@@ -407,6 +413,7 @@ namespace MissionPlanner.Comms
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(WinSerialPort));
 
+        public bool espFix = false;
         public WinSerialPort()
         {
         }
@@ -471,6 +478,7 @@ namespace MissionPlanner.Comms
             // 500ms write timeout - win32 api default
             base.WriteTimeout = 500;
 
+
             if (base.IsOpen)
                 return;
 
@@ -493,6 +501,10 @@ namespace MissionPlanner.Comms
                 if (!File.Exists(PortName))
                     throw new Exception("No such device");
 
+
+            if (espFix)
+                base.Handshake = System.IO.Ports.Handshake.RequestToSend;
+
             try
             {
                 base.Open();
@@ -509,6 +521,8 @@ namespace MissionPlanner.Comms
 
                 throw;
             }
+            if (espFix)
+                base.Handshake = System.IO.Ports.Handshake.None;
         }
 
         public new void Close()

--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -122,6 +122,7 @@
             this.CMB_mapCache = new System.Windows.Forms.ComboBox();
             this.label13 = new System.Windows.Forms.Label();
             this.BUT_mapCacheDir = new MissionPlanner.Controls.MyButton();
+            this.CHK_rtsresetesp32 = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NUM_tracklength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_gcsid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.num_linelength)).BeginInit();
@@ -134,7 +135,6 @@
             // 
             // CMB_ratesensors
             // 
-            resources.ApplyResources(this.CMB_ratesensors, "CMB_ratesensors");
             this.CMB_ratesensors.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_ratesensors.FormattingEnabled = true;
             this.CMB_ratesensors.Items.AddRange(new object[] {
@@ -153,6 +153,7 @@
             resources.GetString("CMB_ratesensors.Items12"),
             resources.GetString("CMB_ratesensors.Items13"),
             resources.GetString("CMB_ratesensors.Items14")});
+            resources.ApplyResources(this.CMB_ratesensors, "CMB_ratesensors");
             this.CMB_ratesensors.Name = "CMB_ratesensors";
             this.CMB_ratesensors.SelectedIndexChanged += new System.EventHandler(this.CMB_ratesensors_SelectedIndexChanged);
             // 
@@ -163,9 +164,9 @@
             // 
             // CMB_videoresolutions
             // 
-            resources.ApplyResources(this.CMB_videoresolutions, "CMB_videoresolutions");
             this.CMB_videoresolutions.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_videoresolutions.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_videoresolutions, "CMB_videoresolutions");
             this.CMB_videoresolutions.Name = "CMB_videoresolutions";
             // 
             // label12
@@ -199,12 +200,12 @@
             // 
             // NUM_tracklength
             // 
-            resources.ApplyResources(this.NUM_tracklength, "NUM_tracklength");
             this.NUM_tracklength.Increment = new decimal(new int[] {
             100,
             0,
             0,
             0});
+            resources.ApplyResources(this.NUM_tracklength, "NUM_tracklength");
             this.NUM_tracklength.Maximum = new decimal(new int[] {
             200000,
             0,
@@ -256,7 +257,6 @@
             // 
             // CMB_raterc
             // 
-            resources.ApplyResources(this.CMB_raterc, "CMB_raterc");
             this.CMB_raterc.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_raterc.FormattingEnabled = true;
             this.CMB_raterc.Items.AddRange(new object[] {
@@ -275,6 +275,7 @@
             resources.GetString("CMB_raterc.Items12"),
             resources.GetString("CMB_raterc.Items13"),
             resources.GetString("CMB_raterc.Items14")});
+            resources.ApplyResources(this.CMB_raterc, "CMB_raterc");
             this.CMB_raterc.Name = "CMB_raterc";
             this.CMB_raterc.SelectedIndexChanged += new System.EventHandler(this.CMB_raterc_SelectedIndexChanged);
             // 
@@ -300,7 +301,6 @@
             // 
             // CMB_ratestatus
             // 
-            resources.ApplyResources(this.CMB_ratestatus, "CMB_ratestatus");
             this.CMB_ratestatus.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_ratestatus.FormattingEnabled = true;
             this.CMB_ratestatus.Items.AddRange(new object[] {
@@ -319,12 +319,12 @@
             resources.GetString("CMB_ratestatus.Items12"),
             resources.GetString("CMB_ratestatus.Items13"),
             resources.GetString("CMB_ratestatus.Items14")});
+            resources.ApplyResources(this.CMB_ratestatus, "CMB_ratestatus");
             this.CMB_ratestatus.Name = "CMB_ratestatus";
             this.CMB_ratestatus.SelectedIndexChanged += new System.EventHandler(this.CMB_ratestatus_SelectedIndexChanged);
             // 
             // CMB_rateposition
             // 
-            resources.ApplyResources(this.CMB_rateposition, "CMB_rateposition");
             this.CMB_rateposition.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_rateposition.FormattingEnabled = true;
             this.CMB_rateposition.Items.AddRange(new object[] {
@@ -343,12 +343,12 @@
             resources.GetString("CMB_rateposition.Items12"),
             resources.GetString("CMB_rateposition.Items13"),
             resources.GetString("CMB_rateposition.Items14")});
+            resources.ApplyResources(this.CMB_rateposition, "CMB_rateposition");
             this.CMB_rateposition.Name = "CMB_rateposition";
             this.CMB_rateposition.SelectedIndexChanged += new System.EventHandler(this.CMB_rateposition_SelectedIndexChanged);
             // 
             // CMB_rateattitude
             // 
-            resources.ApplyResources(this.CMB_rateattitude, "CMB_rateattitude");
             this.CMB_rateattitude.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_rateattitude.FormattingEnabled = true;
             this.CMB_rateattitude.Items.AddRange(new object[] {
@@ -366,6 +366,7 @@
             resources.GetString("CMB_rateattitude.Items11"),
             resources.GetString("CMB_rateattitude.Items12"),
             resources.GetString("CMB_rateattitude.Items13")});
+            resources.ApplyResources(this.CMB_rateattitude, "CMB_rateattitude");
             this.CMB_rateattitude.Name = "CMB_rateattitude";
             this.CMB_rateattitude.SelectedIndexChanged += new System.EventHandler(this.CMB_rateattitude_SelectedIndexChanged);
             // 
@@ -386,17 +387,17 @@
             // 
             // CMB_speedunits
             // 
-            resources.ApplyResources(this.CMB_speedunits, "CMB_speedunits");
             this.CMB_speedunits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_speedunits.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_speedunits, "CMB_speedunits");
             this.CMB_speedunits.Name = "CMB_speedunits";
             this.CMB_speedunits.SelectedIndexChanged += new System.EventHandler(this.CMB_speedunits_SelectedIndexChanged);
             // 
             // CMB_distunits
             // 
-            resources.ApplyResources(this.CMB_distunits, "CMB_distunits");
             this.CMB_distunits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_distunits.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_distunits, "CMB_distunits");
             this.CMB_distunits.Name = "CMB_distunits";
             this.CMB_distunits.SelectedIndexChanged += new System.EventHandler(this.CMB_distunits_SelectedIndexChanged);
             // 
@@ -445,27 +446,27 @@
             // 
             // CMB_osdcolor
             // 
-            resources.ApplyResources(this.CMB_osdcolor, "CMB_osdcolor");
             this.CMB_osdcolor.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.CMB_osdcolor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_osdcolor.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_osdcolor, "CMB_osdcolor");
             this.CMB_osdcolor.Name = "CMB_osdcolor";
             this.CMB_osdcolor.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.CMB_osdcolor_DrawItem);
             this.CMB_osdcolor.SelectedIndexChanged += new System.EventHandler(this.CMB_osdcolor_SelectedIndexChanged);
             // 
             // CMB_severity
             // 
-            resources.ApplyResources(this.CMB_severity, "CMB_severity");
             this.CMB_severity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_severity.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_severity, "CMB_severity");
             this.CMB_severity.Name = "CMB_severity";
             this.CMB_severity.SelectedIndexChanged += new System.EventHandler(this.CMB_severity_SelectedIndexChanged);
             // 
             // CMB_language
             // 
-            resources.ApplyResources(this.CMB_language, "CMB_language");
             this.CMB_language.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_language.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_language, "CMB_language");
             this.CMB_language.Name = "CMB_language";
             this.CMB_language.SelectedIndexChanged += new System.EventHandler(this.CMB_language_SelectedIndexChanged);
             // 
@@ -483,9 +484,9 @@
             // 
             // CHK_hudshow
             // 
-            resources.ApplyResources(this.CHK_hudshow, "CHK_hudshow");
             this.CHK_hudshow.Checked = true;
             this.CHK_hudshow.CheckState = System.Windows.Forms.CheckState.Checked;
+            resources.ApplyResources(this.CHK_hudshow, "CHK_hudshow");
             this.CHK_hudshow.Name = "CHK_hudshow";
             this.CHK_hudshow.UseVisualStyleBackColor = true;
             this.CHK_hudshow.CheckedChanged += new System.EventHandler(this.CHK_hudshow_CheckedChanged);
@@ -497,9 +498,9 @@
             // 
             // CMB_videosources
             // 
-            resources.ApplyResources(this.CMB_videosources, "CMB_videosources");
             this.CMB_videosources.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_videosources.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_videosources, "CMB_videosources");
             this.CMB_videosources.Name = "CMB_videosources";
             this.CMB_videosources.SelectedIndexChanged += new System.EventHandler(this.CMB_videosources_SelectedIndexChanged);
             this.CMB_videosources.Click += new System.EventHandler(this.CMB_videosources_Click);
@@ -523,9 +524,9 @@
             // 
             // CHK_disttohomeflightdata
             // 
-            resources.ApplyResources(this.CHK_disttohomeflightdata, "CHK_disttohomeflightdata");
             this.CHK_disttohomeflightdata.Checked = true;
             this.CHK_disttohomeflightdata.CheckState = System.Windows.Forms.CheckState.Checked;
+            resources.ApplyResources(this.CHK_disttohomeflightdata, "CHK_disttohomeflightdata");
             this.CHK_disttohomeflightdata.Name = "CHK_disttohomeflightdata";
             this.CHK_disttohomeflightdata.UseVisualStyleBackColor = true;
             this.CHK_disttohomeflightdata.CheckedChanged += new System.EventHandler(this.CHK_disttohomeflightdata_CheckedChanged);
@@ -579,9 +580,9 @@
             // 
             // CMB_theme
             // 
-            resources.ApplyResources(this.CMB_theme, "CMB_theme");
             this.CMB_theme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_theme.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_theme, "CMB_theme");
             this.CMB_theme.Name = "CMB_theme";
             this.CMB_theme.SelectedIndexChanged += new System.EventHandler(this.CMB_theme_SelectedIndexChanged);
             // 
@@ -677,9 +678,9 @@
             // 
             // CMB_Layout
             // 
-            resources.ApplyResources(this.CMB_Layout, "CMB_Layout");
             this.CMB_Layout.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_Layout.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_Layout, "CMB_Layout");
             this.CMB_Layout.Name = "CMB_Layout";
             this.CMB_Layout.SelectedIndexChanged += new System.EventHandler(this.CMB_Layout_SelectedIndexChanged);
             // 
@@ -713,9 +714,9 @@
             // 
             // CMB_altunits
             // 
-            resources.ApplyResources(this.CMB_altunits, "CMB_altunits");
             this.CMB_altunits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CMB_altunits.FormattingEnabled = true;
+            resources.ApplyResources(this.CMB_altunits, "CMB_altunits");
             this.CMB_altunits.Name = "CMB_altunits";
             this.CMB_altunits.SelectedIndexChanged += new System.EventHandler(this.CMB_altunits_SelectedIndexChanged);
             // 
@@ -778,9 +779,9 @@
             // 
             // cmb_secondarydisplaystyle
             // 
-            resources.ApplyResources(this.cmb_secondarydisplaystyle, "cmb_secondarydisplaystyle");
             this.cmb_secondarydisplaystyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmb_secondarydisplaystyle.FormattingEnabled = true;
+            resources.ApplyResources(this.cmb_secondarydisplaystyle, "cmb_secondarydisplaystyle");
             this.cmb_secondarydisplaystyle.Name = "cmb_secondarydisplaystyle";
             this.cmb_secondarydisplaystyle.SelectedIndexChanged += new System.EventHandler(this.cmb_secondarydisplaystyle_SelectedIndexChanged);
             // 
@@ -826,12 +827,12 @@
             // 
             // num_linelength
             // 
-            resources.ApplyResources(this.num_linelength, "num_linelength");
             this.num_linelength.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
+            resources.ApplyResources(this.num_linelength, "num_linelength");
             this.num_linelength.Maximum = new decimal(new int[] {
             2000,
             0,
@@ -879,12 +880,21 @@
             // 
             resources.ApplyResources(this.BUT_mapCacheDir, "BUT_mapCacheDir");
             this.BUT_mapCacheDir.Name = "BUT_mapCacheDir";
+            this.BUT_mapCacheDir.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_mapCacheDir.UseVisualStyleBackColor = true;
             this.BUT_mapCacheDir.Click += new System.EventHandler(this.BUT_mapCacheDir_Click);
+            // 
+            // CHK_rtsresetesp32
+            // 
+            resources.ApplyResources(this.CHK_rtsresetesp32, "CHK_rtsresetesp32");
+            this.CHK_rtsresetesp32.Name = "CHK_rtsresetesp32";
+            this.CHK_rtsresetesp32.UseVisualStyleBackColor = true;
+            this.CHK_rtsresetesp32.CheckedChanged += new System.EventHandler(this.CHK_rtsresetesp32_CheckedChanged);
             // 
             // ConfigPlanner
             // 
             resources.ApplyResources(this, "$this");
+            this.Controls.Add(this.CHK_rtsresetesp32);
             this.Controls.Add(this.label10);
             this.Controls.Add(this.cmb_secondarydisplaystyle);
             this.Controls.Add(this.label9);
@@ -1083,5 +1093,6 @@
         private System.Windows.Forms.Label label13;
         public System.Windows.Forms.ComboBox CMB_mapCache;
         private Controls.MyButton BUT_mapCacheDir;
+        private System.Windows.Forms.CheckBox CHK_rtsresetesp32;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -173,6 +173,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             // setup other config state
             SetCheckboxFromConfig("CHK_resetapmonconnect", CHK_resetapmonconnect);
+            SetCheckboxFromConfig("CHK_rtsresetesp32", CHK_rtsresetesp32);
 
             CMB_rateattitude.Text = MainV2.comPort.MAV.cs.rateattitude.ToString();
             CMB_rateposition.Text = MainV2.comPort.MAV.cs.rateposition.ToString();
@@ -620,7 +621,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             CurrentState.ratercbackup = MainV2.comPort.MAV.cs.raterc;
 
             MainV2.comPort.requestDatastream(MAVLink.MAV_DATA_STREAM.RC_CHANNELS, MainV2.comPort.MAV.cs.raterc);
-            // request rc info 
+            // request rc info
         }
 
         private void CMB_ratesensors_SelectedIndexChanged(object sender, EventArgs e)
@@ -647,6 +648,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             Settings.Instance[((CheckBox)sender).Name] = ((CheckBox)sender).Checked.ToString();
         }
+
+        private void CHK_rtsresetesp32_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Instance[((CheckBox)sender).Name] = ((CheckBox)sender).Checked.ToString();
+        }
+
+
+
 
         private void CHK_speechaltwarning_CheckedChanged(object sender, EventArgs e)
         {
@@ -1121,7 +1130,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 Settings.Instance["mapicondesc"] = "";
             }
-            
+
         }
 
         private void num_linelength_ValueChanged(object sender, EventArgs e)

--- a/GCSViews/ConfigurationView/ConfigPlanner.resx
+++ b/GCSViews/ConfigurationView/ConfigPlanner.resx
@@ -117,1181 +117,467 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="CHK_speecharmdisarm.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="BUT_Joystick.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 166</value>
-  </data>
-  <data name="chk_temp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 17</value>
-  </data>
-  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;BUT_logdirbrowse.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="chk_ADSB.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label99.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateposition.ZOrder" xml:space="preserve">
-    <value>65</value>
-  </data>
-  <data name="&gt;&gt;label96.ZOrder" xml:space="preserve">
-    <value>72</value>
-  </data>
-  <data name="CHK_Password.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 554</value>
-  </data>
-  <data name="CMB_altunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechwaypoint.ZOrder" xml:space="preserve">
-    <value>77</value>
-  </data>
-  <data name="&gt;&gt;label108.ZOrder" xml:space="preserve">
-    <value>55</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label93.Name" xml:space="preserve">
-    <value>label93</value>
-  </data>
-  <data name="chk_displaytarget.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
-  </data>
-  <data name="&gt;&gt;CHK_disttohomeflightdata.Name" xml:space="preserve">
-    <value>CHK_disttohomeflightdata</value>
-  </data>
-  <data name="chk_displaytooltip.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
-  </data>
-  <data name="&gt;&gt;label101.Name" xml:space="preserve">
-    <value>label101</value>
-  </data>
-  <data name="CMB_rateattitude.Items" xml:space="preserve">
-    <value>-1</value>
-  </data>
-  <data name="label26.Text" xml:space="preserve">
-    <value>Video Format</value>
-  </data>
-  <data name="CMB_speedunits.TabIndex" type="System.Int32, mscorlib">
-    <value>60</value>
-  </data>
-  <data name="CHK_GDIPlus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 349</value>
-  </data>
-  <data name="chk_displayheading.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 17</value>
-  </data>
-  <data name="&gt;&gt;BUT_logdirbrowse.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="txt_log_dir.Size" type="System.Drawing.Size, System.Drawing">
-    <value>386, 20</value>
-  </data>
-  <data name="&gt;&gt;CMB_ratestatus.Name" xml:space="preserve">
-    <value>CMB_ratestatus</value>
-  </data>
-  <data name="label102.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
-  </data>
-  <data name="&gt;&gt;CHK_GDIPlus.Name" xml:space="preserve">
-    <value>CHK_GDIPlus</value>
-  </data>
-  <data name="CMB_ratesensors.Items2" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Log Path</value>
-  </data>
-  <data name="label95.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label26.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CHK_maprotation.ZOrder" xml:space="preserve">
-    <value>41</value>
-  </data>
-  <data name="CMB_rateposition.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
-  </data>
-  <data name="label104.Location" type="System.Drawing.Point, System.Drawing">
-    <value>330, 254</value>
-  </data>
-  <data name="label26.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label97.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="BUT_Joystick.TabIndex" type="System.Int32, mscorlib">
-    <value>76</value>
-  </data>
-  <data name="&gt;&gt;CHK_GDIPlus.ZOrder" xml:space="preserve">
-    <value>48</value>
-  </data>
-  <data name="CMB_raterc.Items7" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;chk_tfr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_loadwponconnect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 326</value>
-  </data>
-  <data name="label8.Text" xml:space="preserve">
-    <value>NOTE: Set the low level of SEVERITY to speak</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>949, 693</value>
-  </data>
-  <data name="CMB_raterc.Items14" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="&gt;&gt;label107.Name" xml:space="preserve">
-    <value>label107</value>
-  </data>
-  <data name="chk_temp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
-    <value>Low Speed</value>
-  </data>
-  <data name="CHK_Password.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
-  </data>
-  <data name="&gt;&gt;label107.ZOrder" xml:space="preserve">
-    <value>58</value>
-  </data>
-  <data name="CHK_AutoParamCommit.TabIndex" type="System.Int32, mscorlib">
-    <value>116</value>
-  </data>
-  <data name="BUT_themecustom.Text" xml:space="preserve">
-    <value>Custom</value>
-  </data>
-  <data name="&gt;&gt;label95.ZOrder" xml:space="preserve">
-    <value>73</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="BUT_Joystick.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_slowMachine.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chk_tfr.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_videosources.ZOrder" xml:space="preserve">
-    <value>86</value>
-  </data>
-  <data name="&gt;&gt;BUT_themecustom.ZOrder" xml:space="preserve">
-    <value>32</value>
-  </data>
-  <data name="label107.Size" type="System.Drawing.Size, System.Drawing">
-    <value>22, 13</value>
-  </data>
-  <data name="chk_displayradius.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;BUT_videostop.ZOrder" xml:space="preserve">
-    <value>88</value>
-  </data>
-  <data name="&gt;&gt;CHK_GDIPlus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CMB_rateposition.Items12" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;CHK_loadwponconnect.ZOrder" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="label93.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 142</value>
-  </data>
-  <data name="&gt;&gt;CHK_disttohomeflightdata.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label94.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechlowspeed.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
-  </data>
-  <data name="label95.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label103.TabIndex" type="System.Int32, mscorlib">
-    <value>51</value>
-  </data>
-  <data name="&gt;&gt;CHK_enablespeech.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_ratesensors.TabIndex" type="System.Int32, mscorlib">
-    <value>88</value>
-  </data>
-  <data name="chk_tfr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 577</value>
-  </data>
-  <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
-  </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>115</value>
-  </data>
-  <data name="&gt;&gt;chk_slowMachine.Name" xml:space="preserve">
-    <value>chk_slowMachine</value>
-  </data>
-  <data name="&gt;&gt;BUT_Vario.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytooltip.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="BUT_Joystick.Text" xml:space="preserve">
-    <value>Joystick Setup</value>
-  </data>
-  <data name="&gt;&gt;label95.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_speechbattery.Location" type="System.Drawing.Point, System.Drawing">
-    <value>559, 89</value>
-  </data>
-  <data name="CHK_enablespeech.Text" xml:space="preserve">
-    <value>Enable Speech</value>
-  </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 424</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
-  </data>
-  <data name="CHK_speechwaypoint.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;BUT_Vario.ZOrder" xml:space="preserve">
-    <value>30</value>
-  </data>
-  <data name="CMB_rateattitude.Items10" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="num_linelength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>768, 500</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MyUserControl, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="label101.Text" xml:space="preserve">
-    <value>Telemetry Rates</value>
-  </data>
-  <data name="&gt;&gt;CHK_maprotation.Name" xml:space="preserve">
-    <value>CHK_maprotation</value>
-  </data>
-  <data name="chk_shownofly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_slowMachine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 17</value>
-  </data>
-  <data name="chk_analytics.Text" xml:space="preserve">
-    <value>OptOut Anon Stats</value>
-  </data>
-  <data name="&gt;&gt;label24.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;NUM_tracklength.ZOrder" xml:space="preserve">
-    <value>53</value>
-  </data>
-  <data name="&gt;&gt;BUT_themecustom.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chk_temp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label94.Text" xml:space="preserve">
-    <value>OSD Color</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytooltip.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="CMB_raterc.Items10" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 373</value>
-  </data>
-  <data name="label96.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 171</value>
-  </data>
-  <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 13</value>
-  </data>
-  <data name="&gt;&gt;CHK_beta.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechaltwarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CMB_ratestatus.Items10" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="label23.TabIndex" type="System.Int32, mscorlib">
-    <value>81</value>
-  </data>
-  <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 327</value>
-  </data>
-  <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
-    <value>Auto Commit Params</value>
-  </data>
-  <data name="&gt;&gt;CHK_params_bg.Name" xml:space="preserve">
-    <value>CHK_params_bg</value>
-  </data>
-  <data name="&gt;&gt;CMB_raterc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_resetapmonconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label93.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chk_slowMachine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chk_temp.TabIndex" type="System.Int32, mscorlib">
-    <value>110</value>
-  </data>
-  <data name="CHK_speechwaypoint.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;CHK_loadwponconnect.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_Layout.TabIndex" type="System.Int32, mscorlib">
-    <value>113</value>
-  </data>
-  <data name="CMB_osdcolor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 62</value>
-  </data>
-  <data name="CHK_beta.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;CMB_videosources.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CMB_language.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
-    <value>Alt Warning</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>Alt Units</value>
-  </data>
-  <data name="&gt;&gt;CMB_theme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="num_linelength.TabIndex" type="System.Int32, mscorlib">
-    <value>80</value>
-  </data>
-  <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>49</value>
-  </data>
-  <data name="CHK_Password.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
-  </data>
-  <data name="BUT_themecustom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 421</value>
-  </data>
-  <data name="&gt;&gt;chk_tfr.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;BUT_videostart.Name" xml:space="preserve">
-    <value>BUT_videostart</value>
-  </data>
-  <data name="CMB_videoresolutions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 35</value>
-  </data>
-  <data name="CMB_distunits.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 195</value>
-  </data>
-  <data name="CMB_ratesensors.Items13" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="CMB_ratesensors.Items12" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;CHK_hudshow.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_ratesensors.Items10" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;label94.ZOrder" xml:space="preserve">
-    <value>78</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
-  </data>
-  <data name="BUT_logdirbrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CMB_ratesensors.Items4" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label99.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>46</value>
-  </data>
-  <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
-  </data>
-  <data name="&gt;&gt;BUT_Joystick.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label107.Location" type="System.Drawing.Point, System.Drawing">
-    <value>461, 254</value>
-  </data>
-  <data name="label103.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
-  </data>
-  <data name="&gt;&gt;CHK_showairports.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>ConfigPlanner</value>
-  </data>
-  <data name="label33.TabIndex" type="System.Int32, mscorlib">
-    <value>87</value>
-  </data>
-  <data name="BUT_videostop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>439, 6</value>
-  </data>
-  <data name="cmb_secondarydisplaystyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 524</value>
-  </data>
-  <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>157, 31</value>
-  </data>
-  <data name="&gt;&gt;chk_displaycog.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>47</value>
-  </data>
-  <data name="&gt;&gt;CMB_altunits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytooltip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
-  </data>
-  <data name="&gt;&gt;BUT_videostart.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechwaypoint.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label95.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_GDIPlus.Text" xml:space="preserve">
-    <value>GDI+ (old type/no HW acceleration)</value>
-  </data>
-  <data name="&gt;&gt;cmb_secondarydisplaystyle.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_GDIPlus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="BUT_logdirbrowse.TabIndex" type="System.Int32, mscorlib">
-    <value>95</value>
-  </data>
   <data name="label33.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="BUT_logdirbrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="CMB_theme.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="&gt;&gt;label104.Name" xml:space="preserve">
-    <value>label104</value>
-  </data>
-  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 477</value>
-  </data>
-  <data name="&gt;&gt;label108.Name" xml:space="preserve">
-    <value>label108</value>
-  </data>
-  <data name="CHK_speechArmedOnly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>212, 89</value>
-  </data>
-  <data name="&gt;&gt;num_gcsid.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateattitude.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;num_gcsid.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="BUT_videostop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="label26.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 38</value>
-  </data>
-  <data name="label94.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;CMB_raterc.Name" xml:space="preserve">
-    <value>CMB_raterc</value>
-  </data>
-  <data name="CHK_params_bg.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_disttohomeflightdata.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 17</value>
-  </data>
-  <data name="&gt;&gt;BUT_Vario.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CMB_ratestatus.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_maprotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label103.Location" type="System.Drawing.Point, System.Drawing">
-    <value>220, 254</value>
-  </data>
-  <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 502</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechlowspeed.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="label99.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 31</value>
-  </data>
-  <data name="&gt;&gt;CHK_Password.Name" xml:space="preserve">
-    <value>CHK_Password</value>
-  </data>
-  <data name="chk_displayradius.Location" type="System.Drawing.Point, System.Drawing">
-    <value>436, 501</value>
-  </data>
-  <data name="&gt;&gt;label24.Name" xml:space="preserve">
-    <value>label24</value>
-  </data>
-  <data name="&gt;&gt;label103.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_videoresolutions.TabIndex" type="System.Int32, mscorlib">
-    <value>44</value>
-  </data>
-  <data name="CMB_speedunits.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 222</value>
-  </data>
-  <data name="&gt;&gt;label94.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechaltwarning.ZOrder" xml:space="preserve">
-    <value>54</value>
-  </data>
-  <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
-  </data>
-  <data name="&gt;&gt;CHK_resetapmonconnect.Name" xml:space="preserve">
-    <value>CHK_resetapmonconnect</value>
-  </data>
-  <data name="CHK_enablespeech.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 89</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechbattery.Name" xml:space="preserve">
-    <value>CHK_speechbattery</value>
-  </data>
-  <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_disttohomeflightdata.TabIndex" type="System.Int32, mscorlib">
-    <value>92</value>
-  </data>
-  <data name="&gt;&gt;CHK_speecharmdisarm.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_mavdebug.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label12.Name" xml:space="preserve">
-    <value>label12</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateattitude.Name" xml:space="preserve">
-    <value>CMB_rateattitude</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Map Follow</value>
-  </data>
-  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_speechmode.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CHK_speechcustom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>469, 89</value>
-  </data>
-  <data name="&gt;&gt;label101.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="BUT_Joystick.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 23</value>
-  </data>
-  <data name="chk_slowMachine.Text" xml:space="preserve">
-    <value>Runing on a slow computer</value>
-  </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 398</value>
-  </data>
-  <data name="CHK_params_bg.Size" type="System.Drawing.Size, System.Drawing">
-    <value>186, 17</value>
-  </data>
-  <data name="num_gcsid.TabIndex" type="System.Int32, mscorlib">
-    <value>120</value>
-  </data>
-  <data name="CHK_showairports.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 554</value>
-  </data>
-  <data name="chk_displaycog.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label99.Location" type="System.Drawing.Point, System.Drawing">
-    <value>480, 198</value>
-  </data>
-  <data name="CMB_rateposition.TabIndex" type="System.Int32, mscorlib">
-    <value>55</value>
-  </data>
-  <data name="chk_shownofly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>671, 554</value>
-  </data>
-  <data name="&gt;&gt;label96.Name" xml:space="preserve">
-    <value>label96</value>
-  </data>
-  <data name="chk_displayradius.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 17</value>
-  </data>
-  <data name="label9.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="BUT_Vario.TabIndex" type="System.Int32, mscorlib">
-    <value>100</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechArmedOnly.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>51</value>
-  </data>
-  <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
-  </data>
-  <data name="CMB_raterc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>489, 251</value>
-  </data>
-  <data name="&gt;&gt;CHK_beta.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytarget.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="CMB_Layout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 448</value>
-  </data>
-  <data name="CHK_speecharmdisarm.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 527</value>
-  </data>
-  <data name="&gt;&gt;CMB_severity.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label93.ZOrder" xml:space="preserve">
-    <value>82</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechArmedOnly.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chk_displaycog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 501</value>
-  </data>
-  <data name="CMB_ratesensors.Location" type="System.Drawing.Point, System.Drawing">
-    <value>584, 251</value>
-  </data>
-  <data name="CMB_ratestatus.Items12" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="chk_displaytarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 17</value>
-  </data>
-  <data name="chk_displayradius.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="BUT_themecustom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
-  </data>
-  <data name="CHK_loadwponconnect.TabIndex" type="System.Int32, mscorlib">
-    <value>83</value>
-  </data>
-  <data name="CHK_mavdebug.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
-  <data name="label12.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label99.ZOrder" xml:space="preserve">
-    <value>67</value>
-  </data>
-  <data name="&gt;&gt;CMB_osdcolor.Name" xml:space="preserve">
-    <value>CMB_osdcolor</value>
-  </data>
-  <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 623</value>
-  </data>
-  <data name="CHK_enablespeech.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_maprotation.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_hudshow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>520, 10</value>
-  </data>
-  <data name="CHK_showairports.TabIndex" type="System.Int32, mscorlib">
-    <value>107</value>
-  </data>
-  <data name="label101.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;CMB_Layout.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="txt_log_dir.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 395</value>
-  </data>
-  <data name="&gt;&gt;cmb_secondarydisplaystyle.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_raterc.Items9" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>38</value>
-  </data>
-  <data name="label98.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_showairports.Text" xml:space="preserve">
-    <value>Show Airports</value>
-  </data>
-  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>44</value>
-  </data>
-  <data name="chk_displaytarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cmb_secondarydisplaystyle.TabIndex" type="System.Int32, mscorlib">
-    <value>129</value>
-  </data>
-  <data name="label92.Text" xml:space="preserve">
-    <value>Video Device</value>
-  </data>
-  <data name="CMB_ratestatus.Items" xml:space="preserve">
-    <value>-1</value>
-  </data>
-  <data name="CHK_GDIPlus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>220, 17</value>
-  </data>
-  <data name="CHK_params_bg.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_speecharmdisarm.Location" type="System.Drawing.Point, System.Drawing">
-    <value>760, 89</value>
-  </data>
-  <data name="CHK_resetapmonconnect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 277</value>
-  </data>
-  <data name="CHK_GDIPlus.TabIndex" type="System.Int32, mscorlib">
-    <value>85</value>
-  </data>
-  <data name="&gt;&gt;CMB_raterc.ZOrder" xml:space="preserve">
-    <value>59</value>
-  </data>
-  <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
-  </data>
-  <data name="&gt;&gt;label98.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_speechcustom.TabIndex" type="System.Int32, mscorlib">
-    <value>65</value>
-  </data>
-  <data name="&gt;&gt;label104.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_rateposition.Items10" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="chk_displaytooltip.Text" xml:space="preserve">
-    <value>Display ToolTip</value>
-  </data>
-  <data name="label108.TabIndex" type="System.Int32, mscorlib">
-    <value>45</value>
-  </data>
-  <data name="&gt;&gt;num_linelength.Name" xml:space="preserve">
-    <value>num_linelength</value>
-  </data>
-  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CHK_speechmode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
+    <value>535, 254</value>
   </data>
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
     <value>43, 13</value>
   </data>
-  <data name="chk_displaynavbearing.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label33.TabIndex" type="System.Int32, mscorlib">
+    <value>87</value>
   </data>
-  <data name="NUM_tracklength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 20</value>
+  <data name="label33.Text" xml:space="preserve">
+    <value>Sensor</value>
   </data>
-  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label92.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CMB_osdcolor.ZOrder" xml:space="preserve">
-    <value>79</value>
-  </data>
-  <data name="CMB_distunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="label101.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CMB_Layout.Name" xml:space="preserve">
-    <value>CMB_Layout</value>
-  </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
-    <value>96</value>
-  </data>
-  <data name="BUT_videostop.TabIndex" type="System.Int32, mscorlib">
-    <value>77</value>
-  </data>
-  <data name="&gt;&gt;CMB_theme.ZOrder" xml:space="preserve">
-    <value>33</value>
-  </data>
-  <data name="chk_tfr.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chk_displayheading.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechaltwarning.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_speechlowspeed.TabIndex" type="System.Int32, mscorlib">
-    <value>105</value>
-  </data>
-  <data name="label9.TabIndex" type="System.Int32, mscorlib">
-    <value>128</value>
-  </data>
-  <data name="CMB_rateattitude.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
-  </data>
-  <data name="&gt;&gt;label107.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_ratestatus.Items11" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="CHK_maprotation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 372</value>
-  </data>
-  <data name="CMB_videoresolutions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>408, 21</value>
-  </data>
-  <data name="chk_displayheading.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
-  </data>
-  <data name="&gt;&gt;CMB_videosources.Name" xml:space="preserve">
-    <value>CMB_videosources</value>
-  </data>
-  <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CHK_enablespeech.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CMB_raterc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
-  </data>
-  <data name="CHK_speechArmedOnly.Text" xml:space="preserve">
-    <value>Only when Armed</value>
-  </data>
-  <data name="&gt;&gt;CMB_severity.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_mavdebug.Name" xml:space="preserve">
-    <value>CHK_mavdebug</value>
-  </data>
-  <data name="&gt;&gt;label10.Name" xml:space="preserve">
-    <value>label10</value>
-  </data>
-  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
-  </data>
-  <data name="&gt;&gt;chk_ADSB.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;label96.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="BUT_videostop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_enablespeech.TabIndex" type="System.Int32, mscorlib">
-    <value>72</value>
-  </data>
-  <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
-  </data>
-  <data name="&gt;&gt;label92.Name" xml:space="preserve">
-    <value>label92</value>
+  <data name="&gt;&gt;label33.Name" xml:space="preserve">
+    <value>label33</value>
   </data>
   <data name="&gt;&gt;label33.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="CHK_speechwaypoint.Location" type="System.Drawing.Point, System.Drawing">
-    <value>332, 89</value>
-  </data>
-  <data name="chk_shownofly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
-  </data>
-  <data name="&gt;&gt;label94.Name" xml:space="preserve">
-    <value>label94</value>
-  </data>
-  <data name="&gt;&gt;CMB_theme.Parent" xml:space="preserve">
+  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;CHK_Password.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
+    <value>43</value>
   </data>
-  <data name="CMB_language.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 139</value>
+  <data name="CMB_ratesensors.Items" xml:space="preserve">
+    <value>-1</value>
   </data>
-  <data name="label92.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 11</value>
+  <data name="CMB_ratesensors.Items1" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="CMB_ratesensors.Items9" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="BUT_videostart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="&gt;&gt;label92.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label104.ZOrder" xml:space="preserve">
-    <value>60</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateposition.Name" xml:space="preserve">
-    <value>CMB_rateposition</value>
-  </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
+  <data name="CMB_ratesensors.Items2" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="CMB_ratesensors.Items3" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;CMB_videoresolutions.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_ratesensors.Items4" xml:space="preserve">
+    <value>3</value>
   </data>
-  <data name="CMB_raterc.Items" xml:space="preserve">
-    <value>-1</value>
+  <data name="CMB_ratesensors.Items5" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;BUT_Vario.Name" xml:space="preserve">
-    <value>BUT_Vario</value>
+  <data name="CMB_ratesensors.Items6" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;CMB_raterc.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_ratesensors.Items7" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="&gt;&gt;CHK_AutoParamCommit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CMB_ratesensors.Items8" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="&gt;&gt;label102.Name" xml:space="preserve">
-    <value>label102</value>
+  <data name="CMB_ratesensors.Items9" xml:space="preserve">
+    <value>8</value>
   </data>
-  <data name="CHK_mavdebug.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="CMB_ratesensors.Items10" xml:space="preserve">
+    <value>9</value>
   </data>
-  <data name="CHK_disttohomeflightdata.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="CMB_ratesensors.Items11" xml:space="preserve">
+    <value>10</value>
   </data>
-  <data name="chk_displayradius.Text" xml:space="preserve">
-    <value>Display Turn Radius</value>
+  <data name="CMB_ratesensors.Items12" xml:space="preserve">
+    <value>25</value>
   </data>
-  <data name="CMB_raterc.Items13" xml:space="preserve">
-    <value>35</value>
+  <data name="CMB_ratesensors.Items13" xml:space="preserve">
+    <value>50</value>
   </data>
-  <data name="BUT_logdirbrowse.Text" xml:space="preserve">
-    <value>Browse</value>
+  <data name="CMB_ratesensors.Items14" xml:space="preserve">
+    <value>100</value>
   </data>
-  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="CMB_ratesensors.Location" type="System.Drawing.Point, System.Drawing">
+    <value>584, 251</value>
   </data>
-  <data name="&gt;&gt;label97.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_ratesensors.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 21</value>
   </data>
-  <data name="CMB_osdcolor.TabIndex" type="System.Int32, mscorlib">
-    <value>69</value>
+  <data name="CMB_ratesensors.TabIndex" type="System.Int32, mscorlib">
+    <value>88</value>
   </data>
-  <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
-  </data>
-  <data name="label24.Text" xml:space="preserve">
-    <value>Waypoints</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateposition.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytooltip.Name" xml:space="preserve">
-    <value>chk_displaytooltip</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechbattery.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_params_bg.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 600</value>
-  </data>
-  <data name="label93.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;CMB_distunits.ZOrder" xml:space="preserve">
-    <value>71</value>
-  </data>
-  <data name="&gt;&gt;CHK_mavdebug.ZOrder" xml:space="preserve">
-    <value>57</value>
-  </data>
-  <data name="label96.Text" xml:space="preserve">
-    <value>Joystick</value>
-  </data>
-  <data name="&gt;&gt;CHK_speecharmdisarm.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label102.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;num_gcsid.Name" xml:space="preserve">
-    <value>num_gcsid</value>
-  </data>
-  <data name="&gt;&gt;chk_displayradius.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label94.TabIndex" type="System.Int32, mscorlib">
-    <value>68</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Dist to Home</value>
-  </data>
-  <data name="&gt;&gt;CMB_Layout.ZOrder" xml:space="preserve">
-    <value>14</value>
+  <data name="&gt;&gt;CMB_ratesensors.Name" xml:space="preserve">
+    <value>CMB_ratesensors</value>
   </data>
   <data name="&gt;&gt;CMB_ratesensors.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="CHK_hudshow.Text" xml:space="preserve">
-    <value>Enable HUD Overlay</value>
-  </data>
-  <data name="&gt;&gt;label98.Parent" xml:space="preserve">
+  <data name="&gt;&gt;CMB_ratesensors.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="CMB_raterc.Items8" xml:space="preserve">
-    <value>7</value>
+  <data name="&gt;&gt;CMB_ratesensors.ZOrder" xml:space="preserve">
+    <value>44</value>
   </data>
-  <data name="chk_norcreceiver.TabIndex" type="System.Int32, mscorlib">
-    <value>111</value>
+  <data name="label26.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;label92.ZOrder" xml:space="preserve">
+  <data name="label26.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label26.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 38</value>
+  </data>
+  <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 13</value>
+  </data>
+  <data name="label26.TabIndex" type="System.Int32, mscorlib">
+    <value>86</value>
+  </data>
+  <data name="label26.Text" xml:space="preserve">
+    <value>Video Format</value>
+  </data>
+  <data name="&gt;&gt;label26.Name" xml:space="preserve">
+    <value>label26</value>
+  </data>
+  <data name="&gt;&gt;label26.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
+    <value>45</value>
+  </data>
+  <data name="CMB_videoresolutions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 35</value>
+  </data>
+  <data name="CMB_videoresolutions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>408, 21</value>
+  </data>
+  <data name="CMB_videoresolutions.TabIndex" type="System.Int32, mscorlib">
+    <value>44</value>
+  </data>
+  <data name="&gt;&gt;CMB_videoresolutions.Name" xml:space="preserve">
+    <value>CMB_videoresolutions</value>
+  </data>
+  <data name="&gt;&gt;CMB_videoresolutions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_videoresolutions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_videoresolutions.ZOrder" xml:space="preserve">
+    <value>46</value>
+  </data>
+  <data name="label12.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 350</value>
+  </data>
+  <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>31, 13</value>
+  </data>
+  <data name="label12.TabIndex" type="System.Int32, mscorlib">
+    <value>84</value>
+  </data>
+  <data name="label12.Text" xml:space="preserve">
+    <value>HUD</value>
+  </data>
+  <data name="&gt;&gt;label12.Name" xml:space="preserve">
+    <value>label12</value>
+  </data>
+  <data name="&gt;&gt;label12.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
+    <value>48</value>
+  </data>
+  <data name="CHK_GDIPlus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_GDIPlus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 349</value>
+  </data>
+  <data name="CHK_GDIPlus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>220, 17</value>
+  </data>
+  <data name="CHK_GDIPlus.TabIndex" type="System.Int32, mscorlib">
     <value>85</value>
   </data>
-  <data name="&gt;&gt;CHK_speechmode.Parent" xml:space="preserve">
+  <data name="CHK_GDIPlus.Text" xml:space="preserve">
+    <value>GDI+ (old type/no HW acceleration)</value>
+  </data>
+  <data name="&gt;&gt;CHK_GDIPlus.Name" xml:space="preserve">
+    <value>CHK_GDIPlus</value>
+  </data>
+  <data name="&gt;&gt;CHK_GDIPlus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_GDIPlus.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
+  <data name="&gt;&gt;CHK_GDIPlus.ZOrder" xml:space="preserve">
+    <value>49</value>
   </data>
-  <data name="chk_displaytarget.Text" xml:space="preserve">
-    <value>Display Target</value>
+  <data name="label24.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label24.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 327</value>
+  </data>
+  <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 13</value>
+  </data>
+  <data name="label24.TabIndex" type="System.Int32, mscorlib">
+    <value>82</value>
+  </data>
+  <data name="label24.Text" xml:space="preserve">
+    <value>Waypoints</value>
+  </data>
+  <data name="&gt;&gt;label24.Name" xml:space="preserve">
+    <value>label24</value>
+  </data>
+  <data name="&gt;&gt;label24.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label24.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
+    <value>50</value>
+  </data>
+  <data name="CHK_loadwponconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_loadwponconnect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 326</value>
+  </data>
+  <data name="CHK_loadwponconnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 17</value>
+  </data>
+  <data name="CHK_loadwponconnect.TabIndex" type="System.Int32, mscorlib">
+    <value>83</value>
+  </data>
+  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
+    <value>Load Waypoints on connect?</value>
+  </data>
+  <data name="&gt;&gt;CHK_loadwponconnect.Name" xml:space="preserve">
+    <value>CHK_loadwponconnect</value>
+  </data>
+  <data name="&gt;&gt;CHK_loadwponconnect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_loadwponconnect.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_loadwponconnect.ZOrder" xml:space="preserve">
+    <value>51</value>
+  </data>
+  <data name="label23.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label23.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label23.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 301</value>
+  </data>
+  <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="label23.TabIndex" type="System.Int32, mscorlib">
+    <value>81</value>
+  </data>
+  <data name="label23.Text" xml:space="preserve">
+    <value>Track Length</value>
+  </data>
+  <data name="&gt;&gt;label23.Name" xml:space="preserve">
+    <value>label23</value>
+  </data>
+  <data name="&gt;&gt;label23.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
+    <value>52</value>
+  </data>
+  <data name="NUM_tracklength.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 300</value>
+  </data>
+  <data name="NUM_tracklength.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 20</value>
+  </data>
+  <data name="NUM_tracklength.TabIndex" type="System.Int32, mscorlib">
+    <value>80</value>
+  </data>
+  <data name="&gt;&gt;NUM_tracklength.Name" xml:space="preserve">
+    <value>NUM_tracklength</value>
+  </data>
+  <data name="&gt;&gt;NUM_tracklength.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NUM_tracklength.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;NUM_tracklength.ZOrder" xml:space="preserve">
+    <value>54</value>
+  </data>
+  <data name="CHK_speechaltwarning.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechaltwarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechaltwarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>671, 89</value>
+  </data>
+  <data name="CHK_speechaltwarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 17</value>
+  </data>
+  <data name="CHK_speechaltwarning.TabIndex" type="System.Int32, mscorlib">
+    <value>79</value>
+  </data>
+  <data name="CHK_speechaltwarning.Text" xml:space="preserve">
+    <value>Alt Warning</value>
+  </data>
+  <data name="CHK_speechaltwarning.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechaltwarning.Name" xml:space="preserve">
+    <value>CHK_speechaltwarning</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechaltwarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechaltwarning.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechaltwarning.ZOrder" xml:space="preserve">
+    <value>55</value>
+  </data>
+  <data name="label108.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label108.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label108.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 278</value>
+  </data>
+  <data name="label108.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 13</value>
+  </data>
+  <data name="label108.TabIndex" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="label108.Text" xml:space="preserve">
+    <value>Connect Reset</value>
+  </data>
+  <data name="&gt;&gt;label108.Name" xml:space="preserve">
+    <value>label108</value>
+  </data>
+  <data name="&gt;&gt;label108.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label108.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label108.ZOrder" xml:space="preserve">
+    <value>56</value>
+  </data>
+  <data name="CHK_resetapmonconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_resetapmonconnect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 277</value>
+  </data>
+  <data name="CHK_resetapmonconnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>217, 17</value>
+  </data>
+  <data name="CHK_resetapmonconnect.TabIndex" type="System.Int32, mscorlib">
+    <value>46</value>
+  </data>
+  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
+    <value>Reset on USB Connect (toggle DTR)</value>
+  </data>
+  <data name="&gt;&gt;CHK_resetapmonconnect.Name" xml:space="preserve">
+    <value>CHK_resetapmonconnect</value>
+  </data>
+  <data name="&gt;&gt;CHK_resetapmonconnect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_resetapmonconnect.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_resetapmonconnect.ZOrder" xml:space="preserve">
+    <value>57</value>
+  </data>
+  <data name="CHK_mavdebug.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="CHK_mavdebug.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
+    <value>106, 623</value>
+  </data>
+  <data name="CHK_mavdebug.Size" type="System.Drawing.Size, System.Drawing">
+    <value>155, 17</value>
+  </data>
+  <data name="CHK_mavdebug.TabIndex" type="System.Int32, mscorlib">
+    <value>47</value>
+  </data>
+  <data name="CHK_mavdebug.Text" xml:space="preserve">
+    <value>Mavlink Message Debug</value>
+  </data>
+  <data name="&gt;&gt;CHK_mavdebug.Name" xml:space="preserve">
+    <value>CHK_mavdebug</value>
+  </data>
+  <data name="&gt;&gt;CHK_mavdebug.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_mavdebug.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_mavdebug.ZOrder" xml:space="preserve">
+    <value>58</value>
+  </data>
+  <data name="label107.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label107.Location" type="System.Drawing.Point, System.Drawing">
+    <value>461, 254</value>
+  </data>
+  <data name="label107.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 13</value>
+  </data>
+  <data name="label107.TabIndex" type="System.Int32, mscorlib">
+    <value>48</value>
+  </data>
+  <data name="label107.Text" xml:space="preserve">
+    <value>RC</value>
+  </data>
+  <data name="&gt;&gt;label107.Name" xml:space="preserve">
+    <value>label107</value>
+  </data>
+  <data name="&gt;&gt;label107.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label107.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label107.ZOrder" xml:space="preserve">
+    <value>59</value>
+  </data>
+  <data name="CMB_raterc.Items" xml:space="preserve">
+    <value>-1</value>
   </data>
   <data name="CMB_raterc.Items1" xml:space="preserve">
     <value>0</value>
@@ -1311,530 +597,239 @@
   <data name="CMB_raterc.Items6" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
+  <data name="CMB_raterc.Items7" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="label12.Text" xml:space="preserve">
-    <value>HUD</value>
-  </data>
-  <data name="BUT_themecustom.TabIndex" type="System.Int32, mscorlib">
-    <value>98</value>
-  </data>
-  <data name="&gt;&gt;CHK_showairports.Name" xml:space="preserve">
-    <value>CHK_showairports</value>
-  </data>
-  <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 17</value>
-  </data>
-  <data name="&gt;&gt;CHK_hudshow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label98.ZOrder" xml:space="preserve">
-    <value>68</value>
-  </data>
-  <data name="CMB_rateattitude.Items13" xml:space="preserve">
-    <value>100</value>
-  </data>
-  <data name="&gt;&gt;cmb_secondarydisplaystyle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CMB_speedunits.ZOrder" xml:space="preserve">
-    <value>70</value>
-  </data>
-  <data name="label24.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CMB_theme.Name" xml:space="preserve">
-    <value>CMB_theme</value>
-  </data>
-  <data name="CMB_rateposition.Items14" xml:space="preserve">
-    <value>100</value>
-  </data>
-  <data name="CMB_ratesensors.Items" xml:space="preserve">
-    <value>-1</value>
-  </data>
-  <data name="&gt;&gt;BUT_Joystick.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;chk_shownofly.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label24.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label108.Text" xml:space="preserve">
-    <value>Connect Reset</value>
-  </data>
-  <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 17</value>
-  </data>
-  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chk_slowMachine.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_altunits.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_slowMachine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 600</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="chk_displaytarget.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_enablespeech.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+  <data name="CMB_raterc.Items8" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;chk_displayheading.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_raterc.Items9" xml:space="preserve">
+    <value>8</value>
   </data>
-  <data name="chk_displaytarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>563, 501</value>
-  </data>
-  <data name="&gt;&gt;CHK_enablespeech.ZOrder" xml:space="preserve">
-    <value>83</value>
-  </data>
-  <data name="&gt;&gt;chk_displayheading.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateposition.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_raterc.Items12" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;CHK_params_bg.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CMB_ratesensors.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_speedunits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="chk_analytics.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;chk_tfr.Name" xml:space="preserve">
-    <value>chk_tfr</value>
-  </data>
-  <data name="CHK_beta.TabIndex" type="System.Int32, mscorlib">
-    <value>103</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytarget.Name" xml:space="preserve">
-    <value>chk_displaytarget</value>
-  </data>
-  <data name="CHK_speechcustom.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label102.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 254</value>
-  </data>
-  <data name="&gt;&gt;chk_displaynavbearing.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_distunits.Name" xml:space="preserve">
-    <value>CMB_distunits</value>
-  </data>
-  <data name="CHK_Password.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_tfr.TabIndex" type="System.Int32, mscorlib">
-    <value>109</value>
-  </data>
-  <data name="&gt;&gt;label104.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chk_shownofly.TabIndex" type="System.Int32, mscorlib">
-    <value>117</value>
-  </data>
-  <data name="&gt;&gt;label99.Name" xml:space="preserve">
-    <value>label99</value>
-  </data>
-  <data name="label107.TabIndex" type="System.Int32, mscorlib">
-    <value>48</value>
-  </data>
-  <data name="&gt;&gt;CMB_distunits.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
-    <value>115, 17</value>
-  </data>
-  <data name="&gt;&gt;CHK_resetapmonconnect.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label108.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label96.TabIndex" type="System.Int32, mscorlib">
-    <value>62</value>
-  </data>
-  <data name="&gt;&gt;txt_log_dir.ZOrder" xml:space="preserve">
-    <value>36</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechcustom.ZOrder" xml:space="preserve">
-    <value>75</value>
-  </data>
-  <data name="chk_displaycog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 17</value>
-  </data>
-  <data name="label104.TabIndex" type="System.Int32, mscorlib">
-    <value>50</value>
-  </data>
-  <data name="chk_shownofly.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label102.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label93.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CMB_videosources.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 21</value>
-  </data>
-  <data name="&gt;&gt;CHK_GDIPlus.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label103.ZOrder" xml:space="preserve">
-    <value>61</value>
-  </data>
-  <data name="&gt;&gt;NUM_tracklength.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechlowspeed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label95.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 90</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_ratesensors.Items5" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
-    <value>535, 254</value>
-  </data>
-  <data name="CHK_speechmode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>408, 89</value>
-  </data>
-  <data name="&gt;&gt;chk_norcreceiver.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="BUT_videostart.Text" xml:space="preserve">
-    <value>Start</value>
-  </data>
-  <data name="&gt;&gt;CMB_osdcolor.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;CHK_hudshow.Name" xml:space="preserve">
-    <value>CHK_hudshow</value>
-  </data>
-  <data name="&gt;&gt;BUT_logdirbrowse.Name" xml:space="preserve">
-    <value>BUT_logdirbrowse</value>
-  </data>
-  <data name="&gt;&gt;CHK_Password.ZOrder" xml:space="preserve">
-    <value>27</value>
+  <data name="CMB_raterc.Items10" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="CMB_raterc.Items11" xml:space="preserve">
     <value>10</value>
   </data>
-  <data name="&gt;&gt;BUT_videostop.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_raterc.Items12" xml:space="preserve">
+    <value>25</value>
   </data>
-  <data name="CMB_ratestatus.Items5" xml:space="preserve">
-    <value>4</value>
+  <data name="CMB_raterc.Items13" xml:space="preserve">
+    <value>35</value>
   </data>
-  <data name="&gt;&gt;CHK_beta.Name" xml:space="preserve">
-    <value>CHK_beta</value>
+  <data name="CMB_raterc.Items14" xml:space="preserve">
+    <value>50</value>
   </data>
-  <data name="CHK_mavdebug.TabIndex" type="System.Int32, mscorlib">
-    <value>47</value>
+  <data name="CMB_raterc.Location" type="System.Drawing.Point, System.Drawing">
+    <value>489, 251</value>
   </data>
-  <data name="label23.Text" xml:space="preserve">
-    <value>Track Length</value>
+  <data name="CMB_raterc.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 21</value>
   </data>
-  <data name="CHK_loadwponconnect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="CMB_raterc.TabIndex" type="System.Int32, mscorlib">
+    <value>49</value>
   </data>
-  <data name="&gt;&gt;chk_displaycog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;CMB_raterc.Name" xml:space="preserve">
+    <value>CMB_raterc</value>
   </data>
-  <data name="chk_displayheading.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label9.Text" xml:space="preserve">
-    <value>Inactive Aircraft</value>
-  </data>
-  <data name="CMB_rateattitude.Items2" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label92.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label8.TabIndex" type="System.Int32, mscorlib">
-    <value>126</value>
-  </data>
-  <data name="CHK_speecharmdisarm.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateattitude.ZOrder" xml:space="preserve">
-    <value>66</value>
-  </data>
-  <data name="label92.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;BUT_videostart.ZOrder" xml:space="preserve">
-    <value>89</value>
-  </data>
-  <data name="&gt;&gt;CHK_maprotation.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_ADSB.Text" xml:space="preserve">
-    <value>ADSB</value>
-  </data>
-  <data name="label101.TabIndex" type="System.Int32, mscorlib">
-    <value>53</value>
-  </data>
-  <data name="BUT_videostart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_mavdebug.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 623</value>
-  </data>
-  <data name="CMB_rateposition.Items11" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="CHK_speechArmedOnly.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 451</value>
-  </data>
-  <data name="&gt;&gt;CMB_ratesensors.ZOrder" xml:space="preserve">
-    <value>43</value>
-  </data>
-  <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
-  </data>
-  <data name="CHK_speechArmedOnly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
-  </data>
-  <data name="&gt;&gt;chk_temp.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;CHK_showairports.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
-  </data>
-  <data name="CHK_speechaltwarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_resetapmonconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>217, 17</value>
-  </data>
-  <data name="&gt;&gt;CMB_videoresolutions.Type" xml:space="preserve">
+  <data name="&gt;&gt;CMB_raterc.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chk_displayradius.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
-  </data>
-  <data name="CMB_severity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="&gt;&gt;CMB_speedunits.Parent" xml:space="preserve">
+  <data name="&gt;&gt;CMB_raterc.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="label98.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 225</value>
+  <data name="&gt;&gt;CMB_raterc.ZOrder" xml:space="preserve">
+    <value>60</value>
   </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>89</value>
-  </data>
-  <data name="chk_displaynavbearing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 501</value>
-  </data>
-  <data name="BUT_Vario.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="label104.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="CHK_speechbattery.TabIndex" type="System.Int32, mscorlib">
-    <value>64</value>
+  <data name="label104.Location" type="System.Drawing.Point, System.Drawing">
+    <value>330, 254</value>
   </data>
-  <data name="CHK_speechbattery.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="label104.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
   </data>
-  <data name="CHK_maprotation.Text" xml:space="preserve">
-    <value>Map is rotated to follow the plane</value>
+  <data name="label104.TabIndex" type="System.Int32, mscorlib">
+    <value>50</value>
   </data>
-  <data name="&gt;&gt;num_linelength.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="label104.Text" xml:space="preserve">
+    <value>Mode/Status</value>
   </data>
-  <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 17</value>
+  <data name="&gt;&gt;label104.Name" xml:space="preserve">
+    <value>label104</value>
   </data>
-  <data name="&gt;&gt;chk_displaycog.Name" xml:space="preserve">
-    <value>chk_displaycog</value>
+  <data name="&gt;&gt;label104.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="BUT_Vario.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 20</value>
+  <data name="&gt;&gt;label104.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="chk_ADSB.TabIndex" type="System.Int32, mscorlib">
-    <value>108</value>
-  </data>
-  <data name="chk_displaytooltip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
-  </data>
-  <data name="CMB_ratestatus.Items4" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label95.Name" xml:space="preserve">
-    <value>label95</value>
-  </data>
-  <data name="label10.Text" xml:space="preserve">
-    <value>Aircraft Icon</value>
-  </data>
-  <data name="CHK_loadwponconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 17</value>
-  </data>
-  <data name="label97.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chk_displaynavbearing.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 350</value>
-  </data>
-  <data name="CHK_speechArmedOnly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;CMB_speedunits.Name" xml:space="preserve">
-    <value>CMB_speedunits</value>
-  </data>
-  <data name="CHK_mavdebug.Text" xml:space="preserve">
-    <value>Mavlink Message Debug</value>
-  </data>
-  <data name="CHK_beta.Text" xml:space="preserve">
-    <value>Beta Updates</value>
-  </data>
-  <data name="label10.TabIndex" type="System.Int32, mscorlib">
-    <value>130</value>
-  </data>
-  <data name="chk_displayheading.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label95.Text" xml:space="preserve">
-    <value>Speech</value>
+  <data name="&gt;&gt;label104.ZOrder" xml:space="preserve">
+    <value>61</value>
   </data>
   <data name="label103.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label23.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 301</value>
+  <data name="label103.Location" type="System.Drawing.Point, System.Drawing">
+    <value>220, 254</value>
   </data>
-  <data name="BUT_themecustom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="label103.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 13</value>
   </data>
-  <data name="&gt;&gt;label101.ZOrder" xml:space="preserve">
-    <value>63</value>
+  <data name="label103.TabIndex" type="System.Int32, mscorlib">
+    <value>51</value>
   </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+  <data name="label103.Text" xml:space="preserve">
+    <value>Position</value>
+  </data>
+  <data name="&gt;&gt;label103.Name" xml:space="preserve">
+    <value>label103</value>
+  </data>
+  <data name="&gt;&gt;label103.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chk_temp.Text" xml:space="preserve">
-    <value>Testing Screen</value>
+  <data name="&gt;&gt;label103.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="&gt;&gt;CMB_videoresolutions.Name" xml:space="preserve">
-    <value>CMB_videoresolutions</value>
+  <data name="&gt;&gt;label103.ZOrder" xml:space="preserve">
+    <value>62</value>
   </data>
-  <data name="label12.TabIndex" type="System.Int32, mscorlib">
-    <value>84</value>
+  <data name="label102.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="chk_norcreceiver.Text" xml:space="preserve">
-    <value>No RC Receiver</value>
+  <data name="label102.Location" type="System.Drawing.Point, System.Drawing">
+    <value>104, 254</value>
+  </data>
+  <data name="label102.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 13</value>
+  </data>
+  <data name="label102.TabIndex" type="System.Int32, mscorlib">
+    <value>52</value>
+  </data>
+  <data name="label102.Text" xml:space="preserve">
+    <value>Attitude</value>
+  </data>
+  <data name="&gt;&gt;label102.Name" xml:space="preserve">
+    <value>label102</value>
+  </data>
+  <data name="&gt;&gt;label102.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label102.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label102.ZOrder" xml:space="preserve">
+    <value>63</value>
+  </data>
+  <data name="label101.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label101.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label101.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 254</value>
+  </data>
+  <data name="label101.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 13</value>
+  </data>
+  <data name="label101.TabIndex" type="System.Int32, mscorlib">
+    <value>53</value>
+  </data>
+  <data name="label101.Text" xml:space="preserve">
+    <value>Telemetry Rates</value>
+  </data>
+  <data name="&gt;&gt;label101.Name" xml:space="preserve">
+    <value>label101</value>
+  </data>
+  <data name="&gt;&gt;label101.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label101.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label101.ZOrder" xml:space="preserve">
+    <value>64</value>
+  </data>
+  <data name="CMB_ratestatus.Items" xml:space="preserve">
+    <value>-1</value>
+  </data>
+  <data name="CMB_ratestatus.Items1" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CMB_ratestatus.Items2" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CMB_ratestatus.Items3" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="CMB_ratestatus.Items4" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="CMB_ratestatus.Items5" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="CMB_ratestatus.Items6" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="CMB_ratestatus.Items7" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="CMB_ratestatus.Items8" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="CMB_ratestatus.Items9" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="CMB_ratestatus.Items10" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="CMB_ratestatus.Items11" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="CMB_ratestatus.Items12" xml:space="preserve">
+    <value>25</value>
   </data>
   <data name="CMB_ratestatus.Items13" xml:space="preserve">
     <value>35</value>
   </data>
-  <data name="&gt;&gt;CHK_speecharmdisarm.ZOrder" xml:space="preserve">
-    <value>31</value>
-  </data>
-  <data name="label97.TabIndex" type="System.Int32, mscorlib">
-    <value>59</value>
-  </data>
-  <data name="label11.Text" xml:space="preserve">
-    <value>Line Length</value>
-  </data>
-  <data name="&gt;&gt;label102.ZOrder" xml:space="preserve">
-    <value>62</value>
-  </data>
-  <data name="&gt;&gt;chk_analytics.ZOrder" xml:space="preserve">
-    <value>29</value>
-  </data>
-  <data name="&gt;&gt;BUT_themecustom.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechbattery.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>93</value>
+  <data name="CMB_ratestatus.Items14" xml:space="preserve">
+    <value>50</value>
   </data>
   <data name="CMB_ratestatus.Location" type="System.Drawing.Point, System.Drawing">
     <value>415, 251</value>
   </data>
-  <data name="label96.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="CMB_ratestatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 21</value>
   </data>
-  <data name="BUT_videostart.TabIndex" type="System.Int32, mscorlib">
-    <value>78</value>
+  <data name="CMB_ratestatus.TabIndex" type="System.Int32, mscorlib">
+    <value>54</value>
   </data>
-  <data name="CHK_speechmode.Text" xml:space="preserve">
-    <value>Mode </value>
+  <data name="&gt;&gt;CMB_ratestatus.Name" xml:space="preserve">
+    <value>CMB_ratestatus</value>
   </data>
-  <data name="CMB_rateposition.Items2" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;CMB_ratestatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="CHK_speechwaypoint.Text" xml:space="preserve">
-    <value>Waypoint</value>
+  <data name="&gt;&gt;CMB_ratestatus.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="CHK_speechlowspeed.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;CMB_ratestatus.ZOrder" xml:space="preserve">
+    <value>65</value>
+  </data>
+  <data name="CMB_rateposition.Items" xml:space="preserve">
+    <value>-1</value>
   </data>
   <data name="CMB_rateposition.Items1" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="CMB_rateposition.Items6" xml:space="preserve">
-    <value>5</value>
+  <data name="CMB_rateposition.Items2" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="CMB_rateposition.Items7" xml:space="preserve">
-    <value>6</value>
+  <data name="CMB_rateposition.Items3" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="CMB_rateposition.Items4" xml:space="preserve">
     <value>3</value>
@@ -1842,11 +837,11 @@
   <data name="CMB_rateposition.Items5" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>Layout</value>
+  <data name="CMB_rateposition.Items6" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="CHK_speechwaypoint.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="CMB_rateposition.Items7" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="CMB_rateposition.Items8" xml:space="preserve">
     <value>7</value>
@@ -1854,1067 +849,2099 @@
   <data name="CMB_rateposition.Items9" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="chk_displaycog.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
+  <data name="CMB_rateposition.Items10" xml:space="preserve">
+    <value>9</value>
   </data>
-  <data name="NUM_tracklength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 300</value>
+  <data name="CMB_rateposition.Items11" xml:space="preserve">
+    <value>10</value>
   </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="CMB_severity.TabIndex" type="System.Int32, mscorlib">
-    <value>125</value>
-  </data>
-  <data name="CMB_ratesensors.Items7" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="chk_slowMachine.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
-  </data>
-  <data name="&gt;&gt;label107.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
-  </data>
-  <data name="CMB_ratesensors.Items1" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;CMB_severity.ZOrder" xml:space="preserve">
-    <value>80</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechmode.ZOrder" xml:space="preserve">
-    <value>76</value>
-  </data>
-  <data name="&gt;&gt;BUT_Joystick.Name" xml:space="preserve">
-    <value>BUT_Joystick</value>
-  </data>
-  <data name="label92.TabIndex" type="System.Int32, mscorlib">
-    <value>74</value>
-  </data>
-  <data name="CMB_videosources.TabIndex" type="System.Int32, mscorlib">
-    <value>75</value>
-  </data>
-  <data name="&gt;&gt;chk_displaytarget.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_params_bg.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_speechaltwarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_hudshow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>133, 18</value>
-  </data>
-  <data name="label98.TabIndex" type="System.Int32, mscorlib">
-    <value>58</value>
-  </data>
-  <data name="chk_norcreceiver.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 577</value>
-  </data>
-  <data name="CMB_ratesensors.Items8" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label11.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_speechbattery.Text" xml:space="preserve">
-    <value>Battery Warning</value>
-  </data>
-  <data name="CMB_Layout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="&gt;&gt;CMB_ratesensors.Name" xml:space="preserve">
-    <value>CMB_ratesensors</value>
-  </data>
-  <data name="txt_log_dir.TabIndex" type="System.Int32, mscorlib">
-    <value>94</value>
-  </data>
-  <data name="label23.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CMB_ratestatus.Items9" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="CMB_ratestatus.Items8" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;CHK_loadwponconnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chk_displayheading.Name" xml:space="preserve">
-    <value>chk_displayheading</value>
-  </data>
-  <data name="label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CMB_rateposition.Items" xml:space="preserve">
-    <value>-1</value>
-  </data>
-  <data name="CMB_ratestatus.Items7" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="CMB_ratestatus.Items6" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CMB_ratestatus.Items1" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CHK_speechmode.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CMB_ratestatus.Items3" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="CMB_ratestatus.Items2" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;label94.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label107.Text" xml:space="preserve">
-    <value>RC</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_displaytooltip.TabIndex" type="System.Int32, mscorlib">
-    <value>104</value>
-  </data>
-  <data name="CMB_rateposition.Location" type="System.Drawing.Point, System.Drawing">
-    <value>282, 251</value>
+  <data name="CMB_rateposition.Items12" xml:space="preserve">
+    <value>20</value>
   </data>
   <data name="CMB_rateposition.Items13" xml:space="preserve">
     <value>50</value>
   </data>
-  <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 13</value>
-  </data>
-  <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
-  </data>
-  <data name="&gt;&gt;chk_shownofly.Name" xml:space="preserve">
-    <value>chk_shownofly</value>
-  </data>
-  <data name="label104.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 13</value>
-  </data>
-  <data name="CMB_language.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="BUT_Vario.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 551</value>
-  </data>
-  <data name="num_linelength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 20</value>
-  </data>
-  <data name="CHK_speechArmedOnly.TabIndex" type="System.Int32, mscorlib">
-    <value>124</value>
-  </data>
-  <data name="&gt;&gt;chk_displayradius.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
-  </data>
-  <data name="CMB_rateattitude.Location" type="System.Drawing.Point, System.Drawing">
-    <value>166, 251</value>
-  </data>
-  <data name="label102.TabIndex" type="System.Int32, mscorlib">
-    <value>52</value>
-  </data>
-  <data name="CHK_beta.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 577</value>
-  </data>
-  <data name="&gt;&gt;BUT_Joystick.ZOrder" xml:space="preserve">
-    <value>87</value>
-  </data>
-  <data name="&gt;&gt;CHK_speecharmdisarm.Name" xml:space="preserve">
-    <value>CHK_speecharmdisarm</value>
-  </data>
-  <data name="&gt;&gt;chk_temp.Name" xml:space="preserve">
-    <value>chk_temp</value>
-  </data>
-  <data name="CHK_speechaltwarning.TabIndex" type="System.Int32, mscorlib">
-    <value>79</value>
-  </data>
-  <data name="num_gcsid.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 475</value>
-  </data>
-  <data name="BUT_logdirbrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 393</value>
-  </data>
-  <data name="label10.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechwaypoint.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CMB_ratesensors.Items14" xml:space="preserve">
+  <data name="CMB_rateposition.Items14" xml:space="preserve">
     <value>100</value>
   </data>
-  <data name="&gt;&gt;chk_ADSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CMB_rateposition.Location" type="System.Drawing.Point, System.Drawing">
+    <value>282, 251</value>
   </data>
-  <data name="&gt;&gt;CMB_severity.Name" xml:space="preserve">
-    <value>CMB_severity</value>
-  </data>
-  <data name="chk_displaynavbearing.Text" xml:space="preserve">
-    <value>Display Nav Bearing</value>
-  </data>
-  <data name="label104.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_displaytooltip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>663, 501</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_analytics.TabIndex" type="System.Int32, mscorlib">
-    <value>102</value>
-  </data>
-  <data name="label11.TabIndex" type="System.Int32, mscorlib">
-    <value>84</value>
-  </data>
-  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>42</value>
-  </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="label33.Text" xml:space="preserve">
-    <value>Sensor</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechaltwarning.Name" xml:space="preserve">
-    <value>CHK_speechaltwarning</value>
-  </data>
-  <data name="CMB_rateattitude.Items11" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="CMB_raterc.TabIndex" type="System.Int32, mscorlib">
-    <value>49</value>
-  </data>
-  <data name="CHK_hudshow.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label102.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_tfr.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;txt_log_dir.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_hudshow.ZOrder" xml:space="preserve">
-    <value>84</value>
-  </data>
-  <data name="cmb_secondarydisplaystyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="&gt;&gt;CMB_Layout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_AutoParamCommit.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_speechmode.TabIndex" type="System.Int32, mscorlib">
-    <value>66</value>
-  </data>
-  <data name="label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;chk_displaynavbearing.Name" xml:space="preserve">
-    <value>chk_displaynavbearing</value>
-  </data>
-  <data name="&gt;&gt;BUT_logdirbrowse.ZOrder" xml:space="preserve">
-    <value>35</value>
-  </data>
-  <data name="&gt;&gt;CMB_videosources.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_speechcustom.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
-  </data>
-  <data name="&gt;&gt;chk_ADSB.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_displaycog.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_mavdebug.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 17</value>
-  </data>
-  <data name="&gt;&gt;CHK_showairports.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_params_bg.Text" xml:space="preserve">
-    <value>Params Download in BackGround</value>
-  </data>
-  <data name="&gt;&gt;CMB_altunits.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>40</value>
-  </data>
-  <data name="&gt;&gt;chk_displayradius.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="CHK_params_bg.TabIndex" type="System.Int32, mscorlib">
-    <value>122</value>
-  </data>
-  <data name="&gt;&gt;chk_temp.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_disttohomeflightdata.ZOrder" xml:space="preserve">
-    <value>39</value>
-  </data>
-  <data name="&gt;&gt;BUT_videostop.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechcustom.Name" xml:space="preserve">
-    <value>CHK_speechcustom</value>
-  </data>
-  <data name="label24.TabIndex" type="System.Int32, mscorlib">
-    <value>82</value>
-  </data>
-  <data name="chk_displayheading.Location" type="System.Drawing.Point, System.Drawing">
-    <value>199, 501</value>
-  </data>
-  <data name="CMB_theme.TabIndex" type="System.Int32, mscorlib">
-    <value>97</value>
-  </data>
-  <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_norcreceiver.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;cmb_secondarydisplaystyle.Name" xml:space="preserve">
-    <value>cmb_secondarydisplaystyle</value>
-  </data>
-  <data name="&gt;&gt;chk_norcreceiver.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="label96.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_speechcustom.Text" xml:space="preserve">
-    <value>30s Interval</value>
-  </data>
-  <data name="CHK_resetapmonconnect.TabIndex" type="System.Int32, mscorlib">
-    <value>46</value>
-  </data>
-  <data name="CHK_AutoParamCommit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>598, 578</value>
-  </data>
-  <data name="chk_ADSB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
-  </data>
-  <data name="&gt;&gt;chk_shownofly.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;CHK_loadwponconnect.Name" xml:space="preserve">
-    <value>CHK_loadwponconnect</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>Theme</value>
-  </data>
-  <data name="label93.TabIndex" type="System.Int32, mscorlib">
-    <value>71</value>
-  </data>
-  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CHK_beta.ZOrder" xml:space="preserve">
-    <value>28</value>
-  </data>
-  <data name="CMB_altunits.TabIndex" type="System.Int32, mscorlib">
-    <value>119</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechmode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label6.TabIndex" type="System.Int32, mscorlib">
-    <value>118</value>
-  </data>
-  <data name="&gt;&gt;chk_slowMachine.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>252, 108</value>
-  </data>
-  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="BUT_Vario.Text" xml:space="preserve">
-    <value>Start/Stop Vario</value>
-  </data>
-  <data name="label99.TabIndex" type="System.Int32, mscorlib">
-    <value>57</value>
-  </data>
-  <data name="&gt;&gt;label108.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;num_linelength.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_speechcustom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;chk_ADSB.Name" xml:space="preserve">
-    <value>chk_ADSB</value>
-  </data>
-  <data name="&gt;&gt;CMB_osdcolor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="num_gcsid.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 20</value>
-  </data>
-  <data name="CMB_rateattitude.TabIndex" type="System.Int32, mscorlib">
-    <value>56</value>
-  </data>
-  <data name="CMB_ratesensors.Items11" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="label93.Text" xml:space="preserve">
-    <value>UI Language</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechcustom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_loadwponconnect.Text" xml:space="preserve">
-    <value>Load Waypoints on connect?</value>
-  </data>
-  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 198</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chk_displaynavbearing.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="chk_slowMachine.TabIndex" type="System.Int32, mscorlib">
-    <value>123</value>
-  </data>
-  <data name="&gt;&gt;CHK_mavdebug.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label98.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CMB_language.TabIndex" type="System.Int32, mscorlib">
-    <value>70</value>
-  </data>
-  <data name="chk_ADSB.Location" type="System.Drawing.Point, System.Drawing">
-    <value>598, 554</value>
-  </data>
-  <data name="chk_displaynavbearing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
-  </data>
-  <data name="CMB_rateattitude.Items12" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="&gt;&gt;CHK_Password.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label108.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 278</value>
-  </data>
-  <data name="&gt;&gt;CMB_altunits.Name" xml:space="preserve">
-    <value>CMB_altunits</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>GCS ID</value>
-  </data>
-  <data name="CMB_osdcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="&gt;&gt;CMB_speedunits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label33.Name" xml:space="preserve">
-    <value>label33</value>
-  </data>
-  <data name="&gt;&gt;label97.ZOrder" xml:space="preserve">
-    <value>69</value>
-  </data>
-  <data name="CHK_maprotation.TabIndex" type="System.Int32, mscorlib">
-    <value>90</value>
-  </data>
-  <data name="CMB_severity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 111</value>
-  </data>
-  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>91</value>
-  </data>
-  <data name="CHK_speechlowspeed.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;chk_analytics.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="BUT_videostart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>358, 6</value>
-  </data>
-  <data name="chk_tfr.Text" xml:space="preserve">
-    <value>TFR's</value>
-  </data>
-  <data name="label26.TabIndex" type="System.Int32, mscorlib">
-    <value>86</value>
-  </data>
-  <data name="CMB_ratesensors.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="CMB_rateposition.Size" type="System.Drawing.Size, System.Drawing">
     <value>40, 21</value>
   </data>
-  <data name="label94.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 65</value>
+  <data name="CMB_rateposition.TabIndex" type="System.Int32, mscorlib">
+    <value>55</value>
   </data>
-  <data name="&gt;&gt;label93.Parent" xml:space="preserve">
+  <data name="&gt;&gt;CMB_rateposition.Name" xml:space="preserve">
+    <value>CMB_rateposition</value>
+  </data>
+  <data name="&gt;&gt;CMB_rateposition.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_rateposition.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;label108.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;CMB_rateposition.ZOrder" xml:space="preserve">
+    <value>66</value>
   </data>
-  <data name="CHK_speechwaypoint.TabIndex" type="System.Int32, mscorlib">
-    <value>67</value>
+  <data name="CMB_rateattitude.Items" xml:space="preserve">
+    <value>-1</value>
   </data>
-  <data name="&gt;&gt;CHK_AutoParamCommit.ZOrder" xml:space="preserve">
-    <value>12</value>
+  <data name="CMB_rateattitude.Items1" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="BUT_videostop.Text" xml:space="preserve">
-    <value>Stop</value>
-  </data>
-  <data name="CHK_speechArmedOnly.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;chk_displayradius.Name" xml:space="preserve">
-    <value>chk_displayradius</value>
-  </data>
-  <data name="&gt;&gt;CHK_resetapmonconnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_norcreceiver.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chk_displaytooltip.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_tfr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 17</value>
-  </data>
-  <data name="&gt;&gt;chk_analytics.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CHK_resetapmonconnect.Text" xml:space="preserve">
-    <value>Reset on USB Connect (toggle DTR)</value>
-  </data>
-  <data name="CMB_altunits.Location" type="System.Drawing.Point, System.Drawing">
-    <value>320, 195</value>
-  </data>
-  <data name="&gt;&gt;txt_log_dir.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CMB_ratestatus.Items14" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="label101.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 13</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechArmedOnly.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label97.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechwaypoint.Name" xml:space="preserve">
-    <value>CHK_speechwaypoint</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_Password.Text" xml:space="preserve">
-    <value>Password Protect Config</value>
-  </data>
-  <data name="&gt;&gt;CHK_params_bg.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;CMB_videoresolutions.ZOrder" xml:space="preserve">
-    <value>45</value>
-  </data>
-  <data name="&gt;&gt;label98.Name" xml:space="preserve">
-    <value>label98</value>
-  </data>
-  <data name="&gt;&gt;txt_log_dir.Name" xml:space="preserve">
-    <value>txt_log_dir</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
-  </data>
-  <data name="label107.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chk_displaynavbearing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 17</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>180, 303</value>
-  </data>
-  <data name="&gt;&gt;NUM_tracklength.Name" xml:space="preserve">
-    <value>NUM_tracklength</value>
-  </data>
-  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
-    <value>Display in Flightdata</value>
-  </data>
-  <data name="&gt;&gt;CHK_enablespeech.Name" xml:space="preserve">
-    <value>CHK_enablespeech</value>
-  </data>
-  <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>121</value>
-  </data>
-  <data name="CHK_showairports.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chk_displayheading.Text" xml:space="preserve">
-    <value>Display Heading</value>
-  </data>
-  <data name="label103.Text" xml:space="preserve">
-    <value>Position</value>
-  </data>
-  <data name="&gt;&gt;label97.Name" xml:space="preserve">
-    <value>label97</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CHK_AutoParamCommit.Name" xml:space="preserve">
-    <value>CHK_AutoParamCommit</value>
-  </data>
-  <data name="NUM_tracklength.TabIndex" type="System.Int32, mscorlib">
-    <value>80</value>
-  </data>
-  <data name="CMB_videosources.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 8</value>
-  </data>
-  <data name="CMB_ratesensors.Items6" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CHK_beta.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chk_analytics.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 577</value>
-  </data>
-  <data name="label101.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 254</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;CMB_rateattitude.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;num_gcsid.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;NUM_tracklength.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_speechlowspeed.Location" type="System.Drawing.Point, System.Drawing">
-    <value>853, 89</value>
-  </data>
-  <data name="&gt;&gt;label103.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
-    <value>Arm/Disarm</value>
-  </data>
-  <data name="label97.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 198</value>
-  </data>
-  <data name="label23.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CHK_resetapmonconnect.ZOrder" xml:space="preserve">
-    <value>56</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechmode.Name" xml:space="preserve">
-    <value>CHK_speechmode</value>
-  </data>
-  <data name="CMB_rateattitude.Items9" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="CMB_rateattitude.Items8" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="CMB_rateattitude.Items7" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="CMB_rateattitude.Items6" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CMB_rateattitude.Items5" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="CMB_rateattitude.Items4" xml:space="preserve">
-    <value>3</value>
+  <data name="CMB_rateattitude.Items2" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="CMB_rateattitude.Items3" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;CMB_distunits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CMB_rateattitude.Items4" xml:space="preserve">
+    <value>3</value>
   </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CMB_rateattitude.Items5" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;CHK_speechbattery.ZOrder" xml:space="preserve">
-    <value>74</value>
+  <data name="CMB_rateattitude.Items6" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CMB_rateattitude.Items7" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>841, 502</value>
+  <data name="CMB_rateattitude.Items8" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="CHK_maprotation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 17</value>
+  <data name="CMB_rateattitude.Items9" xml:space="preserve">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>34</value>
+  <data name="CMB_rateattitude.Items10" xml:space="preserve">
+    <value>9</value>
   </data>
-  <data name="&gt;&gt;BUT_videostop.Name" xml:space="preserve">
-    <value>BUT_videostop</value>
+  <data name="CMB_rateattitude.Items11" xml:space="preserve">
+    <value>10</value>
   </data>
-  <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CMB_rateattitude.Items12" xml:space="preserve">
+    <value>50</value>
   </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="CMB_rateattitude.Items13" xml:space="preserve">
+    <value>100</value>
   </data>
-  <data name="&gt;&gt;CMB_ratestatus.ZOrder" xml:space="preserve">
-    <value>64</value>
+  <data name="CMB_rateattitude.Location" type="System.Drawing.Point, System.Drawing">
+    <value>166, 251</value>
   </data>
-  <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
-  </data>
-  <data name="label97.Text" xml:space="preserve">
-    <value>Dist Units</value>
-  </data>
-  <data name="CMB_distunits.TabIndex" type="System.Int32, mscorlib">
-    <value>61</value>
-  </data>
-  <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 17</value>
-  </data>
-  <data name="CHK_speechlowspeed.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CHK_speechbattery.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;BUT_videostart.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="CHK_speechaltwarning.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="label95.TabIndex" type="System.Int32, mscorlib">
-    <value>63</value>
-  </data>
-  <data name="chk_displaycog.Text" xml:space="preserve">
-    <value>Display COG</value>
-  </data>
-  <data name="chk_analytics.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label108.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label102.Text" xml:space="preserve">
-    <value>Attitude</value>
-  </data>
-  <data name="&gt;&gt;CMB_language.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="CMB_ratestatus.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="CMB_rateattitude.Size" type="System.Drawing.Size, System.Drawing">
     <value>40, 21</value>
   </data>
-  <data name="CHK_speechaltwarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>671, 89</value>
+  <data name="CMB_rateattitude.TabIndex" type="System.Int32, mscorlib">
+    <value>56</value>
   </data>
-  <data name="&gt;&gt;chk_norcreceiver.Name" xml:space="preserve">
-    <value>chk_norcreceiver</value>
+  <data name="&gt;&gt;CMB_rateattitude.Name" xml:space="preserve">
+    <value>CMB_rateattitude</value>
   </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>37</value>
-  </data>
-  <data name="CMB_rateposition.Items3" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechlowspeed.Name" xml:space="preserve">
-    <value>CHK_speechlowspeed</value>
-  </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
-  </data>
-  <data name="label104.Text" xml:space="preserve">
-    <value>Mode/Status</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechArmedOnly.Name" xml:space="preserve">
-    <value>CHK_speechArmedOnly</value>
-  </data>
-  <data name="&gt;&gt;label96.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;BUT_themecustom.Name" xml:space="preserve">
-    <value>BUT_themecustom</value>
-  </data>
-  <data name="&gt;&gt;chk_analytics.Name" xml:space="preserve">
-    <value>chk_analytics</value>
-  </data>
-  <data name="CMB_ratestatus.TabIndex" type="System.Int32, mscorlib">
-    <value>54</value>
-  </data>
-  <data name="CHK_speecharmdisarm.TabIndex" type="System.Int32, mscorlib">
-    <value>99</value>
-  </data>
-  <data name="&gt;&gt;CHK_speechcustom.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chk_displaynavbearing.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;CHK_AutoParamCommit.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CMB_language.Name" xml:space="preserve">
-    <value>CMB_language</value>
-  </data>
-  <data name="&gt;&gt;label103.Name" xml:space="preserve">
-    <value>label103</value>
-  </data>
-  <data name="CHK_hudshow.TabIndex" type="System.Int32, mscorlib">
-    <value>73</value>
-  </data>
-  <data name="CHK_disttohomeflightdata.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 302</value>
-  </data>
-  <data name="chk_shownofly.Text" xml:space="preserve">
-    <value>No Fly</value>
-  </data>
-  <data name="&gt;&gt;CMB_language.ZOrder" xml:space="preserve">
-    <value>81</value>
-  </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label99.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label98.Text" xml:space="preserve">
-    <value>Speed Units</value>
-  </data>
-  <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
-  </data>
-  <data name="&gt;&gt;CMB_ratestatus.Type" xml:space="preserve">
+  <data name="&gt;&gt;CMB_rateattitude.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+  <data name="&gt;&gt;CMB_rateattitude.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;label26.Name" xml:space="preserve">
-    <value>label26</value>
+  <data name="&gt;&gt;CMB_rateattitude.ZOrder" xml:space="preserve">
+    <value>67</value>
   </data>
-  <data name="CHK_speechbattery.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="label99.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="chk_ADSB.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="label99.Location" type="System.Drawing.Point, System.Drawing">
+    <value>480, 198</value>
   </data>
-  <data name="chk_temp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
+  <data name="label99.Size" type="System.Drawing.Size, System.Drawing">
+    <value>241, 31</value>
   </data>
-  <data name="&gt;&gt;chk_displaycog.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CHK_disttohomeflightdata.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
-  </data>
-  <data name="CMB_theme.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 421</value>
-  </data>
-  <data name="&gt;&gt;chk_norcreceiver.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;num_linelength.ZOrder" xml:space="preserve">
-    <value>52</value>
-  </data>
-  <data name="CHK_showairports.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;label101.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="label99.TabIndex" type="System.Int32, mscorlib">
+    <value>57</value>
   </data>
   <data name="label99.Text" xml:space="preserve">
     <value>NOTE: The Configuration Tab will NOT display these units, as those are raw values.
 </value>
   </data>
+  <data name="&gt;&gt;label99.Name" xml:space="preserve">
+    <value>label99</value>
+  </data>
+  <data name="&gt;&gt;label99.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label99.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label99.ZOrder" xml:space="preserve">
+    <value>68</value>
+  </data>
+  <data name="label98.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label98.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label98.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 225</value>
+  </data>
+  <data name="label98.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 13</value>
+  </data>
+  <data name="label98.TabIndex" type="System.Int32, mscorlib">
+    <value>58</value>
+  </data>
+  <data name="label98.Text" xml:space="preserve">
+    <value>Speed Units</value>
+  </data>
+  <data name="&gt;&gt;label98.Name" xml:space="preserve">
+    <value>label98</value>
+  </data>
+  <data name="&gt;&gt;label98.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label98.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label98.ZOrder" xml:space="preserve">
+    <value>69</value>
+  </data>
+  <data name="label97.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label97.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label97.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 198</value>
+  </data>
+  <data name="label97.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 13</value>
+  </data>
+  <data name="label97.TabIndex" type="System.Int32, mscorlib">
+    <value>59</value>
+  </data>
+  <data name="label97.Text" xml:space="preserve">
+    <value>Dist Units</value>
+  </data>
+  <data name="&gt;&gt;label97.Name" xml:space="preserve">
+    <value>label97</value>
+  </data>
+  <data name="&gt;&gt;label97.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label97.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label97.ZOrder" xml:space="preserve">
+    <value>70</value>
+  </data>
+  <data name="CMB_speedunits.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 222</value>
+  </data>
+  <data name="CMB_speedunits.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_speedunits.TabIndex" type="System.Int32, mscorlib">
+    <value>60</value>
+  </data>
+  <data name="&gt;&gt;CMB_speedunits.Name" xml:space="preserve">
+    <value>CMB_speedunits</value>
+  </data>
+  <data name="&gt;&gt;CMB_speedunits.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_speedunits.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_speedunits.ZOrder" xml:space="preserve">
+    <value>71</value>
+  </data>
+  <data name="CMB_distunits.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 195</value>
+  </data>
+  <data name="CMB_distunits.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_distunits.TabIndex" type="System.Int32, mscorlib">
+    <value>61</value>
+  </data>
+  <data name="&gt;&gt;CMB_distunits.Name" xml:space="preserve">
+    <value>CMB_distunits</value>
+  </data>
+  <data name="&gt;&gt;CMB_distunits.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_distunits.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_distunits.ZOrder" xml:space="preserve">
+    <value>72</value>
+  </data>
+  <data name="label96.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label96.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label96.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 171</value>
+  </data>
+  <data name="label96.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 13</value>
+  </data>
+  <data name="label96.TabIndex" type="System.Int32, mscorlib">
+    <value>62</value>
+  </data>
+  <data name="label96.Text" xml:space="preserve">
+    <value>Joystick</value>
+  </data>
+  <data name="&gt;&gt;label96.Name" xml:space="preserve">
+    <value>label96</value>
+  </data>
+  <data name="&gt;&gt;label96.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label96.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label96.ZOrder" xml:space="preserve">
+    <value>73</value>
+  </data>
+  <data name="label95.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label95.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label95.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 90</value>
+  </data>
+  <data name="label95.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 13</value>
+  </data>
+  <data name="label95.TabIndex" type="System.Int32, mscorlib">
+    <value>63</value>
+  </data>
+  <data name="label95.Text" xml:space="preserve">
+    <value>Speech</value>
+  </data>
+  <data name="&gt;&gt;label95.Name" xml:space="preserve">
+    <value>label95</value>
+  </data>
+  <data name="&gt;&gt;label95.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label95.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label95.ZOrder" xml:space="preserve">
+    <value>74</value>
+  </data>
+  <data name="CHK_speechbattery.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechbattery.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechbattery.Location" type="System.Drawing.Point, System.Drawing">
+    <value>559, 89</value>
+  </data>
+  <data name="CHK_speechbattery.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 17</value>
+  </data>
+  <data name="CHK_speechbattery.TabIndex" type="System.Int32, mscorlib">
+    <value>64</value>
+  </data>
+  <data name="CHK_speechbattery.Text" xml:space="preserve">
+    <value>Battery Warning</value>
+  </data>
+  <data name="CHK_speechbattery.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechbattery.Name" xml:space="preserve">
+    <value>CHK_speechbattery</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechbattery.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechbattery.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechbattery.ZOrder" xml:space="preserve">
+    <value>75</value>
+  </data>
+  <data name="CHK_speechcustom.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechcustom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechcustom.Location" type="System.Drawing.Point, System.Drawing">
+    <value>469, 89</value>
+  </data>
+  <data name="CHK_speechcustom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 17</value>
+  </data>
+  <data name="CHK_speechcustom.TabIndex" type="System.Int32, mscorlib">
+    <value>65</value>
+  </data>
+  <data name="CHK_speechcustom.Text" xml:space="preserve">
+    <value>30s Interval</value>
+  </data>
+  <data name="CHK_speechcustom.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechcustom.Name" xml:space="preserve">
+    <value>CHK_speechcustom</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechcustom.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechcustom.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechcustom.ZOrder" xml:space="preserve">
+    <value>76</value>
+  </data>
+  <data name="CHK_speechmode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechmode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechmode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>408, 89</value>
+  </data>
+  <data name="CHK_speechmode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 17</value>
+  </data>
+  <data name="CHK_speechmode.TabIndex" type="System.Int32, mscorlib">
+    <value>66</value>
+  </data>
+  <data name="CHK_speechmode.Text" xml:space="preserve">
+    <value>Mode </value>
+  </data>
+  <data name="CHK_speechmode.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechmode.Name" xml:space="preserve">
+    <value>CHK_speechmode</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechmode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechmode.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechmode.ZOrder" xml:space="preserve">
+    <value>77</value>
+  </data>
+  <data name="CHK_speechwaypoint.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechwaypoint.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechwaypoint.Location" type="System.Drawing.Point, System.Drawing">
+    <value>332, 89</value>
+  </data>
+  <data name="CHK_speechwaypoint.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 17</value>
+  </data>
+  <data name="CHK_speechwaypoint.TabIndex" type="System.Int32, mscorlib">
+    <value>67</value>
+  </data>
+  <data name="CHK_speechwaypoint.Text" xml:space="preserve">
+    <value>Waypoint</value>
+  </data>
+  <data name="CHK_speechwaypoint.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechwaypoint.Name" xml:space="preserve">
+    <value>CHK_speechwaypoint</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechwaypoint.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechwaypoint.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechwaypoint.ZOrder" xml:space="preserve">
+    <value>78</value>
+  </data>
+  <data name="label94.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label94.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label94.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 65</value>
+  </data>
+  <data name="label94.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 13</value>
+  </data>
+  <data name="label94.TabIndex" type="System.Int32, mscorlib">
+    <value>68</value>
+  </data>
+  <data name="label94.Text" xml:space="preserve">
+    <value>OSD Color</value>
+  </data>
+  <data name="&gt;&gt;label94.Name" xml:space="preserve">
+    <value>label94</value>
+  </data>
+  <data name="&gt;&gt;label94.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label94.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label94.ZOrder" xml:space="preserve">
+    <value>79</value>
+  </data>
+  <data name="CMB_osdcolor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 62</value>
+  </data>
+  <data name="CMB_osdcolor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_osdcolor.TabIndex" type="System.Int32, mscorlib">
+    <value>69</value>
+  </data>
+  <data name="&gt;&gt;CMB_osdcolor.Name" xml:space="preserve">
+    <value>CMB_osdcolor</value>
+  </data>
+  <data name="&gt;&gt;CMB_osdcolor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_osdcolor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_osdcolor.ZOrder" xml:space="preserve">
+    <value>80</value>
+  </data>
+  <data name="CMB_severity.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 111</value>
+  </data>
+  <data name="CMB_severity.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_severity.TabIndex" type="System.Int32, mscorlib">
+    <value>125</value>
+  </data>
+  <data name="&gt;&gt;CMB_severity.Name" xml:space="preserve">
+    <value>CMB_severity</value>
+  </data>
+  <data name="&gt;&gt;CMB_severity.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_severity.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_severity.ZOrder" xml:space="preserve">
+    <value>81</value>
+  </data>
+  <data name="CMB_language.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 139</value>
+  </data>
+  <data name="CMB_language.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_language.TabIndex" type="System.Int32, mscorlib">
+    <value>70</value>
+  </data>
+  <data name="&gt;&gt;CMB_language.Name" xml:space="preserve">
+    <value>CMB_language</value>
+  </data>
+  <data name="&gt;&gt;CMB_language.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_language.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_language.ZOrder" xml:space="preserve">
+    <value>82</value>
+  </data>
+  <data name="label93.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label93.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label93.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 142</value>
+  </data>
+  <data name="label93.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 13</value>
+  </data>
+  <data name="label93.TabIndex" type="System.Int32, mscorlib">
+    <value>71</value>
+  </data>
+  <data name="label93.Text" xml:space="preserve">
+    <value>UI Language</value>
+  </data>
+  <data name="&gt;&gt;label93.Name" xml:space="preserve">
+    <value>label93</value>
+  </data>
+  <data name="&gt;&gt;label93.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label93.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label93.ZOrder" xml:space="preserve">
+    <value>83</value>
+  </data>
+  <data name="CHK_enablespeech.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_enablespeech.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_enablespeech.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 89</value>
+  </data>
+  <data name="CHK_enablespeech.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 17</value>
+  </data>
+  <data name="CHK_enablespeech.TabIndex" type="System.Int32, mscorlib">
+    <value>72</value>
+  </data>
+  <data name="CHK_enablespeech.Text" xml:space="preserve">
+    <value>Enable Speech</value>
+  </data>
+  <data name="&gt;&gt;CHK_enablespeech.Name" xml:space="preserve">
+    <value>CHK_enablespeech</value>
+  </data>
+  <data name="&gt;&gt;CHK_enablespeech.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_enablespeech.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_enablespeech.ZOrder" xml:space="preserve">
+    <value>84</value>
+  </data>
+  <data name="CHK_hudshow.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_hudshow.Location" type="System.Drawing.Point, System.Drawing">
+    <value>520, 10</value>
+  </data>
+  <data name="CHK_hudshow.Size" type="System.Drawing.Size, System.Drawing">
+    <value>133, 18</value>
+  </data>
+  <data name="CHK_hudshow.TabIndex" type="System.Int32, mscorlib">
+    <value>73</value>
+  </data>
+  <data name="CHK_hudshow.Text" xml:space="preserve">
+    <value>Enable HUD Overlay</value>
+  </data>
+  <data name="&gt;&gt;CHK_hudshow.Name" xml:space="preserve">
+    <value>CHK_hudshow</value>
+  </data>
+  <data name="&gt;&gt;CHK_hudshow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_hudshow.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_hudshow.ZOrder" xml:space="preserve">
+    <value>85</value>
+  </data>
+  <data name="label92.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label92.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label92.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 11</value>
+  </data>
+  <data name="label92.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 13</value>
+  </data>
+  <data name="label92.TabIndex" type="System.Int32, mscorlib">
+    <value>74</value>
+  </data>
+  <data name="label92.Text" xml:space="preserve">
+    <value>Video Device</value>
+  </data>
+  <data name="&gt;&gt;label92.Name" xml:space="preserve">
+    <value>label92</value>
+  </data>
+  <data name="&gt;&gt;label92.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label92.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label92.ZOrder" xml:space="preserve">
+    <value>86</value>
+  </data>
+  <data name="CMB_videosources.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 8</value>
+  </data>
+  <data name="CMB_videosources.Size" type="System.Drawing.Size, System.Drawing">
+    <value>245, 21</value>
+  </data>
+  <data name="CMB_videosources.TabIndex" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
+  <data name="&gt;&gt;CMB_videosources.Name" xml:space="preserve">
+    <value>CMB_videosources</value>
+  </data>
+  <data name="&gt;&gt;CMB_videosources.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_videosources.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_videosources.ZOrder" xml:space="preserve">
+    <value>87</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 373</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>89</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Map Follow</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>41</value>
+  </data>
+  <data name="CHK_maprotation.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_maprotation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 372</value>
+  </data>
+  <data name="CHK_maprotation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>205, 17</value>
+  </data>
+  <data name="CHK_maprotation.TabIndex" type="System.Int32, mscorlib">
+    <value>90</value>
+  </data>
+  <data name="CHK_maprotation.Text" xml:space="preserve">
+    <value>Map is rotated to follow the plane</value>
+  </data>
+  <data name="&gt;&gt;CHK_maprotation.Name" xml:space="preserve">
+    <value>CHK_maprotation</value>
+  </data>
+  <data name="&gt;&gt;CHK_maprotation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_maprotation.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_maprotation.ZOrder" xml:space="preserve">
+    <value>42</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>180, 303</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 17</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>91</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Dist to Home</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>39</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.Location" type="System.Drawing.Point, System.Drawing">
+    <value>267, 302</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 17</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.TabIndex" type="System.Int32, mscorlib">
+    <value>92</value>
+  </data>
+  <data name="CHK_disttohomeflightdata.Text" xml:space="preserve">
+    <value>Display in Flightdata</value>
+  </data>
+  <data name="&gt;&gt;CHK_disttohomeflightdata.Name" xml:space="preserve">
+    <value>CHK_disttohomeflightdata</value>
+  </data>
+  <data name="&gt;&gt;CHK_disttohomeflightdata.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_disttohomeflightdata.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_disttohomeflightdata.ZOrder" xml:space="preserve">
+    <value>40</value>
+  </data>
+  <data name="BUT_Joystick.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_Joystick.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 166</value>
+  </data>
+  <data name="BUT_Joystick.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 23</value>
+  </data>
+  <data name="BUT_Joystick.TabIndex" type="System.Int32, mscorlib">
+    <value>76</value>
+  </data>
+  <data name="BUT_Joystick.Text" xml:space="preserve">
+    <value>Joystick Setup</value>
+  </data>
+  <data name="&gt;&gt;BUT_Joystick.Name" xml:space="preserve">
+    <value>BUT_Joystick</value>
+  </data>
+  <data name="&gt;&gt;BUT_Joystick.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_Joystick.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_Joystick.ZOrder" xml:space="preserve">
+    <value>88</value>
+  </data>
+  <data name="BUT_videostop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_videostop.Location" type="System.Drawing.Point, System.Drawing">
+    <value>439, 6</value>
+  </data>
+  <data name="BUT_videostop.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="BUT_videostop.TabIndex" type="System.Int32, mscorlib">
+    <value>77</value>
+  </data>
+  <data name="BUT_videostop.Text" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostop.Name" xml:space="preserve">
+    <value>BUT_videostop</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostop.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostop.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostop.ZOrder" xml:space="preserve">
+    <value>89</value>
+  </data>
+  <data name="BUT_videostart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_videostart.Location" type="System.Drawing.Point, System.Drawing">
+    <value>358, 6</value>
+  </data>
+  <data name="BUT_videostart.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="BUT_videostart.TabIndex" type="System.Int32, mscorlib">
+    <value>78</value>
+  </data>
+  <data name="BUT_videostart.Text" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostart.Name" xml:space="preserve">
+    <value>BUT_videostart</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostart.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostart.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_videostart.ZOrder" xml:space="preserve">
+    <value>90</value>
+  </data>
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 398</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>93</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Log Path</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>38</value>
+  </data>
+  <data name="txt_log_dir.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 395</value>
+  </data>
+  <data name="txt_log_dir.Size" type="System.Drawing.Size, System.Drawing">
+    <value>386, 20</value>
+  </data>
+  <data name="txt_log_dir.TabIndex" type="System.Int32, mscorlib">
+    <value>94</value>
+  </data>
+  <data name="&gt;&gt;txt_log_dir.Name" xml:space="preserve">
+    <value>txt_log_dir</value>
+  </data>
+  <data name="&gt;&gt;txt_log_dir.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txt_log_dir.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;txt_log_dir.ZOrder" xml:space="preserve">
+    <value>37</value>
+  </data>
+  <data name="BUT_logdirbrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_logdirbrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>496, 393</value>
+  </data>
+  <data name="BUT_logdirbrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="BUT_logdirbrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>95</value>
+  </data>
+  <data name="BUT_logdirbrowse.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="&gt;&gt;BUT_logdirbrowse.Name" xml:space="preserve">
+    <value>BUT_logdirbrowse</value>
+  </data>
+  <data name="&gt;&gt;BUT_logdirbrowse.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_logdirbrowse.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_logdirbrowse.ZOrder" xml:space="preserve">
+    <value>36</value>
+  </data>
+  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 424</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>35</value>
+  </data>
+  <data name="CMB_theme.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 421</value>
+  </data>
+  <data name="CMB_theme.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_theme.TabIndex" type="System.Int32, mscorlib">
+    <value>97</value>
+  </data>
+  <data name="&gt;&gt;CMB_theme.Name" xml:space="preserve">
+    <value>CMB_theme</value>
+  </data>
+  <data name="&gt;&gt;CMB_theme.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_theme.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_theme.ZOrder" xml:space="preserve">
+    <value>34</value>
+  </data>
+  <data name="BUT_themecustom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_themecustom.Location" type="System.Drawing.Point, System.Drawing">
+    <value>249, 421</value>
+  </data>
+  <data name="BUT_themecustom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 20</value>
+  </data>
+  <data name="BUT_themecustom.TabIndex" type="System.Int32, mscorlib">
+    <value>98</value>
+  </data>
+  <data name="BUT_themecustom.Text" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="&gt;&gt;BUT_themecustom.Name" xml:space="preserve">
+    <value>BUT_themecustom</value>
+  </data>
+  <data name="&gt;&gt;BUT_themecustom.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_themecustom.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_themecustom.ZOrder" xml:space="preserve">
+    <value>33</value>
+  </data>
+  <data name="CHK_speecharmdisarm.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speecharmdisarm.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Location" type="System.Drawing.Point, System.Drawing">
+    <value>760, 89</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 17</value>
+  </data>
+  <data name="CHK_speecharmdisarm.TabIndex" type="System.Int32, mscorlib">
+    <value>99</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Text" xml:space="preserve">
+    <value>Arm/Disarm</value>
+  </data>
+  <data name="CHK_speecharmdisarm.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speecharmdisarm.Name" xml:space="preserve">
+    <value>CHK_speecharmdisarm</value>
+  </data>
+  <data name="&gt;&gt;CHK_speecharmdisarm.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speecharmdisarm.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speecharmdisarm.ZOrder" xml:space="preserve">
+    <value>32</value>
+  </data>
+  <data name="BUT_Vario.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_Vario.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 551</value>
+  </data>
+  <data name="BUT_Vario.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 20</value>
+  </data>
+  <data name="BUT_Vario.TabIndex" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
+  <data name="BUT_Vario.Text" xml:space="preserve">
+    <value>Start/Stop Vario</value>
+  </data>
+  <data name="&gt;&gt;BUT_Vario.Name" xml:space="preserve">
+    <value>BUT_Vario</value>
+  </data>
+  <data name="&gt;&gt;BUT_Vario.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;BUT_Vario.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BUT_Vario.ZOrder" xml:space="preserve">
+    <value>31</value>
+  </data>
+  <data name="chk_analytics.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_analytics.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_analytics.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 577</value>
+  </data>
+  <data name="chk_analytics.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 17</value>
+  </data>
+  <data name="chk_analytics.TabIndex" type="System.Int32, mscorlib">
+    <value>102</value>
+  </data>
+  <data name="chk_analytics.Text" xml:space="preserve">
+    <value>OptOut Anon Stats</value>
+  </data>
+  <data name="&gt;&gt;chk_analytics.Name" xml:space="preserve">
+    <value>chk_analytics</value>
+  </data>
+  <data name="&gt;&gt;chk_analytics.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_analytics.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_analytics.ZOrder" xml:space="preserve">
+    <value>30</value>
+  </data>
+  <data name="CHK_beta.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_beta.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_beta.Location" type="System.Drawing.Point, System.Drawing">
+    <value>228, 577</value>
+  </data>
+  <data name="CHK_beta.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 17</value>
+  </data>
+  <data name="CHK_beta.TabIndex" type="System.Int32, mscorlib">
+    <value>103</value>
+  </data>
+  <data name="CHK_beta.Text" xml:space="preserve">
+    <value>Beta Updates</value>
+  </data>
+  <data name="&gt;&gt;CHK_beta.Name" xml:space="preserve">
+    <value>CHK_beta</value>
+  </data>
+  <data name="&gt;&gt;CHK_beta.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_beta.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_beta.ZOrder" xml:space="preserve">
+    <value>29</value>
+  </data>
+  <data name="CHK_Password.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_Password.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_Password.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 554</value>
+  </data>
+  <data name="CHK_Password.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 17</value>
+  </data>
+  <data name="CHK_Password.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="CHK_Password.Text" xml:space="preserve">
+    <value>Password Protect Config</value>
+  </data>
+  <data name="&gt;&gt;CHK_Password.Name" xml:space="preserve">
+    <value>CHK_Password</value>
+  </data>
+  <data name="&gt;&gt;CHK_Password.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_Password.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_Password.ZOrder" xml:space="preserve">
+    <value>28</value>
+  </data>
+  <data name="CHK_speechlowspeed.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechlowspeed.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechlowspeed.Location" type="System.Drawing.Point, System.Drawing">
+    <value>853, 89</value>
+  </data>
+  <data name="CHK_speechlowspeed.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 17</value>
+  </data>
+  <data name="CHK_speechlowspeed.TabIndex" type="System.Int32, mscorlib">
+    <value>105</value>
+  </data>
+  <data name="CHK_speechlowspeed.Text" xml:space="preserve">
+    <value>Low Speed</value>
+  </data>
+  <data name="CHK_speechlowspeed.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechlowspeed.Name" xml:space="preserve">
+    <value>CHK_speechlowspeed</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechlowspeed.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechlowspeed.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechlowspeed.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="CHK_showairports.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_showairports.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_showairports.Location" type="System.Drawing.Point, System.Drawing">
+    <value>496, 554</value>
+  </data>
+  <data name="CHK_showairports.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 17</value>
+  </data>
+  <data name="CHK_showairports.TabIndex" type="System.Int32, mscorlib">
+    <value>107</value>
+  </data>
+  <data name="CHK_showairports.Text" xml:space="preserve">
+    <value>Show Airports</value>
+  </data>
+  <data name="&gt;&gt;CHK_showairports.Name" xml:space="preserve">
+    <value>CHK_showairports</value>
+  </data>
+  <data name="&gt;&gt;CHK_showairports.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_showairports.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_showairports.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="chk_ADSB.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_ADSB.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_ADSB.Location" type="System.Drawing.Point, System.Drawing">
+    <value>598, 554</value>
+  </data>
+  <data name="chk_ADSB.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 17</value>
+  </data>
+  <data name="chk_ADSB.TabIndex" type="System.Int32, mscorlib">
+    <value>108</value>
+  </data>
+  <data name="chk_ADSB.Text" xml:space="preserve">
+    <value>ADSB</value>
+  </data>
+  <data name="&gt;&gt;chk_ADSB.Name" xml:space="preserve">
+    <value>chk_ADSB</value>
+  </data>
+  <data name="&gt;&gt;chk_ADSB.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_ADSB.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_ADSB.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="chk_tfr.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_tfr.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_tfr.Location" type="System.Drawing.Point, System.Drawing">
+    <value>496, 577</value>
+  </data>
+  <data name="chk_tfr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>54, 17</value>
+  </data>
+  <data name="chk_tfr.TabIndex" type="System.Int32, mscorlib">
+    <value>109</value>
+  </data>
+  <data name="chk_tfr.Text" xml:space="preserve">
+    <value>TFR's</value>
+  </data>
+  <data name="&gt;&gt;chk_tfr.Name" xml:space="preserve">
+    <value>chk_tfr</value>
+  </data>
+  <data name="&gt;&gt;chk_tfr.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_tfr.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_tfr.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="chk_temp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="chk_temp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_temp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 623</value>
+  </data>
+  <data name="chk_temp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 17</value>
+  </data>
+  <data name="chk_temp.TabIndex" type="System.Int32, mscorlib">
+    <value>110</value>
+  </data>
+  <data name="chk_temp.Text" xml:space="preserve">
+    <value>Testing Screen</value>
+  </data>
+  <data name="&gt;&gt;chk_temp.Name" xml:space="preserve">
+    <value>chk_temp</value>
+  </data>
+  <data name="&gt;&gt;chk_temp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_temp.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_temp.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="chk_norcreceiver.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_norcreceiver.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_norcreceiver.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 577</value>
+  </data>
+  <data name="chk_norcreceiver.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 17</value>
+  </data>
+  <data name="chk_norcreceiver.TabIndex" type="System.Int32, mscorlib">
+    <value>111</value>
+  </data>
+  <data name="chk_norcreceiver.Text" xml:space="preserve">
+    <value>No RC Receiver</value>
+  </data>
+  <data name="&gt;&gt;chk_norcreceiver.Name" xml:space="preserve">
+    <value>chk_norcreceiver</value>
+  </data>
+  <data name="&gt;&gt;chk_norcreceiver.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_norcreceiver.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_norcreceiver.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="CMB_Layout.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 448</value>
+  </data>
+  <data name="CMB_Layout.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_Layout.TabIndex" type="System.Int32, mscorlib">
+    <value>113</value>
+  </data>
+  <data name="&gt;&gt;CMB_Layout.Name" xml:space="preserve">
+    <value>CMB_Layout</value>
+  </data>
+  <data name="&gt;&gt;CMB_Layout.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_Layout.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_Layout.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 451</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>115</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Layout</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="CHK_AutoParamCommit.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>598, 578</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>123, 17</value>
+  </data>
+  <data name="CHK_AutoParamCommit.TabIndex" type="System.Int32, mscorlib">
+    <value>116</value>
+  </data>
+  <data name="CHK_AutoParamCommit.Text" xml:space="preserve">
+    <value>Auto Commit Params</value>
+  </data>
+  <data name="&gt;&gt;CHK_AutoParamCommit.Name" xml:space="preserve">
+    <value>CHK_AutoParamCommit</value>
+  </data>
+  <data name="&gt;&gt;CHK_AutoParamCommit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_AutoParamCommit.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_AutoParamCommit.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="chk_shownofly.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_shownofly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_shownofly.Location" type="System.Drawing.Point, System.Drawing">
+    <value>671, 554</value>
+  </data>
+  <data name="chk_shownofly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 17</value>
+  </data>
+  <data name="chk_shownofly.TabIndex" type="System.Int32, mscorlib">
+    <value>117</value>
+  </data>
+  <data name="chk_shownofly.Text" xml:space="preserve">
+    <value>No Fly</value>
+  </data>
+  <data name="&gt;&gt;chk_shownofly.Name" xml:space="preserve">
+    <value>chk_shownofly</value>
+  </data>
   <data name="&gt;&gt;chk_shownofly.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="CMB_rateattitude.Items1" xml:space="preserve">
-    <value>0</value>
-  </data>
-	<data name="CMB_mapCache.Location" type="System.Drawing.Point, System.Drawing">
-		<value>107, 653</value>
-	</data>
-	<data name="CMB_mapCache.Size" type="System.Drawing.Size, System.Drawing">
-		<value>138, 21</value>
-	</data>
-	<data name="CMB_mapCache.TabIndex" type="System.Int32, mscorlib">
-		<value>127</value>
-	</data>
-	<data name="&gt;&gt;CMB_mapCache.Name" xml:space="preserve">
-    <value>CMB_mapCache</value>
-  </data>
-	<data name="&gt;&gt;CMB_mapCache.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-	<data name="&gt;&gt;CMB_mapCache.Parent" xml:space="preserve">
+  <data name="&gt;&gt;chk_shownofly.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-	<data name="&gt;&gt;CMB_mapCache.ZOrder" xml:space="preserve">
-    <value>80</value>
+  <data name="&gt;&gt;chk_shownofly.ZOrder" xml:space="preserve">
+    <value>12</value>
   </data>
-	<data name="label13.AutoSize" type="System.Boolean, mscorlib">
-		<value>True</value>
-	</data>
-	<data name="label13.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-		<value>NoControl</value>
-	</data>
-	<data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-		<value>9, 656</value>
-	</data>
-	<data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-		<value>96, 13</value>
-	</data>
-	<data name="label13.TabIndex" type="System.Int32, mscorlib">
-		<value>50</value>
-	</data>
-	<data name="label13.Text" xml:space="preserve">
-    <value>Map Access Mode</value>
+  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-	<data name="&gt;&gt;label13.Name" xml:space="preserve">
-    <value>label13</value>
+  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-	<data name="&gt;&gt;label13.Type" xml:space="preserve">
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>249, 198</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 13</value>
+  </data>
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>118</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>Alt Units</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-	<data name="&gt;&gt;label13.Parent" xml:space="preserve">
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-	<data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>79</value>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
-	<data name="BUT_mapCacheDir.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-		<value>NoControl</value>
-	</data>
-	<data name="BUT_mapCacheDir.Location" type="System.Drawing.Point, System.Drawing">
-		<value>251, 653</value>
-	</data>
-	<data name="BUT_mapCacheDir.Size" type="System.Drawing.Size, System.Drawing">
-		<value>94, 21</value>
-	</data>
-	<data name="BUT_mapCacheDir.TabIndex" type="System.Int32, mscorlib">
-		<value>95</value>
-	</data>
-	<data name="BUT_mapCacheDir.Text" xml:space="preserve">
+  <data name="CMB_altunits.Location" type="System.Drawing.Point, System.Drawing">
+    <value>320, 195</value>
+  </data>
+  <data name="CMB_altunits.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_altunits.TabIndex" type="System.Int32, mscorlib">
+    <value>119</value>
+  </data>
+  <data name="&gt;&gt;CMB_altunits.Name" xml:space="preserve">
+    <value>CMB_altunits</value>
+  </data>
+  <data name="&gt;&gt;CMB_altunits.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_altunits.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_altunits.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="num_gcsid.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 475</value>
+  </data>
+  <data name="num_gcsid.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 20</value>
+  </data>
+  <data name="num_gcsid.TabIndex" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
+  <data name="&gt;&gt;num_gcsid.Name" xml:space="preserve">
+    <value>num_gcsid</value>
+  </data>
+  <data name="&gt;&gt;num_gcsid.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;num_gcsid.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;num_gcsid.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 477</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>43, 13</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>121</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>GCS ID</value>
+  </data>
+  <data name="&gt;&gt;label7.Name" xml:space="preserve">
+    <value>label7</value>
+  </data>
+  <data name="&gt;&gt;label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="CHK_params_bg.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_params_bg.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_params_bg.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 600</value>
+  </data>
+  <data name="CHK_params_bg.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 17</value>
+  </data>
+  <data name="CHK_params_bg.TabIndex" type="System.Int32, mscorlib">
+    <value>122</value>
+  </data>
+  <data name="CHK_params_bg.Text" xml:space="preserve">
+    <value>Params Download in BackGround</value>
+  </data>
+  <data name="&gt;&gt;CHK_params_bg.Name" xml:space="preserve">
+    <value>CHK_params_bg</value>
+  </data>
+  <data name="&gt;&gt;CHK_params_bg.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_params_bg.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_params_bg.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="chk_slowMachine.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_slowMachine.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_slowMachine.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 600</value>
+  </data>
+  <data name="chk_slowMachine.Size" type="System.Drawing.Size, System.Drawing">
+    <value>155, 17</value>
+  </data>
+  <data name="chk_slowMachine.TabIndex" type="System.Int32, mscorlib">
+    <value>123</value>
+  </data>
+  <data name="chk_slowMachine.Text" xml:space="preserve">
+    <value>Runing on a slow computer</value>
+  </data>
+  <data name="&gt;&gt;chk_slowMachine.Name" xml:space="preserve">
+    <value>chk_slowMachine</value>
+  </data>
+  <data name="&gt;&gt;chk_slowMachine.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_slowMachine.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_slowMachine.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="CHK_speechArmedOnly.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CHK_speechArmedOnly.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Location" type="System.Drawing.Point, System.Drawing">
+    <value>212, 89</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>109, 17</value>
+  </data>
+  <data name="CHK_speechArmedOnly.TabIndex" type="System.Int32, mscorlib">
+    <value>124</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Text" xml:space="preserve">
+    <value>Only when Armed</value>
+  </data>
+  <data name="CHK_speechArmedOnly.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.Name" xml:space="preserve">
+    <value>CHK_speechArmedOnly</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_speechArmedOnly.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 108</value>
+  </data>
+  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 31</value>
+  </data>
+  <data name="label8.TabIndex" type="System.Int32, mscorlib">
+    <value>126</value>
+  </data>
+  <data name="label8.Text" xml:space="preserve">
+    <value>NOTE: Set the low level of SEVERITY to speak</value>
+  </data>
+  <data name="&gt;&gt;label8.Name" xml:space="preserve">
+    <value>label8</value>
+  </data>
+  <data name="&gt;&gt;label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label9.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 527</value>
+  </data>
+  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="label9.TabIndex" type="System.Int32, mscorlib">
+    <value>128</value>
+  </data>
+  <data name="label9.Text" xml:space="preserve">
+    <value>Inactive Aircraft</value>
+  </data>
+  <data name="&gt;&gt;label9.Name" xml:space="preserve">
+    <value>label9</value>
+  </data>
+  <data name="&gt;&gt;label9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cmb_secondarydisplaystyle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 524</value>
+  </data>
+  <data name="cmb_secondarydisplaystyle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="cmb_secondarydisplaystyle.TabIndex" type="System.Int32, mscorlib">
+    <value>129</value>
+  </data>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.Name" xml:space="preserve">
+    <value>cmb_secondarydisplaystyle</value>
+  </data>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmb_secondarydisplaystyle.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="chk_displaycog.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displaycog.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_displaycog.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 501</value>
+  </data>
+  <data name="chk_displaycog.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 17</value>
+  </data>
+  <data name="chk_displaycog.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="chk_displaycog.Text" xml:space="preserve">
+    <value>Display COG</value>
+  </data>
+  <data name="&gt;&gt;chk_displaycog.Name" xml:space="preserve">
+    <value>chk_displaycog</value>
+  </data>
+  <data name="&gt;&gt;chk_displaycog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displaycog.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displaycog.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="label10.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 502</value>
+  </data>
+  <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
+  </data>
+  <data name="label10.TabIndex" type="System.Int32, mscorlib">
+    <value>130</value>
+  </data>
+  <data name="label10.Text" xml:space="preserve">
+    <value>Aircraft Icon</value>
+  </data>
+  <data name="&gt;&gt;label10.Name" xml:space="preserve">
+    <value>label10</value>
+  </data>
+  <data name="&gt;&gt;label10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chk_displayheading.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displayheading.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_displayheading.Location" type="System.Drawing.Point, System.Drawing">
+    <value>199, 501</value>
+  </data>
+  <data name="chk_displayheading.Size" type="System.Drawing.Size, System.Drawing">
+    <value>103, 17</value>
+  </data>
+  <data name="chk_displayheading.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="chk_displayheading.Text" xml:space="preserve">
+    <value>Display Heading</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.Name" xml:space="preserve">
+    <value>chk_displayheading</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displayheading.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="chk_displaynavbearing.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displaynavbearing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_displaynavbearing.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 501</value>
+  </data>
+  <data name="chk_displaynavbearing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 17</value>
+  </data>
+  <data name="chk_displaynavbearing.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="chk_displaynavbearing.Text" xml:space="preserve">
+    <value>Display Nav Bearing</value>
+  </data>
+  <data name="&gt;&gt;chk_displaynavbearing.Name" xml:space="preserve">
+    <value>chk_displaynavbearing</value>
+  </data>
+  <data name="&gt;&gt;chk_displaynavbearing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displaynavbearing.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displaynavbearing.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="chk_displayradius.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displayradius.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_displayradius.Location" type="System.Drawing.Point, System.Drawing">
+    <value>436, 501</value>
+  </data>
+  <data name="chk_displayradius.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 17</value>
+  </data>
+  <data name="chk_displayradius.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="chk_displayradius.Text" xml:space="preserve">
+    <value>Display Turn Radius</value>
+  </data>
+  <data name="&gt;&gt;chk_displayradius.Name" xml:space="preserve">
+    <value>chk_displayradius</value>
+  </data>
+  <data name="&gt;&gt;chk_displayradius.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displayradius.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displayradius.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="chk_displaytarget.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displaytarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_displaytarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>563, 501</value>
+  </data>
+  <data name="chk_displaytarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 17</value>
+  </data>
+  <data name="chk_displaytarget.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="chk_displaytarget.Text" xml:space="preserve">
+    <value>Display Target</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.Name" xml:space="preserve">
+    <value>chk_displaytarget</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytarget.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="num_linelength.Location" type="System.Drawing.Point, System.Drawing">
+    <value>768, 500</value>
+  </data>
+  <data name="num_linelength.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 20</value>
+  </data>
+  <data name="num_linelength.TabIndex" type="System.Int32, mscorlib">
+    <value>80</value>
+  </data>
+  <data name="&gt;&gt;num_linelength.Name" xml:space="preserve">
+    <value>num_linelength</value>
+  </data>
+  <data name="&gt;&gt;num_linelength.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;num_linelength.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;num_linelength.ZOrder" xml:space="preserve">
+    <value>53</value>
+  </data>
+  <data name="label11.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
+    <value>841, 502</value>
+  </data>
+  <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 13</value>
+  </data>
+  <data name="label11.TabIndex" type="System.Int32, mscorlib">
+    <value>84</value>
+  </data>
+  <data name="label11.Text" xml:space="preserve">
+    <value>Line Length</value>
+  </data>
+  <data name="&gt;&gt;label11.Name" xml:space="preserve">
+    <value>label11</value>
+  </data>
+  <data name="&gt;&gt;label11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
+    <value>47</value>
+  </data>
+  <data name="chk_displaytooltip.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chk_displaytooltip.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chk_displaytooltip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>663, 501</value>
+  </data>
+  <data name="chk_displaytooltip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 17</value>
+  </data>
+  <data name="chk_displaytooltip.TabIndex" type="System.Int32, mscorlib">
+    <value>104</value>
+  </data>
+  <data name="chk_displaytooltip.Text" xml:space="preserve">
+    <value>Display ToolTip</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytooltip.Name" xml:space="preserve">
+    <value>chk_displaytooltip</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytooltip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytooltip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;chk_displaytooltip.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
+  <data name="CMB_mapCache.Location" type="System.Drawing.Point, System.Drawing">
+    <value>107, 653</value>
+  </data>
+  <data name="CMB_mapCache.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="CMB_mapCache.TabIndex" type="System.Int32, mscorlib">
+    <value>127</value>
+  </data>
+  <data name="&gt;&gt;CMB_mapCache.Name" xml:space="preserve">
+    <value>CMB_mapCache</value>
+  </data>
+  <data name="&gt;&gt;CMB_mapCache.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CMB_mapCache.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CMB_mapCache.ZOrder" xml:space="preserve">
+    <value>92</value>
+  </data>
+  <data name="label13.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label13.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 656</value>
+  </data>
+  <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 13</value>
+  </data>
+  <data name="label13.TabIndex" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="label13.Text" xml:space="preserve">
+    <value>Map Access Mode</value>
+  </data>
+  <data name="&gt;&gt;label13.Name" xml:space="preserve">
+    <value>label13</value>
+  </data>
+  <data name="&gt;&gt;label13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label13.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
+    <value>91</value>
+  </data>
+  <data name="BUT_mapCacheDir.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BUT_mapCacheDir.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 653</value>
+  </data>
+  <data name="BUT_mapCacheDir.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="BUT_mapCacheDir.TabIndex" type="System.Int32, mscorlib">
+    <value>95</value>
+  </data>
+  <data name="BUT_mapCacheDir.Text" xml:space="preserve">
     <value>Open Map Cache</value>
   </data>
-	<data name="&gt;&gt;BUT_mapCacheDir.Name" xml:space="preserve">
+  <data name="&gt;&gt;BUT_mapCacheDir.Name" xml:space="preserve">
     <value>BUT_mapCacheDir</value>
   </data>
-	<data name="&gt;&gt;BUT_mapCacheDir.Type" xml:space="preserve">
+  <data name="&gt;&gt;BUT_mapCacheDir.Type" xml:space="preserve">
     <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-	<data name="&gt;&gt;BUT_mapCacheDir.Parent" xml:space="preserve">
+  <data name="&gt;&gt;BUT_mapCacheDir.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-	<data name="&gt;&gt;BUT_mapCacheDir.ZOrder" xml:space="preserve">
-    <value>81</value>
+  <data name="&gt;&gt;BUT_mapCacheDir.ZOrder" xml:space="preserve">
+    <value>93</value>
+  </data>
+  <data name="CHK_rtsresetesp32.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CHK_rtsresetesp32.Location" type="System.Drawing.Point, System.Drawing">
+    <value>320, 277</value>
+  </data>
+  <data name="CHK_rtsresetesp32.Size" type="System.Drawing.Size, System.Drawing">
+    <value>251, 19</value>
+  </data>
+  <data name="CHK_rtsresetesp32.TabIndex" type="System.Int32, mscorlib">
+    <value>131</value>
+  </data>
+  <data name="CHK_rtsresetesp32.Text" xml:space="preserve">
+    <value>Disable RTS reset on ESP32 SerialUSB</value>
+  </data>
+  <data name="&gt;&gt;CHK_rtsresetesp32.Name" xml:space="preserve">
+    <value>CHK_rtsresetesp32</value>
+  </data>
+  <data name="&gt;&gt;CHK_rtsresetesp32.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CHK_rtsresetesp32.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CHK_rtsresetesp32.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>949, 693</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ConfigPlanner</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MyUserControl, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -56,7 +56,7 @@ namespace MissionPlanner
 
         public static menuicons displayicons; //do not initialize to allow update of custom icons
         public static string running_directory = Settings.GetRunningDirectory();
-        
+
         public abstract class menuicons
         {
             public abstract Image fd { get; }
@@ -212,7 +212,7 @@ namespace MissionPlanner
         public class highcontrastmenuicons : menuicons
         {
             private string running_directory = Settings.GetRunningDirectory();
-            
+
             public override Image fd
             {
                 get
@@ -723,6 +723,7 @@ namespace MissionPlanner
             // define default basestream
             comPort.BaseStream = new SerialPort();
             comPort.BaseStream.BaudRate = 57600;
+            ((SerialPort)comPort.BaseStream).espFix = Settings.Instance.GetBoolean("CHK_rtsresetesp32", false);
 
             _connectionControl = toolStripConnectionControl.ConnectionControl;
             _connectionControl.CMB_baudrate.TextChanged += this.CMB_baudrate_TextChanged;
@@ -901,7 +902,7 @@ namespace MissionPlanner
                 try
                 {
                     DisplayConfiguration = Settings.Instance.GetDisplayView("displayview");
-                    //Force new view in case of saved view in config.xml 
+                    //Force new view in case of saved view in config.xml
                     DisplayConfiguration.displayAdvancedParams = false;
                     DisplayConfiguration.displayStandardParams = false;
                     DisplayConfiguration.displayFullParamList = true;
@@ -1448,6 +1449,8 @@ namespace MissionPlanner
                         {
                             _connectionControl.CMB_serialport.Text = comPort.BaseStream.PortName;
                             _connectionControl.CMB_baudrate.Text = comPort.BaseStream.BaudRate.ToString();
+                            ((SerialPort)comPort.BaseStream).espFix = Settings.Instance.GetBoolean("CHK_rtsresetesp32", false);
+
                         }
                     });
                     break;
@@ -1513,6 +1516,8 @@ namespace MissionPlanner
                     else
                     {
                         comPort.BaseStream = new SerialPort();
+                        ((SerialPort)comPort.BaseStream).espFix = Settings.Instance.GetBoolean("CHK_rtsresetesp32", false);
+
                     }
                     break;
             }
@@ -3133,7 +3138,7 @@ namespace MissionPlanner
                 MainV2.comPort.sendPacket(packet, MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid);
 
             }
-            
+
         }
 
 
@@ -4751,6 +4756,7 @@ namespace MissionPlanner
                                 port.PortName = matches.Groups[1].Value;
                                 port.BaudRate = int.Parse(matches.Groups[2].Value);
                                 mav.BaseStream = port;
+                                ((SerialPort)mav.BaseStream).espFix = Settings.Instance.GetBoolean("CHK_rtsresetesp32", false);
                                 mav.BaseStream.Open();
                             }
                             else
@@ -4774,10 +4780,10 @@ namespace MissionPlanner
                         Comports.Add(mav);
                     });
                 }
-                
+
                 */
 
-                Parallel.ForEach(mavs, mav => 
+                Parallel.ForEach(mavs, mav =>
                 {
                     Console.WriteLine("Process connect " + mav);
                     doConnect(mav, "preset", "0", false, false);


### PR DESCRIPTION
For some weird reason the WinSerial driver coupled with the ESP32 SerialOverUSB drive changes the RTS line at connect. But only at the first connect after power up.
The fix is to set RTS/CTS handshake enable but just for the open command, and disable it immediately.
I added a new option to Planner Settings to enable this function, so it can be enabled only on when needed, and does not interfere with any other serial settings.

Note: If you once had a reset on connect, it stuck so you have to remove/reconnect the esp32 before trying again.
