### PR TITLE
Fix color and position of text messages in HUD

### DIFF
--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -3100,7 +3100,7 @@ namespace MissionPlanner.Controls
 
                     var newfontsize = calcfontsize(message, font, fontsize + 10, (SolidBrush) brush, Width - 50 - 50);
 
-                    var size = calcsize(message, newfontsize, (SolidBrush)Brushes.Red);
+                    var size = calcsize(message, newfontsize, (SolidBrush) brush);
 
                     drawstring(message, font, newfontsize, (SolidBrush) brush, size.Width / -2,
                         halfheight / 3);


### PR DESCRIPTION
When addind text with color different from red, it's not centered in the HUD :
<img width="947" height="534" alt="image" src="https://github.com/user-attachments/assets/991f72c9-cea5-4294-8c89-c23559cd2a08" />
<img width="941" height="485" alt="image" src="https://github.com/user-attachments/assets/54ba5860-d21e-4d26-9475-aebc42dcff11" />

Now with the color to calculate the size, the text is centerd in the HUD :
<img width="948" height="535" alt="image" src="https://github.com/user-attachments/assets/dcdf448c-8d36-4c36-a3c6-6d3832dd22b0" />
<img width="942" height="534" alt="image" src="https://github.com/user-attachments/assets/2a720c88-568c-4366-92b5-ec78a5138cc4" />
