### PR TITLE
Handle Quick tab behavior when undocked in FlightData view

### DIFF
--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -744,6 +744,10 @@ namespace MissionPlanner.GCSViews
                 bool added = false;
                 foreach (TabPage tabPage in TabListOriginal)
                 {
+                    // skip the Quick tab if it is currently undocked into a popup window
+                    if (tabQuickDetached && tabPage == tabQuick)
+                        continue;
+
                     if (tabPage.Name == tabname && ((TabListDisplay.ContainsKey(tabname) && TabListDisplay[tabname] == true) || !TabListDisplay.ContainsKey(tabname)))
                     {
                         tabControlactions.TabPages.Add(tabPage);
@@ -765,7 +769,7 @@ namespace MissionPlanner.GCSViews
             loadTabControlActions();
 
             //we want to at least have one tabpage
-            if (tabControlactions.TabPages.Count == 0)
+            if (tabControlactions.TabPages.Count == 0 && !tabQuickDetached)
             {
                 tabControlactions.TabPages.Add(tabQuick);
                 tabControlactions.SelectedIndex = 0;


### PR DESCRIPTION
Fix for https://github.com/ArduPilot/MissionPlanner/issues/3673

When the Quick tab is undocked into a popup window, navigating away from the Flight Data screen (clicking PLAN, SETUP, CONFIG, etc.) and then returning triggers FlightData.Activate(), which calls updateDisplayView() → loadTabControlActions(). That method calls tabControlactions.TabPages.Clear() and then re-adds all tabs from the original list — including tabQuick, which is currently living in the popup form. The TabPages.Add(tabQuick) call reparents tabQuick back to tabControlactions, stealing it from the popup window and leaving it empty (the "ghost" window).
Fix (2 changes in FlightData.cs)
1.	loadTabControlActions() (line 748-749): Skip tabQuick during tab restoration when tabQuickDetached is TRUE, so it remains in the popup form.
2.	updateDisplayView() (line 772): Guard the fallback "ensure at least one tab" logic with !tabQuickDetached, preventing it from forcibly adding the detached Quick tab back.
