### PR TITLE
mavcmd: add do-set-roi-location and do-set-roi-none

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -381,6 +381,24 @@
       <Y>Long</Y>
       <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
+    <DO_SET_ROI_LOCATION>
+      <P1>Gimbal Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z>Alt</Z>
+    </DO_SET_ROI_LOCATION>
+    <DO_SET_ROI_NONE>
+      <P1>Gimbal Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_ROI_NONE>
     <DO_SET_SERVO>
       <P1>Ser No</P1>
       <P2>PWM</P2>
@@ -717,6 +735,24 @@
       <Y>Long</Y>
       <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
+    <DO_SET_ROI_LOCATION>
+      <P1>Gimbal Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z>Alt</Z>
+    </DO_SET_ROI_LOCATION>
+    <DO_SET_ROI_NONE>
+      <P1>Gimbal Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_ROI_NONE>
     <DO_INVERTED_FLIGHT>
       <P1>0=normal, 1=inverted</P1>
       <P2></P2>
@@ -1233,6 +1269,24 @@
       <Y>Long</Y>
       <Z unitType="alt">Alt</Z>
     </DO_SET_ROI>
+    <DO_SET_ROI_LOCATION>
+      <P1>Gimbal Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z>Alt</Z>
+    </DO_SET_ROI_LOCATION>
+    <DO_SET_ROI_NONE>
+      <P1>Gimbal Id</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_SET_ROI_NONE>
     <DO_SET_SERVO>
       <P1>Ser No</P1>
       <P2>PWM</P2>


### PR DESCRIPTION
This adds [DO_SET_ROI_LOCATION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ROI_LOCATION) and [DO_SET_ROI_NONE](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_ROI_NONE) to the list of available mission commands for Copter, Rover and Plane.

This has been lightly tested in SITL and seems fine except that the red marker does not appear on the map like it does for the older DO_SET_ROI command.  Maybe @EosBandi, @robertlong13 or @meee1 could tell me where I could update to fix this?  I suspect there's just some case statement that's missing an entry for DO_SET_ROI_LOCATION.

The corresponding AP flight code PR is here https://github.com/ArduPilot/ardupilot/pull/29567