### PR TITLE
My button : add default value to TextColorNotEnabled

### DIFF
--- a/Controls/AuthKeys.Designer.cs
+++ b/Controls/AuthKeys.Designer.cs
@@ -78,7 +78,6 @@
             // 
             resources.ApplyResources(this.but_save, "but_save");
             this.but_save.Name = "but_save";
-            this.but_save.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_save.UseVisualStyleBackColor = true;
             this.but_save.Click += new System.EventHandler(this.but_save_Click);
             // 
@@ -86,7 +85,6 @@
             // 
             resources.ApplyResources(this.but_add, "but_add");
             this.but_add.Name = "but_add";
-            this.but_add.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_add.UseVisualStyleBackColor = true;
             this.but_add.Click += new System.EventHandler(this.but_add_Click);
             // 
@@ -94,7 +92,6 @@
             // 
             resources.ApplyResources(this.but_disablesigning, "but_disablesigning");
             this.but_disablesigning.Name = "but_disablesigning";
-            this.but_disablesigning.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_disablesigning.UseVisualStyleBackColor = true;
             this.but_disablesigning.Click += new System.EventHandler(this.but_disablesigning_Click);
             // 

--- a/Controls/GimbalControlSettingsForm.Designer.cs
+++ b/Controls/GimbalControlSettingsForm.Designer.cs
@@ -86,7 +86,6 @@
             this.but_cancel.Size = new System.Drawing.Size(75, 23);
             this.but_cancel.TabIndex = 1;
             this.but_cancel.Text = "Cancel";
-            this.but_cancel.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_cancel.UseVisualStyleBackColor = true;
             this.but_cancel.Click += new System.EventHandler(this.but_cancel_Click);
             // 
@@ -98,7 +97,6 @@
             this.but_save.Size = new System.Drawing.Size(75, 23);
             this.but_save.TabIndex = 0;
             this.but_save.Text = "Save";
-            this.but_save.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_save.UseVisualStyleBackColor = true;
             this.but_save.Click += new System.EventHandler(this.but_save_Click);
             // 

--- a/Controls/PreFlight/CheckListControl.Designer.cs
+++ b/Controls/PreFlight/CheckListControl.Designer.cs
@@ -42,7 +42,6 @@
             this.BUT_edit.Size = new System.Drawing.Size(34, 23);
             this.BUT_edit.TabIndex = 0;
             this.BUT_edit.Text = "Edit";
-            this.BUT_edit.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_edit.UseVisualStyleBackColor = true;
             this.BUT_edit.Click += new System.EventHandler(this.BUT_edit_Click);
             // 

--- a/Controls/PreFlight/CheckListEditor.Designer.cs
+++ b/Controls/PreFlight/CheckListEditor.Designer.cs
@@ -70,7 +70,6 @@ namespace MissionPlanner.Controls.PreFlight
             this.BUT_Add.Size = new System.Drawing.Size(75, 23);
             this.BUT_Add.TabIndex = 1;
             this.BUT_Add.Text = "+";
-            this.BUT_Add.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Add.UseVisualStyleBackColor = true;
             this.BUT_Add.Click += new System.EventHandler(this.BUT_Add_Click);
             // 
@@ -81,7 +80,6 @@ namespace MissionPlanner.Controls.PreFlight
             this.BUT_save.Size = new System.Drawing.Size(75, 23);
             this.BUT_save.TabIndex = 2;
             this.BUT_save.Text = "Save";
-            this.BUT_save.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_save.UseVisualStyleBackColor = true;
             this.BUT_save.Click += new System.EventHandler(this.BUT_save_Click);
             // 

--- a/Controls/ScriptConsole.Designer.cs
+++ b/Controls/ScriptConsole.Designer.cs
@@ -64,11 +64,7 @@
             // BUT_clear
             // 
             resources.ApplyResources(this.BUT_clear, "BUT_clear");
-            this.BUT_clear.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_clear.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             this.BUT_clear.Name = "BUT_clear";
-            this.BUT_clear.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
-            this.BUT_clear.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_clear.UseVisualStyleBackColor = true;
             this.BUT_clear.Click += new System.EventHandler(this.BUT_clear_Click);
             // 

--- a/Controls/SerialOutputCoT.Designer.cs
+++ b/Controls/SerialOutputCoT.Designer.cs
@@ -138,7 +138,6 @@
             this.BUT_connect.Size = new System.Drawing.Size(75, 23);
             this.BUT_connect.TabIndex = 9;
             this.BUT_connect.Text = "Connect";
-            this.BUT_connect.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_connect.UseVisualStyleBackColor = true;
             this.BUT_connect.Click += new System.EventHandler(this.BUT_connect_Click);
             // 

--- a/Controls/SerialOutputPass.Designer.cs
+++ b/Controls/SerialOutputPass.Designer.cs
@@ -54,7 +54,6 @@
             // 
             resources.ApplyResources(this.BUT_connect, "BUT_connect");
             this.BUT_connect.Name = "BUT_connect";
-            this.BUT_connect.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_connect.UseVisualStyleBackColor = true;
             this.BUT_connect.Click += new System.EventHandler(this.BUT_connect_Click);
             // 

--- a/Controls/SerialSupportProxy.Designer.cs
+++ b/Controls/SerialSupportProxy.Designer.cs
@@ -132,7 +132,6 @@
             this.BUT_connect.Size = new System.Drawing.Size(75, 23);
             this.BUT_connect.TabIndex = 4;
             this.BUT_connect.Text = "Connect";
-            this.BUT_connect.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_connect.UseVisualStyleBackColor = true;
             this.BUT_connect.Click += new System.EventHandler(this.BUT_connect_Click);
             // 

--- a/Controls/VideoStreamSelector.Designer.cs
+++ b/Controls/VideoStreamSelector.Designer.cs
@@ -54,7 +54,6 @@
             this.but_launch.Size = new System.Drawing.Size(75, 21);
             this.but_launch.TabIndex = 1;
             this.but_launch.Text = "Connect";
-            this.but_launch.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_launch.UseVisualStyleBackColor = true;
             this.but_launch.Click += new System.EventHandler(this.but_launch_Click);
             // 

--- a/ExtLibs/AltitudeAngelWings.Plugin/AASettings.Designer.cs
+++ b/ExtLibs/AltitudeAngelWings.Plugin/AASettings.Designer.cs
@@ -155,7 +155,6 @@ namespace AltitudeAngelWings.Plugin
             this.but_Disable.Size = new System.Drawing.Size(75, 23);
             this.but_Disable.TabIndex = 46;
             this.but_Disable.Text = global::AltitudeAngelWings.Plugin.Properties.Resources.SettingsDisableText;
-            this.but_Disable.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_Disable.UseVisualStyleBackColor = true;
             this.but_Disable.Click += new System.EventHandler(this.but_Disable_Click);
             // 
@@ -166,7 +165,6 @@ namespace AltitudeAngelWings.Plugin
             this.but_Enable.Size = new System.Drawing.Size(75, 23);
             this.but_Enable.TabIndex = 45;
             this.but_Enable.Text = global::AltitudeAngelWings.Plugin.Properties.Resources.SettingsEnableText;
-            this.but_Enable.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_Enable.UseVisualStyleBackColor = true;
             this.but_Enable.Click += new System.EventHandler(this.but_Enable_Click);
             // 
@@ -258,7 +256,6 @@ namespace AltitudeAngelWings.Plugin
             this.but_SignOut.Size = new System.Drawing.Size(75, 23);
             this.but_SignOut.TabIndex = 3;
             this.but_SignOut.Text = global::AltitudeAngelWings.Plugin.Properties.Resources.SettingsSignOutText;
-            this.but_SignOut.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_SignOut.UseVisualStyleBackColor = true;
             this.but_SignOut.Click += new System.EventHandler(this.but_SignOut_Click);
             // 
@@ -269,7 +266,6 @@ namespace AltitudeAngelWings.Plugin
             this.but_SignIn.Size = new System.Drawing.Size(75, 23);
             this.but_SignIn.TabIndex = 2;
             this.but_SignIn.Text = global::AltitudeAngelWings.Plugin.Properties.Resources.SettingsSignInText;
-            this.but_SignIn.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_SignIn.UseVisualStyleBackColor = true;
             this.but_SignIn.Click += new System.EventHandler(this.but_SignIn_Click);
             // 
@@ -354,7 +350,6 @@ namespace AltitudeAngelWings.Plugin
             this.btn_DefaultLayers.Size = new System.Drawing.Size(75, 31);
             this.btn_DefaultLayers.TabIndex = 44;
             this.btn_DefaultLayers.Text = global::AltitudeAngelWings.Plugin.Properties.Resources.SettingsDefaultLayersText;
-            this.btn_DefaultLayers.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.btn_DefaultLayers.UseVisualStyleBackColor = true;
             this.btn_DefaultLayers.Click += new System.EventHandler(this.btn_DefaultLayers_Click);
             // 

--- a/ExtLibs/AltitudeAngelWings.Plugin/WaitPanel.Designer.cs
+++ b/ExtLibs/AltitudeAngelWings.Plugin/WaitPanel.Designer.cs
@@ -56,7 +56,6 @@
             this._btnCancel.Size = new System.Drawing.Size(143, 23);
             this._btnCancel.TabIndex = 8;
             this._btnCancel.Text = "Cancel";
-            this._btnCancel.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this._btnCancel.UseVisualStyleBackColor = true;
             this._btnCancel.Click += new System.EventHandler(this._btnCancel_Click);
             // 

--- a/ExtLibs/Controls/MyButton.cs
+++ b/ExtLibs/Controls/MyButton.cs
@@ -48,6 +48,7 @@ namespace MissionPlanner.Controls
         [DefaultValue(typeof(Color), "0x40, 0x57, 0x04")]
         public Color TextColor { get { return _TextColor; } set { _TextColor = value; this.Invalidate(); } }
         [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Colors")]
+        [DefaultValue(typeof(Color), "0x40, 0x57, 0x04")]
         public Color TextColorNotEnabled { get { return (_TextColorNotEnabled.IsEmpty) ? _TextColor : _TextColorNotEnabled; } set { _TextColorNotEnabled = value; this.Invalidate(); } }
         [System.ComponentModel.Browsable(true), System.ComponentModel.Category("Colors")]
         [DefaultValue(typeof(Color), "0x79, 0x94, 0x29")]

--- a/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.Designer.cs
@@ -62,7 +62,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_calib_accell, "BUT_calib_accell");
             this.BUT_calib_accell.Name = "BUT_calib_accell";
-            this.BUT_calib_accell.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_calib_accell.UseVisualStyleBackColor = true;
             this.BUT_calib_accell.Click += new System.EventHandler(this.BUT_calib_accell_Click);
             // 
@@ -80,7 +79,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_level, "BUT_level");
             this.BUT_level.Name = "BUT_level";
-            this.BUT_level.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_level.UseVisualStyleBackColor = true;
             this.BUT_level.Click += new System.EventHandler(this.BUT_level_Click);
             // 
@@ -88,7 +86,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_simpleAccelCal, "BUT_simpleAccelCal");
             this.BUT_simpleAccelCal.Name = "BUT_simpleAccelCal";
-            this.BUT_simpleAccelCal.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_simpleAccelCal.UseVisualStyleBackColor = true;
             this.BUT_simpleAccelCal.Click += new System.EventHandler(this.BUT_simpleAccelCal_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigArduplane.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigArduplane.Designer.cs
@@ -854,7 +854,6 @@
             // 
             resources.ApplyResources(this.BUT_writePIDS, "BUT_writePIDS");
             this.BUT_writePIDS.Name = "BUT_writePIDS";
-            this.BUT_writePIDS.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_writePIDS.UseVisualStyleBackColor = true;
             this.BUT_writePIDS.Click += new System.EventHandler(this.BUT_writePIDS_Click);
             // 
@@ -862,7 +861,6 @@
             // 
             resources.ApplyResources(this.BUT_rerequestparams, "BUT_rerequestparams");
             this.BUT_rerequestparams.Name = "BUT_rerequestparams";
-            this.BUT_rerequestparams.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_rerequestparams.UseVisualStyleBackColor = true;
             this.BUT_rerequestparams.Click += new System.EventHandler(this.BUT_rerequestparams_Click);
             // 
@@ -994,7 +992,6 @@
             // 
             resources.ApplyResources(this.BUT_refreshpart, "BUT_refreshpart");
             this.BUT_refreshpart.Name = "BUT_refreshpart";
-            this.BUT_refreshpart.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_refreshpart.UseVisualStyleBackColor = true;
             this.BUT_refreshpart.Click += new System.EventHandler(this.BUT_refreshpart_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigCubeID.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigCubeID.Designer.cs
@@ -47,7 +47,6 @@
             this.but_upfw.Size = new System.Drawing.Size(120, 23);
             this.but_upfw.TabIndex = 0;
             this.but_upfw.Text = "Upload Firmware";
-            this.but_upfw.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_upfw.UseVisualStyleBackColor = true;
             this.but_upfw.Click += new System.EventHandler(this.but_upfw_Click);
             // 
@@ -132,7 +131,6 @@
             this.but_customfw.Size = new System.Drawing.Size(109, 23);
             this.but_customfw.TabIndex = 8;
             this.but_customfw.Text = "Upload Custom Firmware";
-            this.but_customfw.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_customfw.UseVisualStyleBackColor = true;
             this.but_customfw.Click += new System.EventHandler(this.but_customfw_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigDroneCAN.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigDroneCAN.Designer.cs
@@ -174,7 +174,6 @@
             this.but_uavcaninspector.Size = new System.Drawing.Size(57, 23);
             this.but_uavcaninspector.TabIndex = 85;
             this.but_uavcaninspector.Text = "Inspector";
-            this.but_uavcaninspector.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_uavcaninspector.UseVisualStyleBackColor = true;
             this.but_uavcaninspector.Click += new System.EventHandler(this.But_uavcaninspector_Click);
             // 
@@ -445,7 +444,6 @@
             this.but_filter.Size = new System.Drawing.Size(42, 23);
             this.but_filter.TabIndex = 92;
             this.but_filter.Text = "Filter";
-            this.but_filter.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_filter.UseVisualStyleBackColor = true;
             this.but_filter.Click += new System.EventHandler(this.but_filter_Click);
             // 
@@ -456,7 +454,6 @@
             this.but_stats.Size = new System.Drawing.Size(42, 23);
             this.but_stats.TabIndex = 93;
             this.but_stats.Text = "Stats";
-            this.but_stats.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_stats.UseVisualStyleBackColor = true;
             this.but_stats.Click += new System.EventHandler(this.but_stats_Click);
             // 
@@ -485,7 +482,6 @@
             this.but_connect.Size = new System.Drawing.Size(75, 23);
             this.but_connect.TabIndex = 98;
             this.but_connect.Text = "Connect";
-            this.but_connect.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_connect.UseVisualStyleBackColor = true;
             this.but_connect.Click += new System.EventHandler(this.but_connect_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigHWOSD.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigHWOSD.Designer.cs
@@ -59,12 +59,8 @@
             // 
             // BUT_osdrates
             // 
-            this.BUT_osdrates.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_osdrates.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             resources.ApplyResources(this.BUT_osdrates, "BUT_osdrates");
             this.BUT_osdrates.Name = "BUT_osdrates";
-            this.BUT_osdrates.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
-            this.BUT_osdrates.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_osdrates.UseVisualStyleBackColor = true;
             this.BUT_osdrates.Click += new System.EventHandler(this.BUT_osdrates_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigMotorTest.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigMotorTest.Designer.cs
@@ -126,7 +126,6 @@
             // 
             resources.ApplyResources(this.but_mot_spin_min, "but_mot_spin_min");
             this.but_mot_spin_min.Name = "but_mot_spin_min";
-            this.but_mot_spin_min.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_mot_spin_min.UseVisualStyleBackColor = true;
             this.but_mot_spin_min.Click += new System.EventHandler(this.but_mot_spin_min_Click);
             // 
@@ -139,7 +138,6 @@
             // 
             resources.ApplyResources(this.but_mot_spin_arm, "but_mot_spin_arm");
             this.but_mot_spin_arm.Name = "but_mot_spin_arm";
-            this.but_mot_spin_arm.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_mot_spin_arm.UseVisualStyleBackColor = true;
             this.but_mot_spin_arm.Click += new System.EventHandler(this.but_mot_spin_arm_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.Designer.cs
@@ -535,7 +535,6 @@
             // 
             resources.ApplyResources(this.BUT_Joystick, "BUT_Joystick");
             this.BUT_Joystick.Name = "BUT_Joystick";
-            this.BUT_Joystick.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Joystick.UseVisualStyleBackColor = true;
             this.BUT_Joystick.Click += new System.EventHandler(this.BUT_Joystick_Click);
             // 
@@ -543,7 +542,6 @@
             // 
             resources.ApplyResources(this.BUT_videostop, "BUT_videostop");
             this.BUT_videostop.Name = "BUT_videostop";
-            this.BUT_videostop.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_videostop.UseVisualStyleBackColor = true;
             this.BUT_videostop.Click += new System.EventHandler(this.BUT_videostop_Click);
             // 
@@ -551,7 +549,6 @@
             // 
             resources.ApplyResources(this.BUT_videostart, "BUT_videostart");
             this.BUT_videostart.Name = "BUT_videostart";
-            this.BUT_videostart.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_videostart.UseVisualStyleBackColor = true;
             this.BUT_videostart.Click += new System.EventHandler(this.BUT_videostart_Click);
             // 
@@ -569,7 +566,6 @@
             // 
             resources.ApplyResources(this.BUT_logdirbrowse, "BUT_logdirbrowse");
             this.BUT_logdirbrowse.Name = "BUT_logdirbrowse";
-            this.BUT_logdirbrowse.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_logdirbrowse.UseVisualStyleBackColor = true;
             this.BUT_logdirbrowse.Click += new System.EventHandler(this.BUT_logdirbrowse_Click);
             // 
@@ -590,7 +586,6 @@
             // 
             resources.ApplyResources(this.BUT_themecustom, "BUT_themecustom");
             this.BUT_themecustom.Name = "BUT_themecustom";
-            this.BUT_themecustom.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_themecustom.UseVisualStyleBackColor = true;
             this.BUT_themecustom.Click += new System.EventHandler(this.BUT_themecustom_Click);
             // 
@@ -605,7 +600,6 @@
             // 
             resources.ApplyResources(this.BUT_Vario, "BUT_Vario");
             this.BUT_Vario.Name = "BUT_Vario";
-            this.BUT_Vario.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Vario.UseVisualStyleBackColor = true;
             this.BUT_Vario.Click += new System.EventHandler(this.BUT_Vario_Click);
             // 
@@ -880,7 +874,6 @@
             // 
             resources.ApplyResources(this.BUT_mapCacheDir, "BUT_mapCacheDir");
             this.BUT_mapCacheDir.Name = "BUT_mapCacheDir";
-            this.BUT_mapCacheDir.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_mapCacheDir.UseVisualStyleBackColor = true;
             this.BUT_mapCacheDir.Click += new System.EventHandler(this.BUT_mapCacheDir_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigRawParams.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.Designer.cs
@@ -76,7 +76,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_compare, "BUT_compare");
             this.BUT_compare.Name = "BUT_compare";
-            this.BUT_compare.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_compare.UseVisualStyleBackColor = true;
             this.BUT_compare.Click += new System.EventHandler(this.BUT_compare_Click);
             // 
@@ -84,7 +83,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_rerequestparams, "BUT_rerequestparams");
             this.BUT_rerequestparams.Name = "BUT_rerequestparams";
-            this.BUT_rerequestparams.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_rerequestparams.UseVisualStyleBackColor = true;
             this.BUT_rerequestparams.Click += new System.EventHandler(this.BUT_rerequestparams_Click);
             // 
@@ -92,7 +90,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_writePIDS, "BUT_writePIDS");
             this.BUT_writePIDS.Name = "BUT_writePIDS";
-            this.BUT_writePIDS.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_writePIDS.UseVisualStyleBackColor = true;
             this.BUT_writePIDS.Click += new System.EventHandler(this.BUT_writePIDS_Click);
             // 
@@ -100,7 +97,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_save, "BUT_save");
             this.BUT_save.Name = "BUT_save";
-            this.BUT_save.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_save.UseVisualStyleBackColor = true;
             this.BUT_save.Click += new System.EventHandler(this.BUT_save_Click);
             // 
@@ -108,7 +104,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_load, "BUT_load");
             this.BUT_load.Name = "BUT_load";
-            this.BUT_load.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_load.UseVisualStyleBackColor = true;
             this.BUT_load.Click += new System.EventHandler(this.BUT_load_Click);
             // 
@@ -127,7 +122,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_paramfileload, "BUT_paramfileload");
             this.BUT_paramfileload.Name = "BUT_paramfileload";
-            this.BUT_paramfileload.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_paramfileload.UseVisualStyleBackColor = true;
             this.BUT_paramfileload.Click += new System.EventHandler(this.BUT_paramfileload_Click);
             // 
@@ -142,7 +136,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_reset_params, "BUT_reset_params");
             this.BUT_reset_params.Name = "BUT_reset_params";
-            this.BUT_reset_params.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_reset_params.UseVisualStyleBackColor = true;
             this.BUT_reset_params.Click += new System.EventHandler(this.BUT_reset_params_Click);
             // 
@@ -161,7 +154,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_commitToFlash, "BUT_commitToFlash");
             this.BUT_commitToFlash.Name = "BUT_commitToFlash";
-            this.BUT_commitToFlash.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_commitToFlash.UseVisualStyleBackColor = true;
             this.BUT_commitToFlash.Click += new System.EventHandler(this.BUT_commitToFlash_Click);
             // 
@@ -176,7 +168,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_refreshTable, "BUT_refreshTable");
             this.BUT_refreshTable.Name = "BUT_refreshTable";
-            this.BUT_refreshTable.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_refreshTable.UseVisualStyleBackColor = true;
             this.BUT_refreshTable.Click += new System.EventHandler(this.BUT_refreshTable_Click);
             // 
@@ -313,7 +304,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.but_collapse, "but_collapse");
             this.but_collapse.Name = "but_collapse";
-            this.but_collapse.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_collapse.UseVisualStyleBackColor = true;
             this.but_collapse.Click += new System.EventHandler(this.but_collapse_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigSecureAP.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigSecureAP.Designer.cs
@@ -54,7 +54,6 @@
             this.but_bootloader.Size = new System.Drawing.Size(75, 23);
             this.but_bootloader.TabIndex = 0;
             this.but_bootloader.Text = "BootLoader";
-            this.but_bootloader.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_bootloader.UseVisualStyleBackColor = true;
             this.but_bootloader.Click += new System.EventHandler(this.but_bootloader_Click);
             // 
@@ -65,7 +64,6 @@
             this.but_firmware.Size = new System.Drawing.Size(75, 23);
             this.but_firmware.TabIndex = 1;
             this.but_firmware.Text = "Firmware";
-            this.but_firmware.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_firmware.UseVisualStyleBackColor = true;
             this.but_firmware.Click += new System.EventHandler(this.but_firmware_Click);
             // 
@@ -76,7 +74,6 @@
             this.but_privkey.Size = new System.Drawing.Size(75, 23);
             this.but_privkey.TabIndex = 2;
             this.but_privkey.Text = "Private Key";
-            this.but_privkey.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_privkey.UseVisualStyleBackColor = true;
             this.but_privkey.Click += new System.EventHandler(this.but_privkey_Click);
             // 
@@ -123,7 +120,6 @@
             this.but_generatekey.Size = new System.Drawing.Size(75, 23);
             this.but_generatekey.TabIndex = 6;
             this.but_generatekey.Text = "Generate Key";
-            this.but_generatekey.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_generatekey.UseVisualStyleBackColor = true;
             this.but_generatekey.Click += new System.EventHandler(this.but_generatekey_Click);
             // 

--- a/GCSViews/ConfigurationView/ConfigSerialInjectGPS.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigSerialInjectGPS.Designer.cs
@@ -629,7 +629,6 @@
             // 
             resources.ApplyResources(this.button_septentriortcminterval, "button_septentriortcminterval");
             this.button_septentriortcminterval.Name = "button_septentriortcminterval";
-            this.button_septentriortcminterval.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.button_septentriortcminterval.UseVisualStyleBackColor = true;
             this.button_septentriortcminterval.Click += new System.EventHandler(this.button_septentriortcminterval_Click);
             // 
@@ -637,7 +636,6 @@
             // 
             resources.ApplyResources(this.button_septentriosetposition, "button_septentriosetposition");
             this.button_septentriosetposition.Name = "button_septentriosetposition";
-            this.button_septentriosetposition.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.button_septentriosetposition.UseVisualStyleBackColor = true;
             this.button_septentriosetposition.Click += new System.EventHandler(this.button_septentriosetposition_Click);
             // 
@@ -645,7 +643,6 @@
             // 
             resources.ApplyResources(this.but_restartsvin, "but_restartsvin");
             this.but_restartsvin.Name = "but_restartsvin";
-            this.but_restartsvin.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.but_restartsvin, resources.GetString("but_restartsvin.ToolTip"));
             this.but_restartsvin.UseVisualStyleBackColor = true;
             this.but_restartsvin.Click += new System.EventHandler(this.but_restartsvin_Click);
@@ -654,7 +651,6 @@
             // 
             resources.ApplyResources(this.but_save_basepos, "but_save_basepos");
             this.but_save_basepos.Name = "but_save_basepos";
-            this.but_save_basepos.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.but_save_basepos, resources.GetString("but_save_basepos.ToolTip"));
             this.but_save_basepos.UseVisualStyleBackColor = true;
             this.but_save_basepos.Click += new System.EventHandler(this.but_save_basepos_Click);
@@ -663,7 +659,6 @@
             // 
             resources.ApplyResources(this.BUT_connect, "BUT_connect");
             this.BUT_connect.Name = "BUT_connect";
-            this.BUT_connect.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_connect.UseVisualStyleBackColor = true;
             this.BUT_connect.Click += new System.EventHandler(this.BUT_connect_Click);
             // 

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -775,7 +775,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_SendMSG.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_SendMSG, "BUT_SendMSG");
             this.BUT_SendMSG.Name = "BUT_SendMSG";
-            this.BUT_SendMSG.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_SendMSG, resources.GetString("BUT_SendMSG.ToolTip"));
             this.BUT_SendMSG.UseVisualStyleBackColor = true;
             this.BUT_SendMSG.Click += new System.EventHandler(this.BUT_SendMSG_Click);
@@ -787,7 +786,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_abortland.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_abortland, "BUT_abortland");
             this.BUT_abortland.Name = "BUT_abortland";
-            this.BUT_abortland.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_abortland, resources.GetString("BUT_abortland.ToolTip"));
             this.BUT_abortland.UseVisualStyleBackColor = true;
             this.BUT_abortland.Click += new System.EventHandler(this.BUT_abortland_Click);
@@ -827,7 +825,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_clear_track.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_clear_track, "BUT_clear_track");
             this.BUT_clear_track.Name = "BUT_clear_track";
-            this.BUT_clear_track.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_clear_track, resources.GetString("BUT_clear_track.ToolTip"));
             this.BUT_clear_track.UseVisualStyleBackColor = true;
             this.BUT_clear_track.Click += new System.EventHandler(this.BUT_clear_track_Click);
@@ -847,7 +844,6 @@ namespace MissionPlanner.GCSViews
             this.BUTactiondo.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUTactiondo, "BUTactiondo");
             this.BUTactiondo.Name = "BUTactiondo";
-            this.BUTactiondo.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUTactiondo, resources.GetString("BUTactiondo.ToolTip"));
             this.BUTactiondo.UseVisualStyleBackColor = true;
             this.BUTactiondo.Click += new System.EventHandler(this.BUTactiondo_Click);
@@ -859,7 +855,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_resumemis.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_resumemis, "BUT_resumemis");
             this.BUT_resumemis.Name = "BUT_resumemis";
-            this.BUT_resumemis.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_resumemis.UseVisualStyleBackColor = true;
             this.BUT_resumemis.Click += new System.EventHandler(this.BUT_resumemis_Click);
             // 
@@ -938,7 +933,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_ARM.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_ARM, "BUT_ARM");
             this.BUT_ARM.Name = "BUT_ARM";
-            this.BUT_ARM.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_ARM, resources.GetString("BUT_ARM.ToolTip"));
             this.BUT_ARM.UseVisualStyleBackColor = true;
             this.BUT_ARM.Click += new System.EventHandler(this.BUT_ARM_Click);
@@ -950,7 +944,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_mountmode.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_mountmode, "BUT_mountmode");
             this.BUT_mountmode.Name = "BUT_mountmode";
-            this.BUT_mountmode.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_mountmode, resources.GetString("BUT_mountmode.ToolTip"));
             this.BUT_mountmode.UseVisualStyleBackColor = true;
             this.BUT_mountmode.Click += new System.EventHandler(this.BUT_mountmode_Click);
@@ -962,7 +955,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_joystick.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_joystick, "BUT_joystick");
             this.BUT_joystick.Name = "BUT_joystick";
-            this.BUT_joystick.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_joystick, resources.GetString("BUT_joystick.ToolTip"));
             this.BUT_joystick.UseVisualStyleBackColor = true;
             this.BUT_joystick.Click += new System.EventHandler(this.BUT_joystick_Click);
@@ -974,7 +966,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_RAWSensor.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_RAWSensor, "BUT_RAWSensor");
             this.BUT_RAWSensor.Name = "BUT_RAWSensor";
-            this.BUT_RAWSensor.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_RAWSensor, resources.GetString("BUT_RAWSensor.ToolTip"));
             this.BUT_RAWSensor.UseVisualStyleBackColor = true;
             this.BUT_RAWSensor.Click += new System.EventHandler(this.BUT_RAWSensor_Click);
@@ -986,7 +977,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_Homealt.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_Homealt, "BUT_Homealt");
             this.BUT_Homealt.Name = "BUT_Homealt";
-            this.BUT_Homealt.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_Homealt, resources.GetString("BUT_Homealt.ToolTip"));
             this.BUT_Homealt.UseVisualStyleBackColor = true;
             this.BUT_Homealt.Click += new System.EventHandler(this.BUT_Homealt_Click);
@@ -998,7 +988,6 @@ namespace MissionPlanner.GCSViews
             this.BUTrestartmission.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUTrestartmission, "BUTrestartmission");
             this.BUTrestartmission.Name = "BUTrestartmission";
-            this.BUTrestartmission.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUTrestartmission, resources.GetString("BUTrestartmission.ToolTip"));
             this.BUTrestartmission.UseVisualStyleBackColor = true;
             this.BUTrestartmission.Click += new System.EventHandler(this.BUTrestartmission_Click);
@@ -1018,7 +1007,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_quickrtl.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_quickrtl, "BUT_quickrtl");
             this.BUT_quickrtl.Name = "BUT_quickrtl";
-            this.BUT_quickrtl.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_quickrtl, resources.GetString("BUT_quickrtl.ToolTip"));
             this.BUT_quickrtl.UseVisualStyleBackColor = true;
             this.BUT_quickrtl.Click += new System.EventHandler(this.BUT_quickrtl_Click);
@@ -1030,7 +1018,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_quickmanual.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_quickmanual, "BUT_quickmanual");
             this.BUT_quickmanual.Name = "BUT_quickmanual";
-            this.BUT_quickmanual.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_quickmanual, resources.GetString("BUT_quickmanual.ToolTip"));
             this.BUT_quickmanual.UseVisualStyleBackColor = true;
             this.BUT_quickmanual.Click += new System.EventHandler(this.BUT_quickmanual_Click);
@@ -1042,7 +1029,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_setwp.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_setwp, "BUT_setwp");
             this.BUT_setwp.Name = "BUT_setwp";
-            this.BUT_setwp.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_setwp, resources.GetString("BUT_setwp.ToolTip"));
             this.BUT_setwp.UseVisualStyleBackColor = true;
             this.BUT_setwp.Click += new System.EventHandler(this.BUT_setwp_Click);
@@ -1063,7 +1049,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_quickauto.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_quickauto, "BUT_quickauto");
             this.BUT_quickauto.Name = "BUT_quickauto";
-            this.BUT_quickauto.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_quickauto, resources.GetString("BUT_quickauto.ToolTip"));
             this.BUT_quickauto.UseVisualStyleBackColor = true;
             this.BUT_quickauto.Click += new System.EventHandler(this.BUT_quickauto_Click);
@@ -1075,7 +1060,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_setmode.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_setmode, "BUT_setmode");
             this.BUT_setmode.Name = "BUT_setmode";
-            this.BUT_setmode.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_setmode, resources.GetString("BUT_setmode.ToolTip"));
             this.BUT_setmode.UseVisualStyleBackColor = true;
             this.BUT_setmode.Click += new System.EventHandler(this.BUT_setmode_Click);
@@ -1108,7 +1092,6 @@ namespace MissionPlanner.GCSViews
             this.myButton1.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.myButton1, "myButton1");
             this.myButton1.Name = "myButton1";
-            this.myButton1.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.myButton1, resources.GetString("myButton1.ToolTip"));
             this.myButton1.UseVisualStyleBackColor = true;
             this.myButton1.Click += new System.EventHandler(this.BUT_quickmanual_Click);
@@ -1120,7 +1103,6 @@ namespace MissionPlanner.GCSViews
             this.myButton2.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.myButton2, "myButton2");
             this.myButton2.Name = "myButton2";
-            this.myButton2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.myButton2, resources.GetString("myButton2.ToolTip"));
             this.myButton2.UseVisualStyleBackColor = true;
             this.myButton2.Click += new System.EventHandler(this.BUT_quickrtl_Click);
@@ -1132,7 +1114,6 @@ namespace MissionPlanner.GCSViews
             this.myButton3.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.myButton3, "myButton3");
             this.myButton3.Name = "myButton3";
-            this.myButton3.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.myButton3, resources.GetString("myButton3.ToolTip"));
             this.myButton3.UseVisualStyleBackColor = true;
             this.myButton3.Click += new System.EventHandler(this.BUT_quickauto_Click);
@@ -2038,7 +2019,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_edit_selected.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_edit_selected, "BUT_edit_selected");
             this.BUT_edit_selected.Name = "BUT_edit_selected";
-            this.BUT_edit_selected.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_edit_selected.UseVisualStyleBackColor = true;
             this.BUT_edit_selected.Click += new System.EventHandler(this.BUT_edit_selected_Click);
             // 
@@ -2054,7 +2034,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_run_script.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_run_script, "BUT_run_script");
             this.BUT_run_script.Name = "BUT_run_script";
-            this.BUT_run_script.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_run_script.UseVisualStyleBackColor = true;
             this.BUT_run_script.Click += new System.EventHandler(this.BUT_run_script_Click);
             // 
@@ -2065,7 +2044,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_abort_script.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_abort_script, "BUT_abort_script");
             this.BUT_abort_script.Name = "BUT_abort_script";
-            this.BUT_abort_script.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_abort_script.UseVisualStyleBackColor = true;
             this.BUT_abort_script.Click += new System.EventHandler(this.BUT_abort_script_Click);
             // 
@@ -2081,7 +2059,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_select_script.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_select_script, "BUT_select_script");
             this.BUT_select_script.Name = "BUT_select_script";
-            this.BUT_select_script.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_select_script.UseVisualStyleBackColor = true;
             this.BUT_select_script.Click += new System.EventHandler(this.BUT_select_script_Click);
             // 
@@ -2100,7 +2077,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_GimbalVideo, "BUT_GimbalVideo");
             this.BUT_GimbalVideo.Name = "BUT_GimbalVideo";
-            this.BUT_GimbalVideo.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_GimbalVideo.UseVisualStyleBackColor = true;
             this.BUT_GimbalVideo.Click += new System.EventHandler(this.gimbalVideoPopOutToolStripMenuItem_Click);
             // 
@@ -2160,7 +2136,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_resetGimbalPos, "BUT_resetGimbalPos");
             this.BUT_resetGimbalPos.Name = "BUT_resetGimbalPos";
-            this.BUT_resetGimbalPos.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_resetGimbalPos.UseVisualStyleBackColor = true;
             this.BUT_resetGimbalPos.Click += new System.EventHandler(this.BUT_resetGimbalPos_Click);
             // 
@@ -2235,7 +2210,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed10, "BUT_speed10");
             this.BUT_speed10.Name = "BUT_speed10";
             this.BUT_speed10.Tag = "10";
-            this.BUT_speed10.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed10.UseVisualStyleBackColor = true;
             this.BUT_speed10.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2247,7 +2221,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed5, "BUT_speed5");
             this.BUT_speed5.Name = "BUT_speed5";
             this.BUT_speed5.Tag = "5";
-            this.BUT_speed5.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed5.UseVisualStyleBackColor = true;
             this.BUT_speed5.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2259,7 +2232,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed2, "BUT_speed2");
             this.BUT_speed2.Name = "BUT_speed2";
             this.BUT_speed2.Tag = "2";
-            this.BUT_speed2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed2.UseVisualStyleBackColor = true;
             this.BUT_speed2.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2271,7 +2243,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1, "BUT_speed1");
             this.BUT_speed1.Name = "BUT_speed1";
             this.BUT_speed1.Tag = "1";
-            this.BUT_speed1.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1.UseVisualStyleBackColor = true;
             this.BUT_speed1.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2283,7 +2254,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1_2, "BUT_speed1_2");
             this.BUT_speed1_2.Name = "BUT_speed1_2";
             this.BUT_speed1_2.Tag = "0.5";
-            this.BUT_speed1_2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1_2.UseVisualStyleBackColor = true;
             this.BUT_speed1_2.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2295,7 +2265,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1_4, "BUT_speed1_4");
             this.BUT_speed1_4.Name = "BUT_speed1_4";
             this.BUT_speed1_4.Tag = "0.25";
-            this.BUT_speed1_4.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1_4.UseVisualStyleBackColor = true;
             this.BUT_speed1_4.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2307,7 +2276,6 @@ namespace MissionPlanner.GCSViews
             resources.ApplyResources(this.BUT_speed1_10, "BUT_speed1_10");
             this.BUT_speed1_10.Name = "BUT_speed1_10";
             this.BUT_speed1_10.Tag = "0.1";
-            this.BUT_speed1_10.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_speed1_10.UseVisualStyleBackColor = true;
             this.BUT_speed1_10.Click += new System.EventHandler(this.BUT_speed1_Click);
             // 
@@ -2318,7 +2286,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_loadtelem.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_loadtelem, "BUT_loadtelem");
             this.BUT_loadtelem.Name = "BUT_loadtelem";
-            this.BUT_loadtelem.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_loadtelem.UseVisualStyleBackColor = true;
             this.BUT_loadtelem.Click += new System.EventHandler(this.BUT_loadtelem_Click);
             // 
@@ -2345,7 +2312,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_log2kml.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_log2kml, "BUT_log2kml");
             this.BUT_log2kml.Name = "BUT_log2kml";
-            this.BUT_log2kml.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_log2kml.UseVisualStyleBackColor = true;
             this.BUT_log2kml.Click += new System.EventHandler(this.BUT_log2kml_Click);
             // 
@@ -2356,7 +2322,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_playlog.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_playlog, "BUT_playlog");
             this.BUT_playlog.Name = "BUT_playlog";
-            this.BUT_playlog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_playlog.UseVisualStyleBackColor = true;
             this.BUT_playlog.Click += new System.EventHandler(this.BUT_playlog_Click);
             // 
@@ -2394,7 +2359,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_DFMavlink.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_DFMavlink, "BUT_DFMavlink");
             this.BUT_DFMavlink.Name = "BUT_DFMavlink";
-            this.BUT_DFMavlink.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_DFMavlink.UseVisualStyleBackColor = true;
             this.BUT_DFMavlink.Click += new System.EventHandler(this.BUT_DFMavlink_Click);
             // 
@@ -2402,7 +2366,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_georefimage, "BUT_georefimage");
             this.BUT_georefimage.Name = "BUT_georefimage";
-            this.BUT_georefimage.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_georefimage.Click += new System.EventHandler(this.BUT_georefimage_Click);
             // 
             // BUT_logbrowse
@@ -2412,7 +2375,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_logbrowse.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_logbrowse, "BUT_logbrowse");
             this.BUT_logbrowse.Name = "BUT_logbrowse";
-            this.BUT_logbrowse.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_logbrowse.UseVisualStyleBackColor = true;
             this.BUT_logbrowse.Click += new System.EventHandler(this.BUT_logbrowse_Click);
             // 
@@ -2423,7 +2385,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_matlab.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_matlab, "BUT_matlab");
             this.BUT_matlab.Name = "BUT_matlab";
-            this.BUT_matlab.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_matlab.UseVisualStyleBackColor = true;
             this.BUT_matlab.Click += new System.EventHandler(this.BUT_matlab_Click);
             // 
@@ -2434,7 +2395,6 @@ namespace MissionPlanner.GCSViews
             this.but_bintolog.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.but_bintolog, "but_bintolog");
             this.but_bintolog.Name = "but_bintolog";
-            this.but_bintolog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_bintolog.UseVisualStyleBackColor = true;
             this.but_bintolog.Click += new System.EventHandler(this.but_bintolog_Click);
             // 
@@ -2445,7 +2405,6 @@ namespace MissionPlanner.GCSViews
             this.but_dflogtokml.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.but_dflogtokml, "but_dflogtokml");
             this.but_dflogtokml.Name = "but_dflogtokml";
-            this.but_dflogtokml.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_dflogtokml.UseVisualStyleBackColor = true;
             this.but_dflogtokml.Click += new System.EventHandler(this.but_dflogtokml_Click);
             // 
@@ -2456,7 +2415,6 @@ namespace MissionPlanner.GCSViews
             this.BUT_loganalysis.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.BUT_loganalysis, "BUT_loganalysis");
             this.BUT_loganalysis.Name = "BUT_loganalysis";
-            this.BUT_loganalysis.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_loganalysis.UseVisualStyleBackColor = true;
             this.BUT_loganalysis.Click += new System.EventHandler(this.BUT_loganalysis_Click);
             // 
@@ -2686,7 +2644,6 @@ namespace MissionPlanner.GCSViews
             this.but_disablejoystick.ColorNotEnabled = System.Drawing.Color.Empty;
             resources.ApplyResources(this.but_disablejoystick, "but_disablejoystick");
             this.but_disablejoystick.Name = "but_disablejoystick";
-            this.but_disablejoystick.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_disablejoystick.UseVisualStyleBackColor = true;
             this.but_disablejoystick.Click += new System.EventHandler(this.but_disablejoystick_Click);
             // 

--- a/GCSViews/FlightPlanner.Designer.cs
+++ b/GCSViews/FlightPlanner.Designer.cs
@@ -298,7 +298,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.but_writewpfast, "but_writewpfast");
             this.but_writewpfast.Name = "but_writewpfast";
-            this.but_writewpfast.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_writewpfast.UseVisualStyleBackColor = true;
             this.but_writewpfast.Click += new System.EventHandler(this.but_writewpfast_Click);
             // 
@@ -306,7 +305,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_write, "BUT_write");
             this.BUT_write.Name = "BUT_write";
-            this.BUT_write.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_write.UseVisualStyleBackColor = true;
             this.BUT_write.Click += new System.EventHandler(this.BUT_write_Click);
             // 
@@ -314,7 +312,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_read, "BUT_read");
             this.BUT_read.Name = "BUT_read";
-            this.BUT_read.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_read.UseVisualStyleBackColor = true;
             this.BUT_read.Click += new System.EventHandler(this.BUT_read_Click);
             // 
@@ -443,7 +440,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.but_mincommands, "but_mincommands");
             this.but_mincommands.Name = "but_mincommands";
-            this.but_mincommands.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_mincommands.UseVisualStyleBackColor = true;
             this.but_mincommands.Click += new System.EventHandler(this.but_mincommands_Click);
             // 
@@ -662,7 +658,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_Add, "BUT_Add");
             this.BUT_Add.Name = "BUT_Add";
-            this.BUT_Add.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.toolTip1.SetToolTip(this.BUT_Add, resources.GetString("BUT_Add.ToolTip"));
             this.BUT_Add.UseVisualStyleBackColor = true;
             this.BUT_Add.Click += new System.EventHandler(this.BUT_Add_Click);
@@ -761,7 +756,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_loadwpfile, "BUT_loadwpfile");
             this.BUT_loadwpfile.Name = "BUT_loadwpfile";
-            this.BUT_loadwpfile.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_loadwpfile.UseVisualStyleBackColor = true;
             this.BUT_loadwpfile.Click += new System.EventHandler(this.BUT_loadwpfile_Click);
             // 
@@ -769,7 +763,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.BUT_saveWPFile, "BUT_saveWPFile");
             this.BUT_saveWPFile.Name = "BUT_saveWPFile";
-            this.BUT_saveWPFile.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_saveWPFile.UseVisualStyleBackColor = true;
             this.BUT_saveWPFile.Click += new System.EventHandler(this.BUT_saveWPFile_Click);
             // 

--- a/GCSViews/SITL.Designer.cs
+++ b/GCSViews/SITL.Designer.cs
@@ -237,7 +237,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.but_swarmrover, "but_swarmrover");
             this.but_swarmrover.Name = "but_swarmrover";
-            this.but_swarmrover.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_swarmrover.UseVisualStyleBackColor = true;
             this.but_swarmrover.Click += new System.EventHandler(this.but_swarmrover_Click);
             // 
@@ -245,7 +244,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.but_swarmplane, "but_swarmplane");
             this.but_swarmplane.Name = "but_swarmplane";
-            this.but_swarmplane.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_swarmplane.UseVisualStyleBackColor = true;
             this.but_swarmplane.Click += new System.EventHandler(this.but_swarmplane_Click);
             // 
@@ -253,7 +251,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.but_swarmseq, "but_swarmseq");
             this.but_swarmseq.Name = "but_swarmseq";
-            this.but_swarmseq.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_swarmseq.UseVisualStyleBackColor = true;
             this.but_swarmseq.Click += new System.EventHandler(this.but_swarmseq_Click);
             // 
@@ -261,7 +258,6 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.but_swarmlink, "but_swarmlink");
             this.but_swarmlink.Name = "but_swarmlink";
-            this.but_swarmlink.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_swarmlink.UseVisualStyleBackColor = true;
             this.but_swarmlink.Click += new System.EventHandler(this.but_swarmlink_Click);
             // 

--- a/GeoRef/Georefimage.Designer.cs
+++ b/GeoRef/Georefimage.Designer.cs
@@ -109,7 +109,6 @@ namespace MissionPlanner.GeoRef
             // 
             resources.ApplyResources(this.BUT_Geotagimages, "BUT_Geotagimages");
             this.BUT_Geotagimages.Name = "BUT_Geotagimages";
-            this.BUT_Geotagimages.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Geotagimages.UseVisualStyleBackColor = true;
             this.BUT_Geotagimages.Click += new System.EventHandler(this.BUT_Geotagimages_Click);
             // 
@@ -117,7 +116,6 @@ namespace MissionPlanner.GeoRef
             // 
             resources.ApplyResources(this.BUT_estoffset, "BUT_estoffset");
             this.BUT_estoffset.Name = "BUT_estoffset";
-            this.BUT_estoffset.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_estoffset.UseVisualStyleBackColor = true;
             this.BUT_estoffset.Click += new System.EventHandler(this.BUT_estoffset_Click);
             // 
@@ -125,7 +123,6 @@ namespace MissionPlanner.GeoRef
             // 
             resources.ApplyResources(this.BUT_doit, "BUT_doit");
             this.BUT_doit.Name = "BUT_doit";
-            this.BUT_doit.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_doit.UseVisualStyleBackColor = true;
             this.BUT_doit.Click += new System.EventHandler(this.BUT_doit_Click);
             // 
@@ -133,7 +130,6 @@ namespace MissionPlanner.GeoRef
             // 
             resources.ApplyResources(this.BUT_browsedir, "BUT_browsedir");
             this.BUT_browsedir.Name = "BUT_browsedir";
-            this.BUT_browsedir.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_browsedir.UseVisualStyleBackColor = true;
             this.BUT_browsedir.Click += new System.EventHandler(this.BUT_browsedir_Click);
             // 
@@ -141,7 +137,6 @@ namespace MissionPlanner.GeoRef
             // 
             resources.ApplyResources(this.BUT_browselog, "BUT_browselog");
             this.BUT_browselog.Name = "BUT_browselog";
-            this.BUT_browselog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_browselog.UseVisualStyleBackColor = true;
             this.BUT_browselog.Click += new System.EventHandler(this.BUT_browselog_Click);
             // 
@@ -149,7 +144,6 @@ namespace MissionPlanner.GeoRef
             // 
             resources.ApplyResources(this.BUT_networklinkgeoref, "BUT_networklinkgeoref");
             this.BUT_networklinkgeoref.Name = "BUT_networklinkgeoref";
-            this.BUT_networklinkgeoref.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_networklinkgeoref.UseVisualStyleBackColor = true;
             this.BUT_networklinkgeoref.Click += new System.EventHandler(this.BUT_networklinkgeoref_Click);
             // 

--- a/Joystick/JoystickSetup.Designer.cs
+++ b/Joystick/JoystickSetup.Designer.cs
@@ -98,7 +98,6 @@ namespace MissionPlanner.Joystick
             // 
             resources.ApplyResources(this.BUT_enable, "BUT_enable");
             this.BUT_enable.Name = "BUT_enable";
-            this.BUT_enable.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_enable.UseVisualStyleBackColor = true;
             this.BUT_enable.Click += new System.EventHandler(this.BUT_enable_Click);
             // 
@@ -106,7 +105,6 @@ namespace MissionPlanner.Joystick
             // 
             resources.ApplyResources(this.BUT_save, "BUT_save");
             this.BUT_save.Name = "BUT_save";
-            this.BUT_save.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_save.UseVisualStyleBackColor = true;
             this.BUT_save.Click += new System.EventHandler(this.BUT_save_Click);
             // 
@@ -126,7 +124,6 @@ namespace MissionPlanner.Joystick
             // 
             resources.ApplyResources(this.but_export, "but_export");
             this.but_export.Name = "but_export";
-            this.but_export.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_export.UseVisualStyleBackColor = true;
             this.but_export.Click += new System.EventHandler(this.but_export_Click);
             // 
@@ -134,7 +131,6 @@ namespace MissionPlanner.Joystick
             // 
             resources.ApplyResources(this.but_import, "but_import");
             this.but_import.Name = "but_import";
-            this.but_import.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_import.UseVisualStyleBackColor = true;
             this.but_import.Click += new System.EventHandler(this.but_import_Click);
             // 

--- a/Log/LogIndex.Designer.cs
+++ b/Log/LogIndex.Designer.cs
@@ -180,7 +180,6 @@
             this.BUT_changedir.Size = new System.Drawing.Size(99, 23);
             this.BUT_changedir.TabIndex = 1;
             this.BUT_changedir.Text = "Custom Directory";
-            this.BUT_changedir.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_changedir.UseVisualStyleBackColor = true;
             this.BUT_changedir.Click += new System.EventHandler(this.BUT_changedir_Click);
             // 
@@ -192,7 +191,6 @@
             this.btnDeleteLog.Size = new System.Drawing.Size(104, 23);
             this.btnDeleteLog.TabIndex = 2;
             this.btnDeleteLog.Text = "Delete selected";
-            this.btnDeleteLog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.btnDeleteLog.UseVisualStyleBackColor = true;
             this.btnDeleteLog.Click += new System.EventHandler(this.btnDeleteLog_Click);
             // 
@@ -213,7 +211,6 @@
             this.but_defaultlogdir.Size = new System.Drawing.Size(99, 23);
             this.but_defaultlogdir.TabIndex = 4;
             this.but_defaultlogdir.Text = "Default Log Dir";
-            this.but_defaultlogdir.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_defaultlogdir.UseVisualStyleBackColor = true;
             this.but_defaultlogdir.Click += new System.EventHandler(this.but_defaultlogdir_Click);
             // 

--- a/Swarm/FollowPathControl.Designer.cs
+++ b/Swarm/FollowPathControl.Designer.cs
@@ -53,72 +53,52 @@
             // 
             // BUT_connect
             // 
-            this.BUT_connect.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_connect.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             this.BUT_connect.Location = new System.Drawing.Point(301, 12);
             this.BUT_connect.Name = "BUT_connect";
-            this.BUT_connect.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
             this.BUT_connect.Size = new System.Drawing.Size(75, 23);
             this.BUT_connect.TabIndex = 7;
             this.BUT_connect.Text = "Connect MAVs";
-            this.BUT_connect.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_connect.UseVisualStyleBackColor = true;
             this.BUT_connect.Click += new System.EventHandler(this.BUT_connect_Click);
             // 
             // BUT_Start
             // 
-            this.BUT_Start.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_Start.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             this.BUT_Start.Enabled = false;
             this.BUT_Start.Location = new System.Drawing.Point(463, 12);
             this.BUT_Start.Name = "BUT_Start";
-            this.BUT_Start.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
             this.BUT_Start.Size = new System.Drawing.Size(75, 23);
             this.BUT_Start.TabIndex = 6;
             this.BUT_Start.Text = Strings.Start;
-            this.BUT_Start.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Start.UseVisualStyleBackColor = true;
             this.BUT_Start.Click += new System.EventHandler(this.BUT_Start_Click);
             // 
             // BUT_leader
             // 
-            this.BUT_leader.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_leader.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             this.BUT_leader.Location = new System.Drawing.Point(382, 12);
             this.BUT_leader.Name = "BUT_leader";
-            this.BUT_leader.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
             this.BUT_leader.Size = new System.Drawing.Size(75, 23);
             this.BUT_leader.TabIndex = 5;
             this.BUT_leader.Text = "Set Leader";
-            this.BUT_leader.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_leader.UseVisualStyleBackColor = true;
             this.BUT_leader.Click += new System.EventHandler(this.BUT_leader_Click);
             // 
             // BUT_Disarm
             // 
-            this.BUT_Disarm.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_Disarm.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             this.BUT_Disarm.Location = new System.Drawing.Point(93, 12);
             this.BUT_Disarm.Name = "BUT_Disarm";
-            this.BUT_Disarm.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
             this.BUT_Disarm.Size = new System.Drawing.Size(75, 23);
             this.BUT_Disarm.TabIndex = 1;
             this.BUT_Disarm.Text = "Disarm (exl leader)";
-            this.BUT_Disarm.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Disarm.UseVisualStyleBackColor = true;
             this.BUT_Disarm.Click += new System.EventHandler(this.BUT_Disarm_Click);
             // 
             // BUT_Arm
             // 
-            this.BUT_Arm.BGGradBot = System.Drawing.Color.FromArgb(((int)(((byte)(205)))), ((int)(((byte)(226)))), ((int)(((byte)(150)))));
-            this.BUT_Arm.BGGradTop = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(193)))), ((int)(((byte)(31)))));
             this.BUT_Arm.Location = new System.Drawing.Point(12, 12);
             this.BUT_Arm.Name = "BUT_Arm";
-            this.BUT_Arm.Outline = System.Drawing.Color.FromArgb(((int)(((byte)(121)))), ((int)(((byte)(148)))), ((int)(((byte)(41)))));
             this.BUT_Arm.Size = new System.Drawing.Size(75, 23);
             this.BUT_Arm.TabIndex = 0;
             this.BUT_Arm.Text = "Arm (exl leader)";
-            this.BUT_Arm.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_Arm.UseVisualStyleBackColor = true;
             this.BUT_Arm.Click += new System.EventHandler(this.BUT_Arm_Click);
             // 

--- a/temp.Designer.cs
+++ b/temp.Designer.cs
@@ -286,7 +286,6 @@
             // 
             resources.ApplyResources(this.BUT_forcecal_accel, "BUT_forcecal_accel");
             this.BUT_forcecal_accel.Name = "BUT_forcecal_accel";
-            this.BUT_forcecal_accel.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_forcecal_accel.UseVisualStyleBackColor = true;
             this.BUT_forcecal_accel.Click += new System.EventHandler(this.BUT_forcecal_accel_Click);
             // 
@@ -294,7 +293,6 @@
             // 
             resources.ApplyResources(this.BUT_forcecal_mag, "BUT_forcecal_mag");
             this.BUT_forcecal_mag.Name = "BUT_forcecal_mag";
-            this.BUT_forcecal_mag.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_forcecal_mag.UseVisualStyleBackColor = true;
             this.BUT_forcecal_mag.Click += new System.EventHandler(this.BUT_forcecal_mag_Click);
             // 
@@ -302,7 +300,6 @@
             // 
             resources.ApplyResources(this.but_apjtool, "but_apjtool");
             this.but_apjtool.Name = "but_apjtool";
-            this.but_apjtool.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_apjtool.UseVisualStyleBackColor = true;
             this.but_apjtool.Click += new System.EventHandler(this.but_signfw_Click);
             // 
@@ -310,7 +307,6 @@
             // 
             resources.ApplyResources(this.BUT_CoT, "BUT_CoT");
             this.BUT_CoT.Name = "BUT_CoT";
-            this.BUT_CoT.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_CoT.UseVisualStyleBackColor = true;
             this.BUT_CoT.Click += new System.EventHandler(this.BUT_CoT_Click);
             // 
@@ -318,7 +314,6 @@
             // 
             resources.ApplyResources(this.but_proximity, "but_proximity");
             this.but_proximity.Name = "but_proximity";
-            this.but_proximity.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_proximity.UseVisualStyleBackColor = true;
             this.but_proximity.Click += new System.EventHandler(this.but_proximity_Click);
             // 
@@ -326,7 +321,6 @@
             // 
             resources.ApplyResources(this.but_followswarm, "but_followswarm");
             this.but_followswarm.Name = "but_followswarm";
-            this.but_followswarm.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_followswarm.UseVisualStyleBackColor = true;
             this.but_followswarm.Click += new System.EventHandler(this.but_followswarm_Click);
             // 
@@ -339,7 +333,6 @@
             // 
             resources.ApplyResources(this.but_lockup, "but_lockup");
             this.but_lockup.Name = "but_lockup";
-            this.but_lockup.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_lockup.UseVisualStyleBackColor = true;
             this.but_lockup.Click += new System.EventHandler(this.but_lockup_Click);
             // 
@@ -347,7 +340,6 @@
             // 
             resources.ApplyResources(this.but_td, "but_td");
             this.but_td.Name = "but_td";
-            this.but_td.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_td.UseVisualStyleBackColor = true;
             this.but_td.Click += new System.EventHandler(this.but_td_Click);
             // 
@@ -355,7 +347,6 @@
             // 
             resources.ApplyResources(this.but_gpsinj, "but_gpsinj");
             this.but_gpsinj.Name = "but_gpsinj";
-            this.but_gpsinj.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_gpsinj.UseVisualStyleBackColor = true;
             this.but_gpsinj.Click += new System.EventHandler(this.but_gpsinj_Click);
             // 
@@ -363,7 +354,6 @@
             // 
             resources.ApplyResources(this.but_dem, "but_dem");
             this.but_dem.Name = "but_dem";
-            this.but_dem.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_dem.UseVisualStyleBackColor = true;
             this.but_dem.Click += new System.EventHandler(this.but_dem_Click);
             // 
@@ -371,7 +361,6 @@
             // 
             resources.ApplyResources(this.BUT_magfit2, "BUT_magfit2");
             this.BUT_magfit2.Name = "BUT_magfit2";
-            this.BUT_magfit2.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_magfit2.UseVisualStyleBackColor = true;
             this.BUT_magfit2.Click += new System.EventHandler(this.BUT_magfit2_Click);
             // 
@@ -379,7 +368,6 @@
             // 
             resources.ApplyResources(this.but_GDAL, "but_GDAL");
             this.but_GDAL.Name = "but_GDAL";
-            this.but_GDAL.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_GDAL.UseVisualStyleBackColor = true;
             this.but_GDAL.Click += new System.EventHandler(this.but_GDAL_Click);
             // 
@@ -387,7 +375,6 @@
             // 
             resources.ApplyResources(this.but_sortlogs, "but_sortlogs");
             this.but_sortlogs.Name = "but_sortlogs";
-            this.but_sortlogs.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_sortlogs.UseVisualStyleBackColor = true;
             this.but_sortlogs.Click += new System.EventHandler(this.but_sortlogs_Click);
             // 
@@ -395,7 +382,6 @@
             // 
             resources.ApplyResources(this.but_optflowcalib, "but_optflowcalib");
             this.but_optflowcalib.Name = "but_optflowcalib";
-            this.but_optflowcalib.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_optflowcalib.UseVisualStyleBackColor = true;
             this.but_optflowcalib.Click += new System.EventHandler(this.but_optflowcalib_Click);
             // 
@@ -403,7 +389,6 @@
             // 
             resources.ApplyResources(this.but_logdlscp, "but_logdlscp");
             this.but_logdlscp.Name = "but_logdlscp";
-            this.but_logdlscp.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_logdlscp.UseVisualStyleBackColor = true;
             this.but_logdlscp.Click += new System.EventHandler(this.but_logdlscp_Click);
             // 
@@ -411,7 +396,6 @@
             // 
             resources.ApplyResources(this.but_signkey, "but_signkey");
             this.but_signkey.Name = "but_signkey";
-            this.but_signkey.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_signkey.UseVisualStyleBackColor = true;
             this.but_signkey.Click += new System.EventHandler(this.but_signkey_Click);
             // 
@@ -419,7 +403,6 @@
             // 
             resources.ApplyResources(this.but_acbarohight, "but_acbarohight");
             this.but_acbarohight.Name = "but_acbarohight";
-            this.but_acbarohight.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_acbarohight.UseVisualStyleBackColor = true;
             this.but_acbarohight.Click += new System.EventHandler(this.but_acbarohight_Click);
             // 
@@ -427,7 +410,6 @@
             // 
             resources.ApplyResources(this.myButton1, "myButton1");
             this.myButton1.Name = "myButton1";
-            this.myButton1.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.myButton1.UseVisualStyleBackColor = true;
             this.myButton1.Click += new System.EventHandler(this.myButton1_Click_2);
             // 
@@ -435,7 +417,6 @@
             // 
             resources.ApplyResources(this.but_driverclean, "but_driverclean");
             this.but_driverclean.Name = "but_driverclean";
-            this.but_driverclean.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_driverclean.UseVisualStyleBackColor = true;
             this.but_driverclean.Click += new System.EventHandler(this.BUT_driverclean_Click);
             // 
@@ -443,7 +424,6 @@
             // 
             resources.ApplyResources(this.but_agemapdata, "but_agemapdata");
             this.but_agemapdata.Name = "but_agemapdata";
-            this.but_agemapdata.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_agemapdata.UseVisualStyleBackColor = true;
             this.but_agemapdata.Click += new System.EventHandler(this.but_agemapdata_Click);
             // 
@@ -451,7 +431,6 @@
             // 
             resources.ApplyResources(this.but_packetbytes, "but_packetbytes");
             this.but_packetbytes.Name = "but_packetbytes";
-            this.but_packetbytes.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_packetbytes.UseVisualStyleBackColor = true;
             this.but_packetbytes.Click += new System.EventHandler(this.but_packetbytes_Click);
             // 
@@ -459,7 +438,6 @@
             // 
             resources.ApplyResources(this.myButton_vlc, "myButton_vlc");
             this.myButton_vlc.Name = "myButton_vlc";
-            this.myButton_vlc.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.myButton_vlc.UseVisualStyleBackColor = true;
             this.myButton_vlc.Click += new System.EventHandler(this.myButton_vlc_Click);
             // 
@@ -472,7 +450,6 @@
             // 
             resources.ApplyResources(this.but_trimble, "but_trimble");
             this.but_trimble.Name = "but_trimble";
-            this.but_trimble.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_trimble.UseVisualStyleBackColor = true;
             this.but_trimble.Click += new System.EventHandler(this.but_trimble_Click);
             // 
@@ -480,7 +457,6 @@
             // 
             resources.ApplyResources(this.but_hwids, "but_hwids");
             this.but_hwids.Name = "but_hwids";
-            this.but_hwids.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_hwids.UseVisualStyleBackColor = true;
             this.but_hwids.Click += new System.EventHandler(this.but_hwids_Click);
             // 
@@ -488,7 +464,6 @@
             // 
             resources.ApplyResources(this.BUT_QNH, "BUT_QNH");
             this.BUT_QNH.Name = "BUT_QNH";
-            this.BUT_QNH.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_QNH.UseVisualStyleBackColor = true;
             this.BUT_QNH.Click += new System.EventHandler(this.BUT_QNH_Click);
             // 
@@ -496,7 +471,6 @@
             // 
             resources.ApplyResources(this.but_reboot, "but_reboot");
             this.but_reboot.Name = "but_reboot";
-            this.but_reboot.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_reboot.UseVisualStyleBackColor = true;
             this.but_reboot.Click += new System.EventHandler(this.but_reboot_Click);
             // 
@@ -504,7 +478,6 @@
             // 
             resources.ApplyResources(this.but_3dmap, "but_3dmap");
             this.but_3dmap.Name = "but_3dmap";
-            this.but_3dmap.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_3dmap.UseVisualStyleBackColor = true;
             this.but_3dmap.Click += new System.EventHandler(this.but_3dmap_Click);
             // 
@@ -512,7 +485,6 @@
             // 
             resources.ApplyResources(this.but_messageinterval, "but_messageinterval");
             this.but_messageinterval.Name = "but_messageinterval";
-            this.but_messageinterval.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_messageinterval.UseVisualStyleBackColor = true;
             this.but_messageinterval.Click += new System.EventHandler(this.but_messageinterval_Click);
             // 
@@ -520,7 +492,6 @@
             // 
             resources.ApplyResources(this.but_blupdate, "but_blupdate");
             this.but_blupdate.Name = "but_blupdate";
-            this.but_blupdate.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_blupdate.UseVisualStyleBackColor = true;
             this.but_blupdate.Click += new System.EventHandler(this.but_blupdate_Click);
             // 
@@ -528,7 +499,6 @@
             // 
             resources.ApplyResources(this.BUT_fft, "BUT_fft");
             this.BUT_fft.Name = "BUT_fft";
-            this.BUT_fft.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_fft.UseVisualStyleBackColor = true;
             this.BUT_fft.Click += new System.EventHandler(this.BUT_fft_Click);
             // 
@@ -536,7 +506,6 @@
             // 
             resources.ApplyResources(this.but_disablearmswitch, "but_disablearmswitch");
             this.but_disablearmswitch.Name = "but_disablearmswitch";
-            this.but_disablearmswitch.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_disablearmswitch.UseVisualStyleBackColor = true;
             this.but_disablearmswitch.Click += new System.EventHandler(this.but_disablearmswitch_Click);
             // 
@@ -544,7 +513,6 @@
             // 
             resources.ApplyResources(this.but_paramrestore, "but_paramrestore");
             this.but_paramrestore.Name = "but_paramrestore";
-            this.but_paramrestore.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_paramrestore.UseVisualStyleBackColor = true;
             this.but_paramrestore.Click += new System.EventHandler(this.but_paramrestore_Click);
             // 
@@ -552,7 +520,6 @@
             // 
             resources.ApplyResources(this.but_mavinspector, "but_mavinspector");
             this.but_mavinspector.Name = "but_mavinspector";
-            this.but_mavinspector.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_mavinspector.UseVisualStyleBackColor = true;
             this.but_mavinspector.Click += new System.EventHandler(this.but_mavinspector_Click);
             // 
@@ -560,7 +527,6 @@
             // 
             resources.ApplyResources(this.but_sitl_comb, "but_sitl_comb");
             this.but_sitl_comb.Name = "but_sitl_comb";
-            this.but_sitl_comb.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_sitl_comb.UseVisualStyleBackColor = true;
             this.but_sitl_comb.Click += new System.EventHandler(this.but_sitl_comb_Click);
             // 
@@ -568,7 +534,6 @@
             // 
             resources.ApplyResources(this.but_anonlog, "but_anonlog");
             this.but_anonlog.Name = "but_anonlog";
-            this.but_anonlog.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_anonlog.UseVisualStyleBackColor = true;
             this.but_anonlog.Click += new System.EventHandler(this.but_anonlog_Click);
             // 
@@ -576,7 +541,6 @@
             // 
             resources.ApplyResources(this.but_dashware, "but_dashware");
             this.but_dashware.Name = "but_dashware";
-            this.but_dashware.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_dashware.UseVisualStyleBackColor = true;
             this.but_dashware.Click += new System.EventHandler(this.but_dashware_Click);
             // 
@@ -624,7 +588,6 @@
             // 
             resources.ApplyResources(this.butlogindex, "butlogindex");
             this.butlogindex.Name = "butlogindex";
-            this.butlogindex.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.butlogindex.UseVisualStyleBackColor = true;
             this.butlogindex.Click += new System.EventHandler(this.butlogindex_Click);
             // 
@@ -632,14 +595,12 @@
             // 
             resources.ApplyResources(this.but_armandtakeoff, "but_armandtakeoff");
             this.but_armandtakeoff.Name = "but_armandtakeoff";
-            this.but_armandtakeoff.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_armandtakeoff.Click += new System.EventHandler(this.but_armandtakeoff_Click);
             // 
             // but_maplogs
             // 
             resources.ApplyResources(this.but_maplogs, "but_maplogs");
             this.but_maplogs.Name = "but_maplogs";
-            this.but_maplogs.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_maplogs.UseVisualStyleBackColor = true;
             this.but_maplogs.Click += new System.EventHandler(this.but_maplogs_Click);
             // 
@@ -652,7 +613,6 @@
             // 
             resources.ApplyResources(this.but_gimbaltest, "but_gimbaltest");
             this.but_gimbaltest.Name = "but_gimbaltest";
-            this.but_gimbaltest.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_gimbaltest.UseVisualStyleBackColor = true;
             this.but_gimbaltest.Click += new System.EventHandler(this.but_gimbaltest_Click);
             // 
@@ -660,7 +620,6 @@
             // 
             resources.ApplyResources(this.but_structtest, "but_structtest");
             this.but_structtest.Name = "but_structtest";
-            this.but_structtest.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_structtest.UseVisualStyleBackColor = true;
             this.but_structtest.Click += new System.EventHandler(this.but_structtest_Click);
             // 
@@ -698,7 +657,6 @@
             // 
             resources.ApplyResources(this.BUT_clearcustommaps, "BUT_clearcustommaps");
             this.BUT_clearcustommaps.Name = "BUT_clearcustommaps";
-            this.BUT_clearcustommaps.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_clearcustommaps.UseVisualStyleBackColor = true;
             this.BUT_clearcustommaps.Click += new System.EventHandler(this.BUT_clearcustommaps_Click);
             // 
@@ -706,7 +664,6 @@
             // 
             resources.ApplyResources(this.but_getfw, "but_getfw");
             this.but_getfw.Name = "but_getfw";
-            this.but_getfw.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_getfw.UseVisualStyleBackColor = true;
             this.but_getfw.Click += new System.EventHandler(this.but_getfw_Click);
             // 
@@ -714,7 +671,6 @@
             // 
             resources.ApplyResources(this.BUT_geinjection, "BUT_geinjection");
             this.BUT_geinjection.Name = "BUT_geinjection";
-            this.BUT_geinjection.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_geinjection.UseVisualStyleBackColor = true;
             this.BUT_geinjection.Click += new System.EventHandler(this.BUT_geinjection_Click);
             // 
@@ -732,7 +688,6 @@
             // 
             resources.ApplyResources(this.BUT_sorttlogs, "BUT_sorttlogs");
             this.BUT_sorttlogs.Name = "BUT_sorttlogs";
-            this.BUT_sorttlogs.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_sorttlogs.UseVisualStyleBackColor = true;
             this.BUT_sorttlogs.Click += new System.EventHandler(this.BUT_sorttlogs_Click);
             // 
@@ -765,7 +720,6 @@
             // 
             resources.ApplyResources(this.BUT_outputMavlink, "BUT_outputMavlink");
             this.BUT_outputMavlink.Name = "BUT_outputMavlink";
-            this.BUT_outputMavlink.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_outputMavlink.UseVisualStyleBackColor = true;
             this.BUT_outputMavlink.Click += new System.EventHandler(this.BUT_outputMavlink_Click);
             // 
@@ -773,7 +727,6 @@
             // 
             resources.ApplyResources(this.BUT_outputMD, "BUT_outputMD");
             this.BUT_outputMD.Name = "BUT_outputMD";
-            this.BUT_outputMD.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_outputMD.UseVisualStyleBackColor = true;
             this.BUT_outputMD.Click += new System.EventHandler(this.myButton1_Click);
             // 
@@ -781,7 +734,6 @@
             // 
             resources.ApplyResources(this.BUT_outputnmea, "BUT_outputnmea");
             this.BUT_outputnmea.Name = "BUT_outputnmea";
-            this.BUT_outputnmea.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_outputnmea.UseVisualStyleBackColor = true;
             this.BUT_outputnmea.Click += new System.EventHandler(this.BUT_outputnmea_Click);
             // 
@@ -789,14 +741,12 @@
             // 
             resources.ApplyResources(this.BUT_georefimage, "BUT_georefimage");
             this.BUT_georefimage.Name = "BUT_georefimage";
-            this.BUT_georefimage.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_georefimage.Click += new System.EventHandler(this.BUT_georefimage_Click);
             // 
             // button3
             // 
             resources.ApplyResources(this.button3, "button3");
             this.button3.Name = "button3";
-            this.button3.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.button3_Click);
             // 
@@ -804,7 +754,6 @@
             // 
             resources.ApplyResources(this.BUT_lang_edit, "BUT_lang_edit");
             this.BUT_lang_edit.Name = "BUT_lang_edit";
-            this.BUT_lang_edit.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_lang_edit.UseVisualStyleBackColor = true;
             this.BUT_lang_edit.Click += new System.EventHandler(this.BUT_lang_edit_Click);
             // 
@@ -812,7 +761,6 @@
             // 
             resources.ApplyResources(this.BUT_follow_me, "BUT_follow_me");
             this.BUT_follow_me.Name = "BUT_follow_me";
-            this.BUT_follow_me.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_follow_me.UseVisualStyleBackColor = true;
             this.BUT_follow_me.Click += new System.EventHandler(this.BUT_follow_me_Click);
             // 
@@ -820,7 +768,6 @@
             // 
             resources.ApplyResources(this.BUT_paramgen, "BUT_paramgen");
             this.BUT_paramgen.Name = "BUT_paramgen";
-            this.BUT_paramgen.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_paramgen.UseVisualStyleBackColor = true;
             this.BUT_paramgen.Click += new System.EventHandler(this.BUT_paramgen_Click);
             // 
@@ -828,7 +775,6 @@
             // 
             resources.ApplyResources(this.but_osdvideo, "but_osdvideo");
             this.but_osdvideo.Name = "but_osdvideo";
-            this.but_osdvideo.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_osdvideo.UseVisualStyleBackColor = true;
             this.but_osdvideo.Click += new System.EventHandler(this.but_osdvideo_Click);
             // 
@@ -836,7 +782,6 @@
             // 
             resources.ApplyResources(this.BUT_movingbase, "BUT_movingbase");
             this.BUT_movingbase.Name = "BUT_movingbase";
-            this.BUT_movingbase.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_movingbase.UseVisualStyleBackColor = true;
             this.BUT_movingbase.Click += new System.EventHandler(this.BUT_movingbase_Click);
             // 
@@ -844,7 +789,6 @@
             // 
             resources.ApplyResources(this.BUT_shptopoly, "BUT_shptopoly");
             this.BUT_shptopoly.Name = "BUT_shptopoly";
-            this.BUT_shptopoly.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_shptopoly.UseVisualStyleBackColor = true;
             this.BUT_shptopoly.Click += new System.EventHandler(this.BUT_shptopoly_Click);
             // 
@@ -852,7 +796,6 @@
             // 
             resources.ApplyResources(this.BUT_swarm, "BUT_swarm");
             this.BUT_swarm.Name = "BUT_swarm";
-            this.BUT_swarm.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_swarm.UseVisualStyleBackColor = true;
             this.BUT_swarm.Click += new System.EventHandler(this.BUT_swarm_Click);
             // 
@@ -860,7 +803,6 @@
             // 
             resources.ApplyResources(this.BUT_followleader, "BUT_followleader");
             this.BUT_followleader.Name = "BUT_followleader";
-            this.BUT_followleader.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_followleader.UseVisualStyleBackColor = true;
             this.BUT_followleader.Click += new System.EventHandler(this.BUT_followleader_Click);
             // 
@@ -873,7 +815,6 @@
             // 
             resources.ApplyResources(this.but_mavserialport, "but_mavserialport");
             this.but_mavserialport.Name = "but_mavserialport";
-            this.but_mavserialport.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_mavserialport.UseVisualStyleBackColor = true;
             this.but_mavserialport.Click += new System.EventHandler(this.but_mavserialport_Click);
             // 
@@ -881,7 +822,6 @@
             // 
             resources.ApplyResources(this.but_hexmavlink, "but_hexmavlink");
             this.but_hexmavlink.Name = "but_hexmavlink";
-            this.but_hexmavlink.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_hexmavlink.UseVisualStyleBackColor = true;
             this.but_hexmavlink.Click += new System.EventHandler(this.but_hexmavlink_Click);
             // 
@@ -1029,7 +969,6 @@
             // 
             resources.ApplyResources(this.but_remotedflogger, "but_remotedflogger");
             this.but_remotedflogger.Name = "but_remotedflogger";
-            this.but_remotedflogger.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_remotedflogger.UseVisualStyleBackColor = true;
             this.but_remotedflogger.Click += new System.EventHandler(this.but_remotedflogger_Click);
             // 
@@ -1042,7 +981,6 @@
             // 
             resources.ApplyResources(this.but_ManageCMDList, "but_ManageCMDList");
             this.but_ManageCMDList.Name = "but_ManageCMDList";
-            this.but_ManageCMDList.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_ManageCMDList.UseVisualStyleBackColor = true;
             this.but_ManageCMDList.Click += new System.EventHandler(this.but_ManageCMDList_Click);
             // 
@@ -1055,7 +993,6 @@
             // 
             resources.ApplyResources(this.but_dfumode, "but_dfumode");
             this.but_dfumode.Name = "but_dfumode";
-            this.but_dfumode.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_dfumode.UseVisualStyleBackColor = true;
             this.but_dfumode.Click += new System.EventHandler(this.but_dfumode_Click);
             // 


### PR DESCRIPTION
When creating a custom button based on MyButton, there is unecessary code for TextColorNotEnabled.
By adding the defaut value into the base code, it's not longer generated.
Remove this properties when the default value is used in every files.

Remove properties BGGradBot BGGradTop Outline TextColor because it's the default values.