### PR TITLE
ExternsionsMP: fix ShowUserControl minimize bug

### DIFF
--- a/Utilities/ExtensionsMP.cs
+++ b/Utilities/ExtensionsMP.cs
@@ -135,8 +135,8 @@ namespace MissionPlanner.Utilities
             var frm = ctl.Tag as Form;
             if (frm == null)
                 return;
-
-            frm.ClientSize = ctl.ClientSize;
+            if (frm.WindowState == FormWindowState.Normal)
+                frm.ClientSize = ctl.ClientSize;
         }
 
         private static void Frm_Closing(object sender, System.ComponentModel.CancelEventArgs e)


### PR DESCRIPTION
When minimizing a form generated by ShowUserControl, the client size gets set to 0, which causes issues when the form is restored. The easiest place to see this is the Joystick config window, but that has a minimum size; it's much worse on things that don't have a minimum size, like the bitmask parameter popup.

Sizes should only be copied when the window state is normal.