### PR TITLE
Fix response spelling in user-facing messages

### DIFF
--- a/Controls/DevopsUI.cs
+++ b/Controls/DevopsUI.cs
@@ -28,7 +28,7 @@ namespace MissionPlanner.Controls
             if (buffer.Length > 0)
                 textBox1.AppendText(buffer.Select(a => a.ToString("X2")).Aggregate((a, b) => a + b) + "\r\n");
             else
-                textBox1.AppendText("No Responce - " + result + "\r\n");
+                textBox1.AppendText("No Response - " + result + "\r\n");
         }
 
         private void dom_bustype_SelectedItemChanged(object sender, EventArgs e)

--- a/ExtLibs/Comms/CommsNTRIP.cs
+++ b/ExtLibs/Comms/CommsNTRIP.cs
@@ -385,7 +385,7 @@ namespace MissionPlanner.Comms
 
                 client = new TcpClient();
 
-                throw new Exception("Bad ntrip Responce\n\n" + line);
+                throw new Exception("Bad ntrip Response\n\n" + line);
             }
 
             if (line.Contains("SOURCETABLE"))

--- a/ExtLibs/Strings/Strings.Designer.cs
+++ b/ExtLibs/Strings/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace MissionPlanner {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -151,6 +151,15 @@ namespace MissionPlanner {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unhealthy Airspeed.
+        /// </summary>
+        public static string BadAirspeed {
+            get {
+                return ResourceManager.GetString("BadAirspeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bad Baro Health.
         /// </summary>
         public static string BadBaroHealth {
@@ -183,15 +192,6 @@ namespace MissionPlanner {
         public static string BadGPSHealth {
             get {
                 return ResourceManager.GetString("BadGPSHealth", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to unhealthy airspeed.
-        /// </summary>
-        public static string BadAirspeed {
-            get {
-                return ResourceManager.GetString("BadAirspeed", resourceCulture);
             }
         }
         
@@ -613,11 +613,11 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error: no responce from MAV.
+        ///   Looks up a localized string similar to Error: no response from MAV.
         /// </summary>
-        public static string ErrorNoResponce {
+        public static string ErrorNoResponse {
             get {
-                return ResourceManager.GetString("ErrorNoResponce", resourceCulture);
+                return ResourceManager.GetString("ErrorNoResponse", resourceCulture);
             }
         }
         

--- a/ExtLibs/Strings/Strings.az-Latn-AZ.resx
+++ b/ExtLibs/Strings/Strings.az-Latn-AZ.resx
@@ -213,7 +213,7 @@
   <data name="WarningUpdateParamList" xml:space="preserve">
     <value>Parametrləri yeniləyin. Diqqət HAVADA OLDUGUNUZ ZAMAN BUNU ETMƏYİN!</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>Xəta :MAV sorğuya cavab vermir.</value>
   </data>
   <data name="Trying" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.id-ID.resx
+++ b/ExtLibs/Strings/Strings.id-ID.resx
@@ -228,7 +228,7 @@
   <data name="WarningUpdateParamList" xml:space="preserve">
     <value>Update ParameterJANGAN LAKUKAN INI JIKA ANDA BERADA DI UDARA</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>Kesalahan: tidak ada respon dari MAV</value>
   </data>
   <data name="Trying" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.ja-JP.resx
+++ b/ExtLibs/Strings/Strings.ja-JP.resx
@@ -219,7 +219,7 @@
     <value>パラメータのアップデート
 機体が空中にある場合には実行しないでください！</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>エラー: MAVからの応答がありません</value>
   </data>
   <data name="Trying" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.ko-KR.resx
+++ b/ExtLibs/Strings/Strings.ko-KR.resx
@@ -147,7 +147,7 @@
   <data name="ErrorLogList" xml:space="preserve">
     <value>로그 목록 수신 중 오류</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>오류: MAV 응답 없음</value>
   </data>
   <data name="ErrorNotConnected" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.pt.resx
+++ b/ExtLibs/Strings/Strings.pt.resx
@@ -222,7 +222,7 @@
   <data name="WarningUpdateParamList" xml:space="preserve">
     <value>Atualizar parametros NÃO CONTINUE SE ESTIVER VOANDO</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>eErro: sem resposta do MAV</value>
   </data>
   <data name="Trying" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.resx
+++ b/ExtLibs/Strings/Strings.resx
@@ -149,8 +149,8 @@
   <data name="ErrorLogList" xml:space="preserve">
     <value>Error receiving log list</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
-    <value>Error: no responce from MAV</value>
+  <data name="ErrorNoResponse" xml:space="preserve">
+    <value>Error: no response from MAV</value>
   </data>
   <data name="ErrorNotConnected" xml:space="preserve">
     <value>You are not connected.</value>

--- a/ExtLibs/Strings/Strings.ru-KZ.resx
+++ b/ExtLibs/Strings/Strings.ru-KZ.resx
@@ -231,7 +231,7 @@
   <data name="WarningUpdateParamList" xml:space="preserve">
     <value>Обновить параметрыНЕ ДЕЛАЙТЕ ЭТО, ЕСЛИ ВЫ В ВОЗДУХЕ</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>Ошибка: нет ответа от MAV</value>
   </data>
   <data name="Trying" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.tr.resx
+++ b/ExtLibs/Strings/Strings.tr.resx
@@ -231,7 +231,7 @@
   <data name="WarningUpdateParamList" xml:space="preserve">
     <value>Güncelleme ayarları AIR'DE</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>Hata: MAV'den yanıt yok</value>
   </data>
   <data name="Trying" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.uk.resx
+++ b/ExtLibs/Strings/Strings.uk.resx
@@ -149,7 +149,7 @@
   <data name="ErrorLogList" xml:space="preserve">
     <value>Помилка при отриманні списку лог-файлів</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>Помилка: М-БпЛА не відповідає</value>
   </data>
   <data name="ErrorNotConnected" xml:space="preserve">

--- a/ExtLibs/Strings/Strings.zh-Hans.resx
+++ b/ExtLibs/Strings/Strings.zh-Hans.resx
@@ -149,7 +149,7 @@
   <data name="ErrorLogList" xml:space="preserve">
     <value>接收日志列表时错误</value>
   </data>
-  <data name="ErrorNoResponce" xml:space="preserve">
+  <data name="ErrorNoResponse" xml:space="preserve">
     <value>错误: 没有来自飞行器的响应</value>
   </data>
   <data name="ErrorNotConnected" xml:space="preserve">

--- a/GCSViews/ConfigurationView/ConfigAntennaTracker.cs
+++ b/GCSViews/ConfigurationView/ConfigAntennaTracker.cs
@@ -262,7 +262,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
             }
         }
 
@@ -286,7 +286,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
             }
         }
 

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1057,7 +1057,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
             }
         }
 
@@ -1249,7 +1249,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
             }
         }
 
@@ -1390,7 +1390,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
             }
         }
 
@@ -1545,7 +1545,7 @@ namespace MissionPlanner.GCSViews
 
                                 if (timeout > 30)
                                 {
-                                    CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                                    CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
                                     return;
                                 }
                             }
@@ -1560,7 +1560,7 @@ namespace MissionPlanner.GCSViews
 
                                 if (timeout > 30)
                                 {
-                                    CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                                    CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
                                     return;
                                 }
                             }
@@ -1580,7 +1580,7 @@ namespace MissionPlanner.GCSViews
 
                                 if (timeout > 40)
                                 {
-                                    CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                                    CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
                                     return;
                                 }
                             }
@@ -1596,7 +1596,7 @@ namespace MissionPlanner.GCSViews
 
                             if (timeout > 30)
                             {
-                                CustomMessageBox.Show(Strings.ErrorNoResponce, Strings.ERROR);
+                                CustomMessageBox.Show(Strings.ErrorNoResponse, Strings.ERROR);
                                 return;
                             }
                         }


### PR DESCRIPTION

New behavior: 
![image](https://github.com/user-attachments/assets/ebdffaf5-b38d-4fd0-9d84-f0eed2c2f707)

This seems to be a common misspelling in the repo. I propose fixing it in user-facing strings. 

https://word.tips/spelling/response-vs-responce/
