### PR TITLE
Install Android SDK Platform 33 in build workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,20 @@ jobs:
         with:
           submodules: true
           fetch-depth: 10
+          
+      - name: Install Android SDK Platform 33
+        run: |
+            gci
+            pwd
+            cd "C:\Program Files (x86)\Android\android-sdk\cmdline-tools"
+            gci
+            pwd
+            cd latest
+            cd bin            
+            .\sdkmanager.bat "platforms;android-33"
 
+
+          
       - name: Cache multiple paths
         uses: actions/cache@v4
         with:
@@ -95,7 +108,18 @@ jobs:
         with:
           submodules: true
           fetch-depth: 10
-
+          
+      - name: Install Android SDK Platform 33
+        run: |
+            gci
+            pwd
+            cd "C:\Program Files (x86)\Android\android-sdk\cmdline-tools"
+            gci
+            pwd
+            cd latest
+            cd bin            
+            .\sdkmanager.bat "platforms;android-33"
+          
       - name: Cache multiple paths
         uses: actions/cache@v4
         with:
@@ -169,4 +193,11 @@ jobs:
           prerelease: true
           title: "Android Development Build"
           files: '**/*-signed.apk'
+
+
+
+
+
+
+
 


### PR DESCRIPTION
Added installation step for Android SDK Platform 33 in both AAB and APK build jobs.