### PR TITLE
FlightData: allow plugin tab visibility to persist

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -758,8 +758,6 @@ namespace MissionPlanner.GCSViews
             }
 
             ThemeManager.ApplyThemeTo(tabControlactions);
-
-            saveTabControlActions();
         }
 
         internal void BUT_run_script_Click(object sender, EventArgs e)


### PR DESCRIPTION
This addition of `saveTabControlActions` here means that users cannot save their visibility preferences for the plugin-added tabs. Plugin tabs don't exist when this first gets called, so their visibility settings get wiped out on startup. 

Currently, plugins have to do one of the following:
1. Force the tab on every time, making the user disable the plugin to hide the tab
2. Force the user to unhide the tab every time
3. Make a redundant setting to watch the `tabcontrolactions` setting and save a backup of the user's preference to restore later.

Removing this line should have no negative impacts.