### PR TITLE
Populate VFR_HUD heading into MP HUD yaw display

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -3760,6 +3760,7 @@ namespace MissionPlanner
                             groundspeed = vfr.groundspeed;
                             airspeed = vfr.airspeed;
                             ch3percent = vfr.throttle;
+                            yaw = vfr.heading;
 
                             if (sensors_present.revthrottle && sensors_enabled.revthrottle && sensors_health.revthrottle)
                                 if (ch3percent > 0)


### PR DESCRIPTION
# Purpose

Allow the yaw field from [VFR_HUD](https://mavlink.io/en/messages/common.html#VFR_HUD) to populate the mission planner yaw field.

According to the message docs:
```
Metrics typically displayed on a HUD for fixed wing aircraft.
```

Given that, I think the yaw field should be displayed.

# Demo

Using MAVROS, I publish mavros VFR_HUD, which gets converted into MAVLink VFR_HUD.
 
 ```
 ros2 topic pub /mavros/vfr_hud mavros_msgs/msg/VfrHud "{header: auto, altitude: 5.0, climb: 6.0, airspeed: 1.28, groundspeed: 7.0, throttle: 8.0, heading: 9.0}
 ```
 
 Then, you can see mission planner show the data correctly.
![image](https://github.com/user-attachments/assets/bb61ec43-c68f-4c9b-a385-5069babdffa6)

Before this change, VFR_HUD's heading was not parsed.
