### PR TITLE
LogDownloadMavLink : More readable info of files size and during downloding a file

### DIFF
--- a/Controls/ConnectionStats.cs
+++ b/Controls/ConnectionStats.cs
@@ -162,13 +162,15 @@ namespace MissionPlanner.Controls
             return packetsReceived / (packetsReceived + (double)packetsLost);
         }
 
-        private static string ToHumanReadableByteCount(int i)
+        public static string ToHumanReadableByteCount(int i)
         {
+            if (i > 1024 * 1024 * 1024)
+                return string.Format("{0:0.00}Gb", i / (float)(1024 * 1024 * 1024));
             if (i > 1024 * 1024)
                 return string.Format("{0:0.00}Mb", i / (float)(1024 * 1024));
             if (i > 1024)
-                return string.Format("{0:0.00}K", i / (float)1024);
-            return string.Format("{0:####}", i);
+                return string.Format("{0:0.00}Kb", i / (float)1024);
+            return string.Format("{0:####}b", i);
         }
 
         private void chk_mavlink2_CheckedChanged(object sender, EventArgs e)

--- a/Log/LogDownloadMavLink.cs
+++ b/Log/LogDownloadMavLink.cs
@@ -96,7 +96,7 @@ namespace MissionPlanner.Log
                 {
                     try
                     {
-                        string caption = item.id + " " + GetItemCaption(item) + "  (" + item.size + ")";
+                        string caption = item.id + " " + GetItemCaption(item) + "  (" + MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)item.size) + ")";
                         AddCheckedListBoxItem(caption);
                     }
                     catch (Exception ex)
@@ -399,7 +399,7 @@ namespace MissionPlanner.Log
                 if (current == 0)
                     start = DateTime.Now;
 
-                if (current < max)
+                if (current > 0 && current < max)
                 {
                     var per = (current / (double)max) * 100;
                     
@@ -411,9 +411,11 @@ namespace MissionPlanner.Log
                         avgbps = 1;
                     var left = max - current;
                     var eta = DateTime.Now.AddSeconds(left / avgbps);
-                    
-
-                    labelBytes.Text = current.ToString() + " " + per.ToString("N1") + "% " + eta.ToString("hh:mm t") + " ETA";
+                    var remaining = new DateTime().AddSeconds(left / avgbps);
+                    labelBytes.Text = MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)current) + " "
+                    + per.ToString("N1") + "% "
+                    + MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)avgbps) + "/s "
+                    + (remaining.Day > 1 || remaining.Hour > 0 ? ((remaining.Day - 1) * 24 + remaining.Hour).ToString() + ":" : "") + remaining.ToString("mm:ss") + " left";
                 }
                 else
                 {

--- a/Log/LogDownloadscp.cs
+++ b/Log/LogDownloadscp.cs
@@ -116,7 +116,7 @@ namespace MissionPlanner.Log
                 {
                     try
                     {
-                        string caption = item.Name + " " + GetItemCaption(item) + "  (" + item.Length + ")";
+                        string caption = item.Name + " " + GetItemCaption(item) + "  (" + MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)item.Length) + ")";
                         AddCheckedListBoxItem(caption);
                     }
                     catch (Exception ex)
@@ -418,7 +418,8 @@ namespace MissionPlanner.Log
 
                 if (current < max)
                 {
-                    labelBytes.Text = current.ToString();
+                    var per = (current / (double)max) * 100;
+                    labelBytes.Text = MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)current) + " " + per.ToString("N1") + "% ";
                 }
                 else
                 {


### PR DESCRIPTION
The size of each log files is in bytes and it's not readable by humain (at least not by me). 
So i convert the size into Kb, Mb, etc... i use an already existing function ToHumanReadableByteCount at MissionPlanner.Controls.ConnectionStats and made it public to acess it.
![image](https://github.com/user-attachments/assets/fc2c336b-03a5-48c8-95c9-0a1c0b2f31c5)


Also add more information during downloading a file.
![image](https://github.com/user-attachments/assets/2cb27f34-8815-42cc-bb5e-5db60c08b909)

I also made  the (almost) same modifications for LogDownloadscp but i'm not able to test it. Maybe someone can ?