### PR TITLE
Add unitType attribute to mavcmd.xml

### DIFF
--- a/ExtLibs/Xamarin/Xamarin/Resources/mavcmd.xml
+++ b/ExtLibs/Xamarin/Xamarin/Resources/mavcmd.xml
@@ -10,44 +10,17 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </WAYPOINT>
-    <SPLINE_WAYPOINT>
-      <P1>Delay</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </SPLINE_WAYPOINT>
-    <LOITER_TURNS>
-      <P1>Turns</P1>
-      <P2></P2>
-      <P3>Radius</P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </LOITER_TURNS>
-    <LOITER_TIME>
-      <P1>Time s</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </LOITER_TIME>
-    <LOITER_UNLIM>
+    <TAKEOFF>
       <P1></P1>
       <P2></P2>
       <P3></P3>
       <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </LOITER_UNLIM>
+      <X></X>
+      <Y></Y>
+      <Z unitType="alt">Alt</Z>
+    </TAKEOFF>
     <RETURN_TO_LAUNCH>
       <P1></P1>
       <P2></P2>
@@ -57,24 +30,15 @@
       <Y></Y>
       <Z></Z>
     </RETURN_TO_LAUNCH>
-    <LAND>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </LAND>
-    <TAKEOFF>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
+    <ATTITUDE_TIME>
+      <P1>Time (sec)</P1>
+      <P2>Roll</P2>
+      <P3>Pitch</P3>
+      <P4>Yaw</P4>
+      <X>ClimbRate</X>
       <Y></Y>
-      <Z>Alt</Z>
-    </TAKEOFF>
+      <Z></Z>
+    </ATTITUDE_TIME>
     <DELAY>
       <P1>Seconds (or -1)</P1>
       <P2>Hour UTC (or -1)</P2>
@@ -93,6 +57,42 @@
       <Y></Y>
       <Z></Z>
     </GUIDED_ENABLE>
+    <LAND>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </LAND>
+    <LOITER_TIME>
+      <P1>Time s</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </LOITER_TIME>
+    <LOITER_TURNS>
+      <P1>Turns</P1>
+      <P2></P2>
+      <P3>Radius</P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </LOITER_TURNS>
+    <LOITER_UNLIM>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </LOITER_UNLIM>
     <PAYLOAD_PLACE>
       <P1>max descent</P1>
       <P2></P2>
@@ -100,82 +100,109 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </PAYLOAD_PLACE>
-    <DO_GUIDED_LIMITS>
-      <P1>timeout S</P1>
-      <P2>min alt</P2>
-      <P3>max alt</P3>
-      <P4>max dist</P4>
+    <SCRIPT_TIME>
+      <P1>command</P1>
+      <P2>timeout</P2>
+      <P3>arg1</P3>
+      <P4>arg2</P4>
+      <X>arg3</X>
+      <Y>arg4</Y>
+      <Z></Z>
+    </SCRIPT_TIME>
+    <DO_SEND_SCRIPT_MESSAGE>
+      <P1>ID</P1>
+      <P2>P1</P2>
+      <P3>P2</P3>
+      <P4>P3</P4>
       <X></X>
       <Y></Y>
       <Z></Z>
-    </DO_GUIDED_LIMITS>
-    <DO_WINCH>
-      <P1>winch no</P1>
-      <P2>action</P2>
-      <P3>length</P3>
-      <P4>rate</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_WINCH>
-    <DO_SET_ROI>
-      <P1></P1>
+    </DO_SEND_SCRIPT_MESSAGE>
+    <SPLINE_WAYPOINT>
+      <P1>Delay</P1>
       <P2></P2>
       <P3></P3>
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
-    </DO_SET_ROI>
-    <CONDITION_DELAY>
-      <P1>Time (sec)</P1>
+      <Z unitType="alt">Alt</Z>
+    </SPLINE_WAYPOINT>
+    <IMAGE_START_CAPTURE>
+      <P1>Id</P1>
+      <P2>Interval</P2>
+      <P3>Total Images</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_START_CAPTURE>
+    <IMAGE_STOP_CAPTURE>
+      <P1>Id</P1>
       <P2></P2>
       <P3></P3>
       <P4></P4>
       <X></X>
       <Y></Y>
       <Z></Z>
-    </CONDITION_DELAY>
-    <CONDITION_CHANGE_ALT>
-      <P1>Rate (cm/sec)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z>Alt</Z>
-    </CONDITION_CHANGE_ALT>
-    <CONDITION_DISTANCE>
-      <P1>Dist (m)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </CONDITION_DISTANCE>
-    <CONDITION_YAW>
-      <P1>Deg</P1>
-      <P2>Sec</P2>
-      <P3>Dir 1=CW</P3>
-      <P4>rel/abs</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </CONDITION_YAW>
-    <DO_JUMP>
-      <P1>WP #</P1>
-      <P2>Repeat#</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_JUMP>
-    <DO_CHANGE_SPEED>
+    </IMAGE_STOP_CAPTURE>
+    <SET_CAMERA_ZOOM>
       <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_ZOOM>
+    <SET_CAMERA_FOCUS>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_FOCUS>
+    <SET_CAMERA_SOURCE>
+      <P1>Id</P1>
+      <P2>Primary(1:RGB,2:IR,3:NDVI,4:Wide)</P2>
+      <P3>Secondary(1:RGB,2:IR,3:NDVI,4:Wide)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_SOURCE>
+    <VIDEO_START_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_START_CAPTURE>
+    <VIDEO_STOP_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_STOP_CAPTURE>
+    <DO_AUX_FUNCTION>
+      <P1>AuxFunction</P1>
+      <P2>SwitchPosition</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_AUX_FUNCTION>
+    <DO_CHANGE_SPEED>
+      <P1>Type (0:horiz,2:up,3:down)</P1>
       <P2>Speed m/s</P2>
       <P3></P3>
       <P4></P4>
@@ -183,6 +210,42 @@
       <Y></Y>
       <Z></Z>
     </DO_CHANGE_SPEED>
+    <DO_DIGICAM_CONFIGURE>
+      <P1>Mode</P1>
+      <P2>Shutter Speed</P2>
+      <P3>Aperture</P3>
+      <P4>ISO</P4>
+      <X>ExposureMode</X>
+      <Y>CommandID</Y>
+      <Z></Z>
+    </DO_DIGICAM_CONFIGURE>
+    <DO_DIGICAM_CONTROL>
+      <P1>Session Control</P1>
+      <P2>Zoom Position</P2>
+      <P3>Zoom Step</P3>
+      <P4>Focus Lock</P4>
+      <X>Shutter Cmd</X>
+      <Y>CommandID</Y>
+      <Z></Z>
+    </DO_DIGICAM_CONTROL>
+    <DO_ENGINE_CONTROL>
+      <P1>Start Engine</P1>
+      <P2>Cold Start</P2>
+      <P3>Height Delay</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_ENGINE_CONTROL>
+    <DO_GIMBAL_MANAGER_PITCHYAW>
+      <P1>Pitch Angle</P1>
+      <P2>Yaw Angle</P2>
+      <P3>Pitch Rate</P3>
+      <P4>Yaw Rate</P4>
+      <X>Flags</X>
+      <Y></Y>
+      <Z>Gimbal Id</Z>
+    </DO_GIMBAL_MANAGER_PITCHYAW>
     <DO_GRIPPER>
       <P1>Gripper No</P1>
       <P2>drop(0)/grab(1)</P2>
@@ -192,6 +255,60 @@
       <Y></Y>
       <Z></Z>
     </DO_GRIPPER>
+    <DO_GUIDED_LIMITS>
+      <P1>timeout S</P1>
+      <P2>min alt</P2>
+      <P3>max alt</P3>
+      <P4>max dist</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_GUIDED_LIMITS>
+    <DO_JUMP>
+      <P1>WP #</P1>
+      <P2>Repeat#</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP>
+    <JUMP_TAG>
+      <P1>Tag</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </JUMP_TAG>
+    <DO_JUMP_TAG>
+      <P1>Tag</P1>
+      <P2>Repeat</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP_TAG>
+    <DO_LAND_START>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_LAND_START>
+    <DO_MOUNT_CONTROL>
+      <P1>Pitch</P1>
+      <P2>Roll</P2>
+      <P3>Yaw</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_MOUNT_CONTROL>
     <DO_PARACHUTE>
       <P1>Enable(1)/Release(2)</P1>
       <P2></P2>
@@ -201,6 +318,24 @@
       <Y></Y>
       <Z></Z>
     </DO_PARACHUTE>
+    <DO_REPEAT_RELAY>
+      <P1>Relay No</P1>
+      <P2>Repeat#</P2>
+      <P3>Delay (s)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_REPEAT_RELAY>
+    <DO_REPEAT_SERVO>
+      <P1>Ser No</P1>
+      <P2>PWM</P2>
+      <P3>Repeat#</P3>
+      <P4>Delay (s)</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_REPEAT_SERVO>
     <DO_SET_CAM_TRIGG_DIST>
       <P1>Dist (m)</P1>
       <P2></P2>
@@ -219,15 +354,24 @@
       <Y></Y>
       <Z></Z>
     </DO_SET_RELAY>
-    <DO_REPEAT_RELAY>
-      <P1>Relay No</P1>
-      <P2>Repeat#</P2>
-      <P3>Delay (s)</P3>
+    <DO_SET_RESUME_REPEAT_DIST>
+      <P1>Distance(m)</P1>
+      <P2></P2>
+      <P3></P3>
       <P4></P4>
       <X></X>
       <Y></Y>
       <Z></Z>
-    </DO_REPEAT_RELAY>
+    </DO_SET_RESUME_REPEAT_DIST>   
+    <DO_SET_ROI>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </DO_SET_ROI>
     <DO_SET_SERVO>
       <P1>Ser No</P1>
       <P2>PWM</P2>
@@ -237,43 +381,51 @@
       <Y></Y>
       <Z></Z>
     </DO_SET_SERVO>
-    <DO_REPEAT_SERVO>
-      <P1>Ser No</P1>
-      <P2>PWM</P2>
-      <P3>Repeat#</P3>
-      <P4>Delay (s)</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_REPEAT_SERVO>
-    <DO_DIGICAM_CONFIGURE>
-      <P1>Mode</P1>
-      <P2>Shutter Speed</P2>
-      <P3>Aperture</P3>
-      <P4>ISO</P4>
-      <X>ExposureMode</X>
-      <Y>CommandID</Y>
-      <Z></Z>
-    </DO_DIGICAM_CONFIGURE>
-    <DO_DIGICAM_CONTROL>
-      <P1>On/Off</P1>
-      <P2>Zoom Position</P2>
-      <P3>Zoom Step</P3>
-      <P4>Focus Lock</P4>
-      <X>Shutter Cmd</X>
-      <Y>CommandID</Y>
-      <Z></Z>
-    </DO_DIGICAM_CONTROL>
-    <DO_MOUNT_CONTROL>
-      <P1>Pitch</P1>
-      <P2>Roll</P2>
-      <P3>Yaw</P3>
+    <DO_SPRAYER>
+      <P1>Sprayer Enable</P1>
+      <P2></P2>
+      <P3></P3>
       <P4></P4>
       <X></X>
       <Y></Y>
       <Z></Z>
-    </DO_MOUNT_CONTROL>
-
+    </DO_SPRAYER>
+    <DO_WINCH>
+      <P1>winch no</P1>
+      <P2>action</P2>
+      <P3>length</P3>
+      <P4>rate</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_WINCH>
+    <CONDITION_DELAY>
+      <P1>Time (sec)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </CONDITION_DELAY>
+    <CONDITION_DISTANCE>
+      <P1>Dist (m)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </CONDITION_DISTANCE>
+    <CONDITION_YAW>
+      <P1>Deg</P1>
+      <P2>Speed deg/s</P2>
+      <P3>Dir 1=CW</P3>
+      <P4>0=Abs,1=Rel</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </CONDITION_YAW>
   </AC2>
   <!-- -->
   <APM>
@@ -284,7 +436,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </WAYPOINT>
     <LOITER_UNLIM>
       <P1></P1>
@@ -293,7 +445,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_UNLIM>
     <LOITER_TURNS>
       <P1>Turns</P1>
@@ -302,7 +454,7 @@
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TURNS>
     <LOITER_TIME>
       <P1>Time s</P1>
@@ -311,7 +463,7 @@
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TIME>
     <LOITER_TO_ALT>
       <P1></P1>
@@ -320,7 +472,7 @@
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TO_ALT>
     <RETURN_TO_LAUNCH>
       <P1></P1>
@@ -338,7 +490,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LAND>
     <TAKEOFF>
       <P1>Pitch Angle</P1>
@@ -347,8 +499,17 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </TAKEOFF>
+    <DELAY>
+      <P1>Seconds (or -1)</P1>
+      <P2>Hour UTC (or -1)</P2>
+      <P3>Minute UTC (or -1)</P3>
+      <P4>Second UTC</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DELAY>
     <VTOL_TAKEOFF>
       <P1></P1>
       <P2></P2>
@@ -356,7 +517,7 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </VTOL_TAKEOFF>
     <VTOL_LAND>
       <P1></P1>
@@ -365,15 +526,24 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </VTOL_LAND>
+    <PAYLOAD_PLACE>
+      <P1>max descent</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </PAYLOAD_PLACE>
     <SCRIPT_TIME>
       <P1>commandId</P1>
       <P2>timeout</P2>
       <P3>arg1</P3>
       <P4>arg2</P4>
-      <X></X>
-      <Y></Y>
+      <X>arg3</X>
+      <Y>arg4</Y>
       <Z></Z>
     </SCRIPT_TIME>
     <DO_SEND_SCRIPT_MESSAGE>
@@ -394,6 +564,78 @@
       <Y></Y>
       <Z></Z>
     </DO_VTOL_TRANSITION>
+    <IMAGE_START_CAPTURE>
+      <P1>Id</P1>
+      <P2>Interval</P2>
+      <P3>Total Images</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_START_CAPTURE>
+    <IMAGE_STOP_CAPTURE>
+      <P1>Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_STOP_CAPTURE>
+    <SET_CAMERA_ZOOM>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_ZOOM>
+    <SET_CAMERA_FOCUS>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_FOCUS>
+    <SET_CAMERA_SOURCE>
+      <P1>Id</P1>
+      <P2>Primary(1:RGB,2:IR,3:NDVI,4:Wide)</P2>
+      <P3>Secondary(1:RGB,2:IR,3:NDVI,4:Wide)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_SOURCE>
+    <VIDEO_START_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_START_CAPTURE>
+    <VIDEO_STOP_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_STOP_CAPTURE>
+    <DO_AUX_FUNCTION>
+      <P1>AuxFunction</P1>
+      <P2>SwitchPosition</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_AUX_FUNCTION>
     <ALTITUDE_WAIT>
       <P1>Alt</P1>
       <P2>Descent rate</P2>
@@ -410,7 +652,7 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </CONTINUE_AND_CHANGE_ALT>
     <CONDITION_DELAY>
       <P1>Time (sec)</P1>
@@ -439,6 +681,15 @@
       <Y></Y>
       <Z></Z>
     </CONDITION_YAW>
+    <DO_GRIPPER>
+      <P1>Gripper No</P1>
+      <P2>drop(0)/grab(1)</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_GRIPPER>
     <DO_LAND_START>
       <P1></P1>
       <P2></P2>
@@ -455,7 +706,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
     <DO_INVERTED_FLIGHT>
       <P1>0=normal, 1=inverted</P1>
@@ -466,15 +717,6 @@
       <Y></Y>
       <Z></Z>
     </DO_INVERTED_FLIGHT>
-    <DO_SET_MODE>
-      <P1>mode #</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_MODE>
     <DO_SET_CAM_TRIGG_DIST>
       <P1>Dist (m)</P1>
       <P2></P2>
@@ -493,6 +735,24 @@
       <Y></Y>
       <Z></Z>
     </DO_JUMP>
+    <JUMP_TAG>
+      <P1>Tag</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </JUMP_TAG>
+    <DO_JUMP_TAG>
+      <P1>Tag</P1>
+      <P2>Repeat</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP_TAG>
     <DO_CHANGE_SPEED>
       <P1>Type (0=as 1=gs)</P1>
       <P2>Speed (m/s)</P2>
@@ -509,7 +769,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </DO_SET_HOME>
     <DO_SET_RELAY>
       <P1>Relay No</P1>
@@ -557,7 +817,7 @@
       <Z></Z>
     </DO_DIGICAM_CONFIGURE>
     <DO_DIGICAM_CONTROL>
-      <P1>On/Off</P1>
+      <P1>Session Control</P1>
       <P2>Zoom Position</P2>
       <P3>Zoom Step</P3>
       <P4>Focus Lock</P4>
@@ -565,15 +825,6 @@
       <Y>CommandID</Y>
       <Z></Z>
     </DO_DIGICAM_CONTROL>
-    <DO_MOUNT_CONFIGURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_MOUNT_CONFIGURE>
     <DO_MOUNT_CONTROL>
       <P1>Pitch</P1>
       <P2>Roll</P2>
@@ -583,6 +834,15 @@
       <Y></Y>
       <Z></Z>
     </DO_MOUNT_CONTROL>
+    <DO_GIMBAL_MANAGER_PITCHYAW>
+      <P1>Pitch Angle</P1>
+      <P2>Yaw Angle</P2>
+      <P3>Pitch Rate</P3>
+      <P4>Yaw Rate</P4>
+      <X>Flags</X>
+      <Y></Y>
+      <Z>Gimbal Id</Z>
+    </DO_GIMBAL_MANAGER_PITCHYAW>
     <DO_PARACHUTE>
       <P1>Enable(1)/Release(2)</P1>
       <P2></P2>
@@ -601,6 +861,42 @@
       <Y></Y>
       <Z></Z>
     </DO_FENCE_ENABLE>
+    <DO_SPRAYER>
+      <P1>Sprayer Enable</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SPRAYER>
+    <DO_AUTOTUNE_ENABLE>
+      <P1>enable</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_AUTOTUNE_ENABLE>
+    <DO_ENGINE_CONTROL>
+      <P1>Start Engine</P1>
+      <P2>Cold Start</P2>
+      <P3>Height Delay</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_ENGINE_CONTROL>
+    <DO_SET_RESUME_REPEAT_DIST>
+      <P1>Distance(m)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_RESUME_REPEAT_DIST>
   </APM>
   <!-- -->
   <APRover>
@@ -611,35 +907,332 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </WAYPOINT>
-    <LOITER_UNLIM>
+    <RETURN_TO_LAUNCH>
       <P1></P1>
       <P2></P2>
-      <P3>Dir 1=CW</P3>
+      <P3></P3>
       <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </LOITER_UNLIM>
-    <LOITER_TIME>
-      <P1>Time s</P1>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </RETURN_TO_LAUNCH>
+    <DELAY>
+      <P1>Seconds (or -1)</P1>
+      <P2>Hour UTC (or -1)</P2>
+      <P3>Minute UTC (or -1)</P3>
+      <P4>Second UTC</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DELAY>
+    <GUIDED_ENABLE>
+      <P1>on=1/off=0</P1>
       <P2></P2>
-      <P3>Dir 1=CW</P3>
+      <P3></P3>
       <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </LOITER_TIME>
-    <RETURN_TO_LAUNCH>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </GUIDED_ENABLE>
+    <LOITER_UNLIM>
       <P1></P1>
       <P2></P2>
       <P3></P3>
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
-    </RETURN_TO_LAUNCH>
+      <Z unitType="alt">Alt</Z>
+    </LOITER_UNLIM>
+    <LOITER_TURNS>
+      <P1>Turns</P1>
+      <P2></P2>
+      <P3>Radius</P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </LOITER_TURNS>
+    <LOITER_TIME>
+      <P1>Time s</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </LOITER_TIME>
+    <SCRIPT_TIME>
+      <P1>command</P1>
+      <P2>timeout</P2>
+      <P3>arg1</P3>
+      <P4>arg2</P4>
+      <X>arg3</X>
+      <Y>arg4</Y>
+      <Z></Z>
+    </SCRIPT_TIME>
+    <DO_SEND_SCRIPT_MESSAGE>
+      <P1>ID</P1>
+      <P2>P1</P2>
+      <P3>P2</P3>
+      <P4>P3</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SEND_SCRIPT_MESSAGE>
+    <SET_YAW_SPEED>
+      <P1>angle(CD)</P1>
+      <P2>Speed(0..1)</P2>
+      <P3>0=Abs,1=Rel</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_YAW_SPEED>
+    <IMAGE_START_CAPTURE>
+      <P1>Id</P1>
+      <P2>Interval</P2>
+      <P3>Total Images</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_START_CAPTURE>
+    <IMAGE_STOP_CAPTURE>
+      <P1>Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </IMAGE_STOP_CAPTURE>
+    <SET_CAMERA_ZOOM>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_ZOOM>
+    <SET_CAMERA_FOCUS>
+      <P1>Type</P1>
+      <P2>Value</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_FOCUS>
+    <SET_CAMERA_SOURCE>
+      <P1>Id</P1>
+      <P2>Primary(1:RGB,2:IR,3:NDVI,4:Wide)</P2>
+      <P3>Secondary(1:RGB,2:IR,3:NDVI,4:Wide)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </SET_CAMERA_SOURCE>
+    <VIDEO_START_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_START_CAPTURE>
+    <VIDEO_STOP_CAPTURE>
+      <P1>StreamId</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </VIDEO_STOP_CAPTURE>
+    <DO_AUX_FUNCTION>
+      <P1>AuxFunction</P1>
+      <P2>SwitchPosition</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_AUX_FUNCTION>
+    <DO_CHANGE_SPEED>
+      <P1></P1>
+      <P2>Speed (m/s)</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_CHANGE_SPEED>
+    <DO_DIGICAM_CONFIGURE>
+      <P1>Mode</P1>
+      <P2>Shutter Speed</P2>
+      <P3>Aperture</P3>
+      <P4>ISO</P4>
+      <X>ExposureMode</X>
+      <Y>CommandID</Y>
+      <Z></Z>
+    </DO_DIGICAM_CONFIGURE>
+    <DO_DIGICAM_CONTROL>
+      <P1>Session Control</P1>
+      <P2>Zoom Position</P2>
+      <P3>Zoom Step</P3>
+      <P4>Focus Lock</P4>
+      <X>Shutter Cmd</X>
+      <Y>CommandID</Y>
+      <Z></Z>
+    </DO_DIGICAM_CONTROL>
+    <DO_GIMBAL_MANAGER_PITCHYAW>
+      <P1>Pitch Angle</P1>
+      <P2>Yaw Angle</P2>
+      <P3>Pitch Rate</P3>
+      <P4>Yaw Rate</P4>
+      <X>Flags</X>
+      <Y></Y>
+      <Z>Gimbal Id</Z>
+    </DO_GIMBAL_MANAGER_PITCHYAW>
+    <DO_GRIPPER>
+      <P1>Gripper No</P1>
+      <P2>drop(0)/grab(1)</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_GRIPPER>
+    <DO_JUMP>
+      <P1>WP #</P1>
+      <P2>Repeat#</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP>
+    <JUMP_TAG>
+      <P1>Tag</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </JUMP_TAG>
+    <DO_JUMP_TAG>
+      <P1>Tag</P1>
+      <P2>Repeat</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_JUMP_TAG>
+    <DO_GUIDED_LIMITS>
+      <P1>timeout S</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4>max dist</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_GUIDED_LIMITS>
+    <DO_MOUNT_CONTROL>
+      <P1>Pitch</P1>
+      <P2>Roll</P2>
+      <P3>Yaw</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_MOUNT_CONTROL>
+    <DO_REPEAT_RELAY>
+      <P1>Relay No</P1>
+      <P2>Repeat#</P2>
+      <P3>Delay (s)</P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_REPEAT_RELAY>
+    <DO_REPEAT_SERVO>
+      <P1>Ser No</P1>
+      <P2>PWM</P2>
+      <P3>Repeat#</P3>
+      <P4>Delay (s)</P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_REPEAT_SERVO>
+    <DO_SET_CAM_TRIGG_DIST>
+      <P1>Dist (m)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_CAM_TRIGG_DIST>
+    <DO_SET_RELAY>
+      <P1>Relay No</P1>
+      <P2>off(0)/on(1)</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_RELAY>
+    <DO_SET_RESUME_REPEAT_DIST>
+      <P1>Distance(m)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_RESUME_REPEAT_DIST>
+    <DO_SET_REVERSE>
+      <P1>Direction (0=F,1=R)</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_REVERSE>
+    <DO_SET_ROI>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </DO_SET_ROI>
+    <DO_SET_SERVO>
+      <P1>Ser No</P1>
+      <P2>PWM</P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_SERVO>
+    <DO_SPRAYER>
+      <P1>Sprayer Enable</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SPRAYER>
     <CONDITION_DELAY>
       <P1>Time (sec)</P1>
       <P2></P2>
@@ -658,167 +1251,5 @@
       <Y></Y>
       <Z></Z>
     </CONDITION_DISTANCE>
-    <SET_YAW_SPEED>
-      <P1>angle(CD)</P1>
-      <P2>Speed(0..1)</P2>
-      <P3>0=Abs,1=Rel</P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </SET_YAW_SPEED>
-    <DELAY>
-      <P1>Seconds (or -1)</P1>
-      <P2>Hour UTC (or -1)</P2>
-      <P3>Minute UTC (or -1)</P3>
-      <P4>Second UTC</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DELAY>
-    <DO_GRIPPER>
-      <P1>Gripper No</P1>
-      <P2>drop(0)/grab(1)</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_GRIPPER>
-    <DO_SET_ROI>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </DO_SET_ROI>
-    <DO_SET_REVERSE>
-      <P1>Direction (0=F,1=R)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_REVERSE>
-    <DO_SET_MODE>
-      <P1>mode#</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_MODE>
-    <DO_SET_CAM_TRIGG_DIST>
-      <P1>Dist (m)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_CAM_TRIGG_DIST>
-    <DO_JUMP>
-      <P1>WP #</P1>
-      <P2>Repeat#</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_JUMP>
-    <DO_CHANGE_SPEED>
-      <P1>Type (0=as 1=gs)</P1>
-      <P2>Speed (m/s)</P2>
-      <P3>Throttle(%)</P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_CHANGE_SPEED>
-    <DO_SET_HOME>
-      <P1>Current(1)/Spec(0)</P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X>Lat</X>
-      <Y>Long</Y>
-      <Z>Alt</Z>
-    </DO_SET_HOME>
-    <DO_SET_RELAY>
-      <P1>Relay No</P1>
-      <P2>off(0)/on(1)</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_RELAY>
-    <DO_REPEAT_RELAY>
-      <P1>Relay No</P1>
-      <P2>Repeat#</P2>
-      <P3>Delay (s)</P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_REPEAT_RELAY>
-    <DO_SET_SERVO>
-      <P1>Ser No</P1>
-      <P2>PWM</P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_SET_SERVO>
-    <DO_REPEAT_SERVO>
-      <P1>Ser No</P1>
-      <P2>PWM</P2>
-      <P3>Repeat#</P3>
-      <P4>Delay (s)</P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_REPEAT_SERVO>
-    <DO_DIGICAM_CONFIGURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_DIGICAM_CONFIGURE>
-    <DO_DIGICAM_CONTROL>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_DIGICAM_CONTROL>
-    <DO_MOUNT_CONFIGURE>
-      <P1></P1>
-      <P2></P2>
-      <P3></P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_MOUNT_CONFIGURE>
-    <DO_MOUNT_CONTROL>
-      <P1>Pitch</P1>
-      <P2>Roll</P2>
-      <P3>Yaw</P3>
-      <P4></P4>
-      <X></X>
-      <Y></Y>
-      <Z></Z>
-    </DO_MOUNT_CONTROL>
   </APRover>
 </CMD>

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -661,7 +661,7 @@ namespace MissionPlanner.GCSViews
                 home.id = (ushort) MAVLink.MAV_CMD.WAYPOINT;
                 home.lat = (double.Parse(TXT_homelat.Text));
                 home.lng = (double.Parse(TXT_homelng.Text));
-                home.alt = (float.Parse(TXT_homealt.Text) / CurrentState.multiplierdist); // use saved home
+                home.alt = (float.Parse(TXT_homealt.Text) / CurrentState.multiplieralt); // use saved home
             }
             catch
             {
@@ -1424,8 +1424,8 @@ namespace MissionPlanner.GCSViews
 
                         wpOverlay.CreateOverlay(home,
                             commandlist,
-                            double.Parse(TXT_WPRad.Text) / CurrentState.multiplieralt,
-                            double.Parse(TXT_loiterrad.Text) / CurrentState.multiplieralt, CurrentState.multiplieralt);
+                            double.Parse(TXT_WPRad.Text) / CurrentState.multiplierdist,
+                            double.Parse(TXT_loiterrad.Text) / CurrentState.multiplierdist, CurrentState.multiplieralt);
                     }
                     catch (FormatException)
                     {

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -10,7 +10,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </WAYPOINT>
     <TAKEOFF>
       <P1></P1>
@@ -19,7 +19,7 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </TAKEOFF>
     <RETURN_TO_LAUNCH>
       <P1></P1>
@@ -64,7 +64,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LAND>
     <LOITER_TIME>
       <P1>Time s</P1>
@@ -73,7 +73,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TIME>
     <LOITER_TURNS>
       <P1>Turns</P1>
@@ -82,7 +82,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TURNS>
     <LOITER_UNLIM>
       <P1></P1>
@@ -91,7 +91,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_UNLIM>
     <PAYLOAD_PLACE>
       <P1>max descent</P1>
@@ -100,7 +100,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </PAYLOAD_PLACE>
     <SCRIPT_TIME>
       <P1>command</P1>
@@ -127,7 +127,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </SPLINE_WAYPOINT>
     <IMAGE_START_CAPTURE>
       <P1>Id</P1>
@@ -370,7 +370,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
     <DO_SET_SERVO>
       <P1>Ser No</P1>
@@ -436,7 +436,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </WAYPOINT>
     <LOITER_UNLIM>
       <P1></P1>
@@ -445,7 +445,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_UNLIM>
     <LOITER_TURNS>
       <P1>Turns</P1>
@@ -454,7 +454,7 @@
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TURNS>
     <LOITER_TIME>
       <P1>Time s</P1>
@@ -463,7 +463,7 @@
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TIME>
     <LOITER_TO_ALT>
       <P1></P1>
@@ -472,7 +472,7 @@
       <P4>1=Exit Tangent</P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TO_ALT>
     <RETURN_TO_LAUNCH>
       <P1></P1>
@@ -490,7 +490,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LAND>
     <TAKEOFF>
       <P1>Pitch Angle</P1>
@@ -499,7 +499,7 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </TAKEOFF>
     <DELAY>
       <P1>Seconds (or -1)</P1>
@@ -517,7 +517,7 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </VTOL_TAKEOFF>
     <VTOL_LAND>
       <P1></P1>
@@ -526,7 +526,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </VTOL_LAND>
     <PAYLOAD_PLACE>
       <P1>max descent</P1>
@@ -535,7 +535,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </PAYLOAD_PLACE>
     <SCRIPT_TIME>
       <P1>commandId</P1>
@@ -652,7 +652,7 @@
       <P4></P4>
       <X></X>
       <Y></Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </CONTINUE_AND_CHANGE_ALT>
     <CONDITION_DELAY>
       <P1>Time (sec)</P1>
@@ -706,7 +706,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
     <DO_INVERTED_FLIGHT>
       <P1>0=normal, 1=inverted</P1>
@@ -769,7 +769,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </DO_SET_HOME>
     <DO_SET_RELAY>
       <P1>Relay No</P1>
@@ -907,7 +907,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </WAYPOINT>
     <RETURN_TO_LAUNCH>
       <P1></P1>
@@ -943,7 +943,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_UNLIM>
     <LOITER_TURNS>
       <P1>Turns</P1>
@@ -952,7 +952,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TURNS>
     <LOITER_TIME>
       <P1>Time s</P1>
@@ -961,7 +961,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </LOITER_TIME>
     <SCRIPT_TIME>
       <P1>command</P1>
@@ -1213,7 +1213,7 @@
       <P4></P4>
       <X>Lat</X>
       <Y>Long</Y>
-      <Z>Alt</Z>
+      <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
     <DO_SET_SERVO>
       <P1>Ser No</P1>


### PR DESCRIPTION
This fixes an issue where commands that used the <Z> parameter for anything other than altitude were getting unit conversions applied when they shouldn't have been. I'm also adding a unit label to the altitude column.

This also opens up the possibility of converting units (distance or altitude) for other columns, which I'll do next, probably as part of this PR, but I haven't gotten that far yet.

This will take some careful review to make sure I haven't screwed things up. I looked long and hard at all the places in FlightData that look at `multiplieralt`, but I could have missed something. I've done some basic testing, and it appears to be working.

One thing I noticed is that we don't seem to updata `mavcmd.xml` when we update Planner. If the file exists, we don't overwrite it with the one baked into the resources, which seems to be a problem IMO. Someone running Planner that was installed ages ago might not have up-to-date mavcmds, unless I'm mistaken. I can understand not wanting to immediately clobber a customized file, but we have other paths to add custom mission items in config.xml. I made sure to try to handle legacy files just in case.