### PR TITLE
Add `.idea` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docs/
 *.pem
 *.key
 /.vscode
+/.idea
 obj2/
 obj3/
 


### PR DESCRIPTION
This commit updates the ignore rules so the IDE’s project settings folder is no longer tracked by version control. In practice, that keeps local Rider/IntelliJ-style workspace metadata out of the repository and reduces noise in future commits. It’s a small housekeeping change with no runtime impact.