### PR TITLE
Fix AltMode resetting when loading saved Flight plan

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5362,7 +5362,7 @@ namespace MissionPlanner.GCSViews
                     // not home
                     if (i != 0)
                     {
-                        CMB_altmode.SelectedValue = temp.frame;
+                        CMB_altmode.SelectedValue = (int) temp.frame;
                     }
                 }
 


### PR DESCRIPTION
Realted issue: #3542 
Fixes resetting Altmode combobox to `Relative` mode after loading saved plan instead of loading last entry value.