### PR TITLE
ConfigArducopter: add ParamName to tooltips

### DIFF
--- a/GCSViews/ConfigurationView/ConfigArducopter.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.cs
@@ -188,16 +188,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     {
                         var ParamName = ((MavlinkNumericUpDown) control2).ParamName;
                         toolTip1.SetToolTip(control2,
-                            ParameterMetaDataRepository.GetParameterMetaData(ParamName,
-                                ParameterMetaDataConstants.Description, MainV2.comPort.MAV.cs.firmware.ToString()));
+                            $"{ParamName}:\n{ParameterMetaDataRepository.GetParameterMetaData(ParamName, ParameterMetaDataConstants.Description, MainV2.comPort.MAV.cs.firmware.ToString())}");
                     }
 
                     if (control2 is MavlinkComboBox)
                     {
                         var ParamName = ((MavlinkComboBox) control2).ParamName;
                         toolTip1.SetToolTip(control2,
-                            ParameterMetaDataRepository.GetParameterMetaData(ParamName,
-                                ParameterMetaDataConstants.Description, MainV2.comPort.MAV.cs.firmware.ToString()));
+                            $"{ParamName}:\n{ParameterMetaDataRepository.GetParameterMetaData(ParamName, ParameterMetaDataConstants.Description, MainV2.comPort.MAV.cs.firmware.ToString())}");
                     }
                 }
             }


### PR DESCRIPTION
Adds the parameter name to each tooltip on the Extended Tuning tab. A few users requested this feature, and it's a simple two line change.

I used string interpolation because it should be more performant than concatenation, but it does require the entire string to reside on a single, long line.

<img width="356" height="99" alt="{A70E6CB4-AE60-45EC-BE93-EA90411B2DD7}" src="https://github.com/user-attachments/assets/741b5901-940c-4710-b07d-af7e6c395716" />
