### PR TITLE
mavcmd: add arc waypoint

### DIFF
--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -30,6 +30,15 @@
       <Y></Y>
       <Z></Z>
     </RETURN_TO_LAUNCH>
+    <ARC_WAYPOINT>
+      <P1>Arc Angle</P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z unitType="alt">Alt</Z>
+    </ARC_WAYPOINT>
     <ATTITUDE_TIME>
       <P1>Time (sec)</P1>
       <P2>Roll</P2>


### PR DESCRIPTION
This adds support for the ARC_WAYPOINT command in the Plan screen.

The mavlink PR has already been merged https://github.com/ArduPilot/mavlink/pull/429 but I think Mission Planner's mavlink submodule hasn't been brought forward yet to include this message

The corresponding flight code PR is here https://github.com/ArduPilot/ardupilot/pull/31139 and we should wait until it is merged before merging this one.