### PR TITLE
Fix popout StartupLocation bug

### DIFF
--- a/ExtLibs/Controls/ControlHelpers.cs
+++ b/ExtLibs/Controls/ControlHelpers.cs
@@ -45,7 +45,7 @@ namespace MissionPlanner.Controls
         /// <param name="control">Control to save the settings for</param>
         public static void SaveStartupLocation(this Form control)
         {
-            Settings.Instance[control.Text.Replace(" ", "_") + "_StartLocation"] = new FormStartLocation {Location = control.Location, Size = control.Size, State = control.WindowState}.ToJSON();
+            Settings.Instance[control.Text.Replace(" ", "_") + "_StartLocation"] = new FormStartLocation {Location = control.RestoreBounds.Location, Size = control.RestoreBounds.Size, State = control.WindowState}.ToJSON();
         }
 
         /// <summary>

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -3227,6 +3227,7 @@ namespace MissionPlanner.GCSViews
         {
             EKFStatus frm = new EKFStatus();
             frm.RestoreStartupLocation();
+            frm.WindowState = FormWindowState.Normal;
             frm.FormClosed += (a, e2) => frm.SaveStartupLocation();
             frm.TopMost = true;
             frm.Show();
@@ -3248,6 +3249,7 @@ namespace MissionPlanner.GCSViews
         {
             Vibration frm = new Vibration();
             frm.RestoreStartupLocation();
+            frm.WindowState = FormWindowState.Normal;
             frm.FormClosed += (a, e2) => frm.SaveStartupLocation();
             frm.TopMost = true;
             frm.Show();
@@ -3257,6 +3259,7 @@ namespace MissionPlanner.GCSViews
         {
             PrearmStatus frm = new PrearmStatus();
             frm.RestoreStartupLocation();
+            frm.WindowState = FormWindowState.Normal;
             frm.FormClosed += (a, e2) => frm.SaveStartupLocation();
             frm.TopMost = true;
             frm.Show();


### PR DESCRIPTION
There is a bug where a user can be persistently stuck with a full-screen sized, or a zero sized, EKF status window (or Vibe or PreArm messages windows). We don't allow the user to resize these windows, so the only way to fix it is with config.xml hacking (or deleting).

We hide the minimize/maximize buttons on these windows, but they can still be minimized or maximized in multiple ways: keyboard shortcut, double-clicking the titlebar, or from the context menu on the title bar. If the user does this, and then closes the window before restoring it, the size gets saved and it cannot be fixed through the UI.

This PR fixes this by saving the location and size of the `RestoreBounds` of the form, instead of the literal size.

Additionally I made the EKF/Vibe/PreArm windows always open in normal state, regardless of the state they were in when they closed.