### PR TITLE
Common: add mapicondesc for ArduCopter

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -209,6 +209,10 @@ namespace MissionPlanner
                     MAV.sysid)
                 {
                     IsActive = MAV == MainV2.comPort?.MAV,
+                    ToolTipText = ArduPilot.Common.speechConversion(MAV, "" + Settings.Instance["mapicondesc"]),
+                    ToolTipMode = String.IsNullOrEmpty(Settings.Instance["mapicondesc"]) ?
+                                  MarkerTooltipMode.Never :
+                                  MarkerTooltipMode.Always,
                     Tag = MAV
                 };
             }


### PR DESCRIPTION
In 1.3.82, “Change icon Description” is no longer available for ArduCopter.
I believe it was removed by mistake and will be restored.
https://github.com/ArduPilot/MissionPlanner/commit/b6e8270a5a4307057d4f1d976f200a2685d42b1e