### PR TITLE
AccelCalib: Fix UK translation, accelerometer calibration messages not shown.

### DIFF
--- a/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.Designer.cs
@@ -62,6 +62,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_calib_accell, "BUT_calib_accell");
             this.BUT_calib_accell.Name = "BUT_calib_accell";
+            this.BUT_calib_accell.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_calib_accell.UseVisualStyleBackColor = true;
             this.BUT_calib_accell.Click += new System.EventHandler(this.BUT_calib_accell_Click);
             // 
@@ -79,6 +80,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_level, "BUT_level");
             this.BUT_level.Name = "BUT_level";
+            this.BUT_level.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_level.UseVisualStyleBackColor = true;
             this.BUT_level.Click += new System.EventHandler(this.BUT_level_Click);
             // 
@@ -86,6 +88,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_simpleAccelCal, "BUT_simpleAccelCal");
             this.BUT_simpleAccelCal.Name = "BUT_simpleAccelCal";
+            this.BUT_simpleAccelCal.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_simpleAccelCal.UseVisualStyleBackColor = true;
             this.BUT_simpleAccelCal.Click += new System.EventHandler(this.BUT_simpleAccelCal_Click);
             // 
@@ -101,6 +104,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             // ConfigAccelerometerCalibration
             // 
+            resources.ApplyResources(this, "$this");
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.BUT_level);
@@ -111,7 +115,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Controls.Add(this.label5);
             this.Controls.Add(this.BUT_simpleAccelCal);
             this.Name = "ConfigAccelerometerCalibration";
-            resources.ApplyResources(this, "$this");
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.resx
+++ b/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.resx
@@ -178,9 +178,6 @@ This will ask you to place your autopilot on each edge.</value>
   <data name="BUT_level.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 21</value>
   </data>
-  <data name="&gt;&gt;BUT_calib_accell.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
   <data name="&gt;&gt;lineSeparator2.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
@@ -224,9 +221,6 @@ This requires you to place your autopilot flat and level.</value>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.MyUserControl, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="lbl_Accel_user.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 96</value>
-  </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -254,6 +248,9 @@ This requires you to place your autopilot flat and level.</value>
   </data>
   <data name="&gt;&gt;label4.Name" xml:space="preserve">
     <value>label4</value>
+  </data>
+  <data name="BUT_level.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="lineSeparator2.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 30</value>
@@ -285,14 +282,17 @@ This requires you to place your autopilot flat and level.</value>
   <data name="&gt;&gt;lbl_Accel_user.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;BUT_simpleAccelCal.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="&gt;&gt;lbl_Accel_user.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>ConfigAccelerometerCalibration</value>
-  </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>Accelerometer Calibration</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -303,14 +303,14 @@ This requires you to place your autopilot flat and level.</value>
   <data name="BUT_calib_accell.Location" type="System.Drawing.Point, System.Drawing">
     <value>188, 72</value>
   </data>
+  <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 12pt</value>
+  </data>
   <data name="&gt;&gt;BUT_level.Type" xml:space="preserve">
     <value>MissionPlanner.Controls.MyButton, MissionPlanner.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="lineSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 2</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>85</value>
@@ -324,8 +324,8 @@ This requires you to place your autopilot flat and level.</value>
   <data name="&gt;&gt;label5.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;BUT_simpleAccelCal.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ConfigAccelerometerCalibration</value>
   </data>
   <data name="lineSeparator2.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>0, 2</value>
@@ -357,8 +357,8 @@ This requires you to place your autopilot flat and level.</value>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="label5.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 12pt</value>
+  <data name="&gt;&gt;BUT_calib_accell.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -375,11 +375,11 @@ This requires you to place your autopilot flat and level.</value>
   <data name="BUT_calib_accell.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>Accelerometer Calibration</value>
+  <data name="lbl_Accel_user.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 96</value>
   </data>
-  <data name="BUT_level.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="lineSeparator2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>460, 2</value>
   </data>
   <data name="BUT_calib_accell.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 21</value>

--- a/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.uk.resx
+++ b/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.uk.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>436, 37</value>
+    <value>231, 20</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>Калібрування акселерометру</value>
@@ -128,7 +128,7 @@
     <value>60, 45</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>822, 75</value>
+    <value>418, 39</value>
   </data>
   <data name="label4.Text" xml:space="preserve">
     <value>Вирівняйте свій дрон горизонтально, щоб встановити Мін. та Макс. значення
@@ -136,7 +136,7 @@
 дрон на кожній зі сторін по черзі.</value>
   </data>
   <data name="lbl_Accel_user.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 121</value>
+    <value>18, 122</value>
   </data>
   <data name="BUT_calib_accell.Location" type="System.Drawing.Point, System.Drawing">
     <value>188, 87</value>
@@ -148,7 +148,7 @@
     <value>Калібрувати аксел.</value>
   </data>
   <data name="BUT_level.Location" type="System.Drawing.Point, System.Drawing">
-    <value>188, 161</value>
+    <value>188, 192</value>
   </data>
   <data name="BUT_level.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 31</value>
@@ -158,7 +158,7 @@
 гориз.рівень</value>
   </data>
   <data name="BUT_simpleAccelCal.Location" type="System.Drawing.Point, System.Drawing">
-    <value>188, 247</value>
+    <value>188, 280</value>
   </data>
   <data name="BUT_simpleAccelCal.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 38</value>
@@ -166,18 +166,27 @@
   <data name="BUT_simpleAccelCal.Text" xml:space="preserve">
     <value>Просте калібрування аксел.</value>
   </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>60, 164</value>
+  </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>838, 50</value>
+    <value>428, 26</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Вирівняйте свій дрон горизонтально, щоб встановити зміщення акселерометру за
 замовчуванням (1 вісь/AHRS).</value>
   </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>60, 251</value>
+  </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>785, 50</value>
+    <value>398, 26</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Вирівняйте свій дрон горизонтально, щоб встановити масштабні коефіцієнти
 акселерометру за замовчуванням для горизонтального польоту (1 вісь).</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>516, 394</value>
   </data>
 </root>


### PR DESCRIPTION
Label was under a normal text, rearranged labels to correct it.