### PR TITLE
FlightPlanner: Add units to Takeoff prompt & skip pitch for VTOL

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -6552,14 +6552,26 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                 MainV2.comPort.MAV.cs.firmware == Firmwares.Ateryx)
             {
                 string top = "15";
+                bool skipPitch = false;
 
-                if (DialogResult.Cancel == InputBox.Show("Takeoff Pitch", "Please enter your takeoff pitch", ref top))
-                    return;
-
-                if (!int.TryParse(top, out topi))
+                // Check if Quadplane with Bit 1 not enabled — skip takeoff pitch input
+                if (MainV2.comPort.MAV.param.ContainsKey("Q_OPTIONS"))
                 {
-                    MessageBox.Show("Bad Takeoff pitch");
-                    return;
+                    if (((int)MainV2.comPort.MAV.param["Q_OPTIONS"] & (1 << 1)) == 0)
+                    {
+                        skipPitch = true;
+                    }
+                }
+                if (!skipPitch)
+                {
+                    if (DialogResult.Cancel == InputBox.Show("Takeoff Pitch", "Please enter your takeoff pitch", ref top))
+                        return;
+
+                    if (!int.TryParse(top, out topi))
+                    {
+                        MessageBox.Show("Bad Takeoff pitch");
+                        return;
+                    }
                 }
             }
 

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -6532,9 +6532,9 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
         public void takeoffToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // altitude
-            string alt = "10";
+            string alt = CurrentState.AltUnit == "m" ? "10" : "30"; ;
 
-            if (DialogResult.Cancel == InputBox.Show("Altitude", "Please enter your takeoff altitude", ref alt))
+            if (DialogResult.Cancel == InputBox.Show("Altitude", "Please enter your takeoff altitude in " + CurrentState.AltUnit, ref alt))
                 return;
 
             int alti = -1;


### PR DESCRIPTION
Updates the takeoff altitude prompt to display the current altitude unit.
The default takeoff altitude is adjusted based on selected unit.
Will Skip the Pitch prompt for Quadplanes if Q_OPTIONS bit 1 is disabled
Relies on reading params so does rely on connection to a quadplane to skip pitch
May need to add a setting in planner at some point to have a default firmware type when disconnected from an aircraft.