### PR TITLE
Fix Issue #3335 - Make Messages tab textbox non-interactive

### DIFF
--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -1091,6 +1091,8 @@ namespace MissionPlanner.GCSViews
             // 
             resources.ApplyResources(this.txt_messagebox, "txt_messagebox");
             this.txt_messagebox.Name = "txt_messagebox";
+            this.txt_messagebox.ReadOnly = true;
+            this.txt_messagebox.Enabled = false;
             // 
             // tabActionsSimple
             // 


### PR DESCRIPTION
Set `txt_messagebox` to read-only and disabled in `FlightData.Designer.cs`, preventing both typing and focus/click interaction while still displaying messages.