### PR TITLE
FlightPlanner : Adding prefetch menu

### DIFF
--- a/ExtLibs/GMap.NET.Core/GMap.NET/PureProjection.cs
+++ b/ExtLibs/GMap.NET.Core/GMap.NET/PureProjection.cs
@@ -233,6 +233,16 @@ namespace GMap.NET
       }
 
       /// <summary>
+      /// get number of tiles in rect at specific zoom
+      /// </summary>
+      public long GetAreaTileNumber(RectLatLng rect, int zoom, int padding)
+      {
+         GPoint topLeft = FromPixelToTileXY(FromLatLngToPixel(rect.LocationTopLeft, zoom));
+         GPoint rightBottom = FromPixelToTileXY(FromLatLngToPixel(rect.LocationRightBottom, zoom));
+         return (rightBottom.X - topLeft.X + 1) * (rightBottom.Y - topLeft.Y + 1);
+      }
+
+      /// <summary>
       /// The ground resolution indicates the distance (in meters) on the ground that’s represented by a single pixel in the map.
       /// For example, at a ground resolution of 10 meters/pixel, each pixel represents a ground distance of 10 meters.
       /// </summary>

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
@@ -228,6 +228,7 @@ namespace GMap.NET
             list.Clear();
             list = null;
          }
+         worker.ReportProgress(0, 0);
          list = provider.Projection.GetAreaTileList(area, zoom, 0);
          maxOfTiles = provider.Projection.GetTileMatrixMaxXY(zoom);
          all = list.Count;

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcherMenu.Designer.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcherMenu.Designer.cs
@@ -1,0 +1,220 @@
+﻿namespace GMap.NET
+{
+    partial class TilePrefetcherMenu
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.trackBarMaxZoom = new System.Windows.Forms.TrackBar();
+            this.trackBarMinZoom = new System.Windows.Forms.TrackBar();
+            this.labelMaxZoom = new System.Windows.Forms.Label();
+            this.labelMinZoom = new System.Windows.Forms.Label();
+            this.buttonOK = new System.Windows.Forms.Button();
+            this.textBoxTile = new System.Windows.Forms.TextBox();
+            this.labelTotal = new System.Windows.Forms.Label();
+            this.numericUpDownMinZoom = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDownMaxZoom = new System.Windows.Forms.NumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarMaxZoom)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarMinZoom)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMinZoom)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMaxZoom)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(174, 360);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 0;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // trackBarMaxZoom
+            // 
+            this.trackBarMaxZoom.Location = new System.Drawing.Point(74, 46);
+            this.trackBarMaxZoom.Maximum = 20;
+            this.trackBarMaxZoom.Minimum = 1;
+            this.trackBarMaxZoom.Name = "trackBarMaxZoom";
+            this.trackBarMaxZoom.Orientation = System.Windows.Forms.Orientation.Vertical;
+            this.trackBarMaxZoom.Size = new System.Drawing.Size(45, 295);
+            this.trackBarMaxZoom.TabIndex = 1;
+            this.trackBarMaxZoom.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
+            this.trackBarMaxZoom.Value = 20;
+            this.trackBarMaxZoom.ValueChanged += new System.EventHandler(this.trackBarMaxZoom_ValueChanged);
+            // 
+            // trackBarMinZoom
+            // 
+            this.trackBarMinZoom.Location = new System.Drawing.Point(7, 46);
+            this.trackBarMinZoom.Maximum = 20;
+            this.trackBarMinZoom.Minimum = 1;
+            this.trackBarMinZoom.Name = "trackBarMinZoom";
+            this.trackBarMinZoom.Orientation = System.Windows.Forms.Orientation.Vertical;
+            this.trackBarMinZoom.Size = new System.Drawing.Size(45, 295);
+            this.trackBarMinZoom.TabIndex = 1;
+            this.trackBarMinZoom.Value = 1;
+            this.trackBarMinZoom.ValueChanged += new System.EventHandler(this.trackBarMinZoom_ValueChanged);
+            // 
+            // labelMaxZoom
+            // 
+            this.labelMaxZoom.AutoSize = true;
+            this.labelMaxZoom.Location = new System.Drawing.Point(74, 4);
+            this.labelMaxZoom.Name = "labelMaxZoom";
+            this.labelMaxZoom.Size = new System.Drawing.Size(64, 13);
+            this.labelMaxZoom.TabIndex = 2;
+            this.labelMaxZoom.Text = "Max zoom : ";
+            // 
+            // labelMinZoom
+            // 
+            this.labelMinZoom.AutoSize = true;
+            this.labelMinZoom.Location = new System.Drawing.Point(7, 4);
+            this.labelMinZoom.Name = "labelMinZoom";
+            this.labelMinZoom.Size = new System.Drawing.Size(61, 13);
+            this.labelMinZoom.TabIndex = 2;
+            this.labelMinZoom.Text = "Min zoom : ";
+            // 
+            // buttonOK
+            // 
+            this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOK.Location = new System.Drawing.Point(7, 360);
+            this.buttonOK.Name = "buttonOK";
+            this.buttonOK.Size = new System.Drawing.Size(75, 23);
+            this.buttonOK.TabIndex = 0;
+            this.buttonOK.Text = "OK";
+            this.buttonOK.UseVisualStyleBackColor = true;
+            // 
+            // textBoxTile
+            // 
+            this.textBoxTile.Location = new System.Drawing.Point(144, 7);
+            this.textBoxTile.Multiline = true;
+            this.textBoxTile.Name = "textBoxTile";
+            this.textBoxTile.ReadOnly = true;
+            this.textBoxTile.Size = new System.Drawing.Size(105, 334);
+            this.textBoxTile.TabIndex = 3;
+            // 
+            // labelTotal
+            // 
+            this.labelTotal.AutoSize = true;
+            this.labelTotal.Location = new System.Drawing.Point(7, 344);
+            this.labelTotal.Name = "labelTotal";
+            this.labelTotal.Size = new System.Drawing.Size(132, 13);
+            this.labelTotal.TabIndex = 4;
+            this.labelTotal.Text = "Estimated : 0 tiles for 0 MB";
+            // 
+            // numericUpDownMinZoom
+            // 
+            this.numericUpDownMinZoom.Location = new System.Drawing.Point(7, 20);
+            this.numericUpDownMinZoom.Maximum = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            this.numericUpDownMinZoom.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMinZoom.Name = "numericUpDownMinZoom";
+            this.numericUpDownMinZoom.Size = new System.Drawing.Size(61, 20);
+            this.numericUpDownMinZoom.TabIndex = 6;
+            this.numericUpDownMinZoom.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.numericUpDownMinZoom.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMinZoom.ValueChanged += new System.EventHandler(this.numericUpDownMinZoom_ValueChanged);
+            // 
+            // numericUpDownMaxZoom
+            // 
+            this.numericUpDownMaxZoom.Location = new System.Drawing.Point(74, 20);
+            this.numericUpDownMaxZoom.Maximum = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            this.numericUpDownMaxZoom.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMaxZoom.Name = "numericUpDownMaxZoom";
+            this.numericUpDownMaxZoom.Size = new System.Drawing.Size(61, 20);
+            this.numericUpDownMaxZoom.TabIndex = 6;
+            this.numericUpDownMaxZoom.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.numericUpDownMaxZoom.Value = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            this.numericUpDownMaxZoom.ValueChanged += new System.EventHandler(this.numericUpDownMaxZoom_ValueChanged);
+            // 
+            // TilePrefetcherMenu
+            // 
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(256, 388);
+            this.Controls.Add(this.numericUpDownMaxZoom);
+            this.Controls.Add(this.numericUpDownMinZoom);
+            this.Controls.Add(this.labelTotal);
+            this.Controls.Add(this.textBoxTile);
+            this.Controls.Add(this.labelMinZoom);
+            this.Controls.Add(this.labelMaxZoom);
+            this.Controls.Add(this.trackBarMinZoom);
+            this.Controls.Add(this.trackBarMaxZoom);
+            this.Controls.Add(this.buttonOK);
+            this.Controls.Add(this.buttonCancel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.KeyPreview = true;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "TilePrefetcherMenu";
+            this.Padding = new System.Windows.Forms.Padding(4);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Tile Prefetcher Menu";
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarMaxZoom)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarMinZoom)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMinZoom)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMaxZoom)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+        private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.TrackBar trackBarMaxZoom;
+        private System.Windows.Forms.TrackBar trackBarMinZoom;
+        private System.Windows.Forms.Label labelMaxZoom;
+        private System.Windows.Forms.Label labelMinZoom;
+        private System.Windows.Forms.Button buttonOK;
+        private System.Windows.Forms.TextBox textBoxTile;
+        private System.Windows.Forms.Label labelTotal;
+        private System.Windows.Forms.NumericUpDown numericUpDownMinZoom;
+        private System.Windows.Forms.NumericUpDown numericUpDownMaxZoom;
+    }
+}

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcherMenu.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcherMenu.cs
@@ -1,0 +1,157 @@
+using GMap.NET.MapProviders;
+using System;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace GMap.NET
+{
+    /// <summary>
+    /// form helping to prefetch tiles on local db
+    /// </summary>
+    public partial class TilePrefetcherMenu : Form
+    {
+        public int Minimum { get; set; } = 1;
+        public int Maximum { get; set; } = 20;
+
+        private RectLatLng area;
+        private GMapProvider provider;
+
+        public TilePrefetcherMenu(int min, int max, RectLatLng area, GMapProvider provider)
+        {
+            InitializeComponent();
+            numericUpDownMinZoom.Minimum = numericUpDownMaxZoom.Minimum = trackBarMinZoom.Minimum = trackBarMaxZoom.Minimum = min;
+            numericUpDownMinZoom.Maximum = numericUpDownMaxZoom.Maximum = trackBarMinZoom.Maximum = trackBarMaxZoom.Maximum = max;
+            this.area = area;
+            this.provider = provider;
+            UpdateTilesCount();
+        }
+
+        private void UpdateTilesCount()
+        {
+            long count = 0;
+            string results = "";
+            long total = 0;
+            var nfi = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+            nfi.NumberGroupSeparator = " ";
+            for (int i = Minimum; i <= Maximum; i++)
+            {
+                count = provider.Projection.GetAreaTileNumber(area, i, 0);
+
+                results += "Zoom " + i + " : " + count.ToString("#,0", nfi);
+                if (i < Maximum)
+                    results += Environment.NewLine;
+                total += count;
+            }
+            textBoxTile.Text = results;
+
+            long averageTileSize = 15000; // byte
+            labelTotal.Text = "Estimated: " + total.ToString("#,0", nfi) + " tile" + (total > 1 ? "s" : "") + " for " + sizeConverter(total * averageTileSize);
+        }
+        private string sizeConverter(float bytes)
+        {
+            try
+            {
+                float gb = 1024 * 1024 * 1024;
+                float mb = 1024 * 1024;
+                float kb = 1024;
+                float result = 0;
+                string ext = "";
+                if (bytes >= gb)
+                {
+                    result = bytes / gb;
+                    ext = " GB ";
+                }
+                else if (bytes >= mb)
+                {
+                    result = bytes / mb;
+                    ext = " MB ";
+                }
+                else if (bytes >= kb)
+                {
+                    result = bytes / kb;
+                    ext = " KB ";
+                }
+                else
+                {
+                    result = bytes;
+                    ext = " B ";
+                }
+                string ret = (result).ToString("N2") + ext;
+                return ret;
+            }
+            catch
+            {
+
+            }
+            return "";
+        }
+
+        private void numericUpDownMinZoom_ValueChanged(object sender, EventArgs e)
+        {
+            if (Minimum != (int)numericUpDownMinZoom.Value)
+            {
+                if ((int)numericUpDownMinZoom.Value <= (int)numericUpDownMaxZoom.Value)
+                {
+                    Minimum = (int)numericUpDownMinZoom.Value;
+                    trackBarMinZoom.Value = Minimum;
+                    UpdateTilesCount();
+                }
+                else
+                {
+                    numericUpDownMinZoom.Value = Minimum;
+                }
+            }
+        }
+
+        private void trackBarMinZoom_ValueChanged(object sender, EventArgs e)
+        {
+            if (Minimum != (int)trackBarMinZoom.Value)
+            {
+                if ((int)trackBarMinZoom.Value <= (int)trackBarMaxZoom.Value)
+                {
+                    Minimum = (int)trackBarMinZoom.Value;
+                    numericUpDownMinZoom.Value = Minimum;
+                    UpdateTilesCount();
+                }
+                else
+                {
+                    trackBarMinZoom.Value = Minimum;
+                }
+            }
+        }
+
+        private void numericUpDownMaxZoom_ValueChanged(object sender, EventArgs e)
+        {
+            if (Maximum != (int)numericUpDownMaxZoom.Value)
+            {
+                if ((int)numericUpDownMinZoom.Value <= (int)numericUpDownMaxZoom.Value)
+                {
+                    Maximum = (int)numericUpDownMaxZoom.Value;
+                    trackBarMaxZoom.Value = Maximum;
+                    UpdateTilesCount();
+                }
+                else
+                {
+                    numericUpDownMaxZoom.Value = Maximum;
+                }
+            }
+        }
+
+        private void trackBarMaxZoom_ValueChanged(object sender, EventArgs e)
+        {
+            if (Maximum != (int)trackBarMaxZoom.Value)
+            {
+                if ((int)trackBarMinZoom.Value <= (int)trackBarMaxZoom.Value)
+                {
+                    Maximum = (int)trackBarMaxZoom.Value;
+                    numericUpDownMaxZoom.Value = Maximum;
+                    UpdateTilesCount();
+                }
+                else
+                {
+                    trackBarMaxZoom.Value = Maximum;
+                }
+            }
+        }
+    }
+}

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcherMenu.resx
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcherMenu.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -1886,10 +1886,6 @@ namespace MissionPlanner.GCSViews
             }
         }
 
-        private void BUT_Prefetch_Click(object sender, EventArgs e)
-        {
-        }
-
         public void BUT_saveWPFile_Click(object sender, EventArgs e)
         {
             SaveFile_Click(null, null);
@@ -5052,38 +5048,18 @@ namespace MissionPlanner.GCSViews
 
             if (!area.IsEmpty)
             {
-                string maxzoomstring = "20";
-                if (InputBox.Show("max zoom", "Enter the max zoom to prefetch to.", ref maxzoomstring) !=
-                    DialogResult.OK)
-                    return;
+                int maxzoom = MainMap.MaxZoom;
+                int minzoom = MainMap.MinZoom;
+                TilePrefetcherMenu tilePrefetcherMenu = new TilePrefetcherMenu(MainMap.MinZoom, MainMap.MaxZoom, area, MainMap.MapProvider);
 
-                int maxzoom = 20;
-                if (!int.TryParse(maxzoomstring, out maxzoom))
+                if (tilePrefetcherMenu.ShowDialog(this) != DialogResult.OK)
                 {
-                    CustomMessageBox.Show(Strings.InvalidNumberEntered, Strings.ERROR);
+                    tilePrefetcherMenu.Dispose();
                     return;
                 }
-
-                maxzoom = Math.Min(maxzoom, MainMap.MaxZoom);
-
-                string minzoomstring = "1";
-                if (InputBox.Show("min zoom", "Enter the min zoom to prefetch to.", ref minzoomstring) !=
-                    DialogResult.OK)
-                    return;
-
-                int minzoom = 20;
-                if (!int.TryParse(minzoomstring, out minzoom))
-                {
-                    CustomMessageBox.Show(Strings.InvalidNumberEntered, Strings.ERROR);
-                    return;
-                }
-                minzoom = Math.Max(minzoom, MainMap.MinZoom);
-
-                if (minzoom > maxzoom)
-                {
-                    CustomMessageBox.Show(Strings.InvalidNumberEntered, Strings.ERROR);
-                    return;
-                }
+                minzoom = tilePrefetcherMenu.Minimum;
+                maxzoom = tilePrefetcherMenu.Maximum;
+                tilePrefetcherMenu.Dispose();
 
                 for (int i = minzoom; i <= maxzoom; i++)
                 {


### PR DESCRIPTION
Currently, when you want to prefetch, you need to select min and max zoom in messages box :
<img width="398" height="142" alt="image" src="https://github.com/user-attachments/assets/dd96196f-e304-4ec2-aff0-83d7242a47ab" />
<img width="398" height="142" alt="image" src="https://github.com/user-attachments/assets/c5f6b18e-b2dc-45d3-90b9-c6e880daa1ff" />

Now all of this is available in one place with a detailed number of tiles per zoom and an estimated size of the total downloaded tiles.
<img width="258" height="422" alt="image" src="https://github.com/user-attachments/assets/edb91d49-dd44-4c39-b9ad-dbc94e09ba97" />
