### PR TITLE
Gmap.NET: set UserAgent

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -363,6 +363,7 @@ namespace MissionPlanner
             Console.WriteLine("Setup Settings.Instance.UserAgent");
             Settings.Instance.UserAgent = Application.ProductName + " " + Application.ProductVersion + " (" +
                                           Environment.OSVersion?.VersionString + ")";
+            GMap.NET.MapProviders.GMapProvider.UserAgent = Settings.Instance.UserAgent;
 
             Console.WriteLine("Setup check gdal dir");
             // optionally add gdal support


### PR DESCRIPTION
Should prevent OpenStreetMap or others from blocking us. Fixes #2538

I've tested that this does in fact fix OSM, and this doesn't *cause* any exiting working providers to break.

We should really strip out the large number of apparently broken providers in here, but I don't know which are just "broken for me" because they are IP geographically limited or something. Wouldn't want to break something that happens to be working for someone.