### PR TITLE
ThemeManager: auto theme child classes of MyButton

### DIFF
--- a/Controls/GimbalControlSettingsForm.cs
+++ b/Controls/GimbalControlSettingsForm.cs
@@ -20,11 +20,10 @@ namespace MissionPlanner.Controls
         {
             InitializeComponent();
 
-            ThemeManager.ApplyThemeTo(this);
-
             this.preferences = new GimbalControlSettings(preferences);
-
             LoadPreferences();
+
+            ThemeManager.ApplyThemeTo(this);
         }
 
         private void LoadPreferences()

--- a/Utilities/ThemeManager.cs
+++ b/Utilities/ThemeManager.cs
@@ -1147,9 +1147,8 @@ mc:Ignorable=""d""
                     ctl.ForeColor = Color.Black;
                     ctl.BackColor = ButBG;
                 }
-                else if (ctl.GetType() == typeof(MyButton))
+                else if (ctl is MyButton but)
                 {
-                    Controls.MyButton but = (MyButton)ctl;
                     but.BGGradTop = ButBG;
                     but.BGGradBot = ButBGBot;
                     but.TextColor = ButtonTextColor;


### PR DESCRIPTION
Michael brought this up during #3386, but I didn't get around to fixing it.

Now, any future classes that inherit `MyButton` will be automatically handled as `MyButton` by the theme manager.