### PR TITLE
MAVLinkInterface: plane guided error

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4477,7 +4477,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                 if (ans != MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
                 {
-                    giveComport = false;
                     throw new Exception("Alt Change Failed");
                 }
 
@@ -4490,12 +4489,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             }
             catch (Exception ex)
             {
-                giveComport = false;
                 log.Error(ex);
                 throw;
             }
-
-            giveComport = false;
         }
 
         public void setPositionTargetGlobalInt(byte sysid, byte compid, bool pos, bool vel, bool acc, bool yaw,

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4422,8 +4422,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             if (gotohere.alt == 0 || gotohere.lat == 0 || gotohere.lng == 0)
                 return;
 
-            giveComport = true;
-
             try
             {
                 gotohere.id = (ushort) MAV_CMD.WAYPOINT;
@@ -4444,7 +4442,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                     if (ans != MAV_MISSION_RESULT.MAV_MISSION_ACCEPTED)
                     {
-                        giveComport = false;
                         throw new Exception("Guided Mode Failed");
                     }
                 }
@@ -4459,8 +4456,6 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             {
                 log.Error(ex);
             }
-
-            giveComport = false;
         }
 
         [Obsolete]


### PR DESCRIPTION
`setGuidedModeWP` can cause a double-setting of `giveComport` (due to it calling `setWP` for Plane). It should not need to set `giveComport` at all.

Typically, this just causes log spam, but for some reason, if a plugin calls it, it actually locks up the UI for several seconds when it hits `Debugger.Break()`. 