### PR TITLE
Update ConfigureArducopter and FlightPlanner to accomodate new param names and units/scales

### DIFF
--- a/ExtLibs/Utilities/paramchanges47.cs
+++ b/ExtLibs/Utilities/paramchanges47.cs
@@ -88,11 +88,6 @@ namespace MissionPlanner.Utilities
             { "Q_LOIT_ACC_MAX_M", "Q_LOIT_ACC_MAX → Q_LOIT_ACC_MAX_M: units changed from cm/s/s to m/s/s" },
             { "Q_LOIT_BRK_ACC_M", "Q_LOIT_BRK_ACCEL → Q_LOIT_BRK_ACC_M: units changed from cm/s/s to m/s/s" },
             { "Q_LOIT_BRK_JRK_M", "Q_LOIT_BRK_JERK → Q_LOIT_BRK_JRK_M: units changed from cm/s/s/s to m/s/s/s" },
-            // Q_PILOT (Plane QuadPlane)
-            { "Q_PILOT_ACCEL_Z", "Q_PILOT_ACCEL_Z → Q_PILOT_ACCEL_Z: units changed from cm/s/s to m/s/s" },
-            { "Q_PILOT_SPD_UP", "Q_PILOT_SPEED_UP → Q_PILOT_SPD_UP: units changed from cm/s to m/s" },
-            { "Q_PILOT_SPD_DN", "Q_PILOT_SPEED_DN → Q_PILOT_SPD_DN: units changed from cm/s to m/s" },
-            { "Q_PILOT_TKO_ALT_M", "Q_PILOT_TKOFF_ALT → Q_PILOT_TKO_ALT_M: units changed from cm to m" },
             // Q_P_VELXY → Q_P_NE_VEL (Plane QuadPlane)
             { "Q_P_NE_VEL_P", "Q_P_VELXY_P → Q_P_NE_VEL_P: no scaling change, name only" },
             { "Q_P_NE_VEL_I", "Q_P_VELXY_I → Q_P_NE_VEL_I: no scaling change, name only" },

--- a/ExtLibs/Utilities/paramchanges47.cs
+++ b/ExtLibs/Utilities/paramchanges47.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MissionPlanner.Utilities
+{
+    public class paramchanges47
+    {
+        // 4.7 parameter changes - keyed by new param name, value is "OLD → NEW: description"
+        private static readonly Dictionary<string, string> _byNewParam = new Dictionary<string, string>
+        {
+            // ARMING
+            { "ARMING_SKIPCHK", "ARMING_CHECK → ARMING_SKIPCHK: select which checks to disable" },
+            // ATC (Copter)
+            { "ATC_ANGLE_MAX", "ANGLE_MAX → ATC_ANGLE_MAX: units changed from cd to deg" },
+            { "ATC_ACC_R_MAX", "ATC_ACCEL_R_MAX → ATC_ACC_R_MAX: units changed from cm/s/s to m/s/s" },
+            { "ATC_ACC_P_MAX", "ATC_ACCEL_P_MAX → ATC_ACC_P_MAX: units changed from cm/s/s to m/s/s" },
+            { "ATC_ACC_Y_MAX", "ATC_ACCEL_Y_MAX → ATC_ACC_Y_MAX: units changed from cm/s/s to m/s/s" },
+            { "ATC_RATE_WPY_MAX", "ATC_SLEW_YAW → ATC_RATE_WPY_MAX: units changed from cdeg/s to deg/s" },
+            // CIRCLE (Copter)
+            { "CIRCLE_RADIUS_M", "CIRCLE_RADIUS → CIRCLE_RADIUS_M: units changed from cm to m" },
+            // LAND (Copter)
+            { "LAND_SPD_MS", "LAND_SPEED → LAND_SPD_MS: units changed from cm/s to m/s" },
+            { "LAND_SPD_HIGH_MS", "LAND_SPEED_HIGH → LAND_SPD_HIGH_MS: units changed from cm/s to m/s" },
+            { "LAND_ALT_LOW_M", "LAND_ALT_LOW → LAND_ALT_LOW_M: units changed from cm to m" },
+            // LOIT (Copter)
+            { "LOIT_SPEED_MS", "LOIT_SPEED → LOIT_SPEED_MS: units changed from cm/s to m/s" },
+            { "LOIT_ACC_MAX_M", "LOIT_ACC_MAX → LOIT_ACC_MAX_M: units changed from cm/s/s to m/s/s" },
+            { "LOIT_BRK_ACC_M", "LOIT_BRK_ACCEL → LOIT_BRK_ACC_M: units changed from cm/s/s to m/s/s" },
+            { "LOIT_BRK_JRK_M", "LOIT_BRK_JERK → LOIT_BRK_JRK_M: units changed from cm/s/s/s to m/s/s/s" },
+            // PILOT (Copter)
+            { "PILOT_ACC_Z", "PILOT_ACCEL_Z → PILOT_ACC_Z: units changed from cm/s/s to m/s/s" },
+            { "PILOT_SPD_UP", "PILOT_SPEED_UP → PILOT_SPD_UP: units changed from cm/s to m/s" },
+            { "PILOT_SPD_DN", "PILOT_SPEED_DN → PILOT_SPD_DN: units changed from cm/s to m/s" },
+            { "PILOT_TKO_ALT_M", "PILOT_TKOFF_ALT → PILOT_TKO_ALT_M: units changed from cm to m" },
+            // PHLD (Copter)
+            { "PHLD_BRK_ANGLE", "PHLD_BRAKE_ANGLE → PHLD_BRK_ANGLE: units changed from cd to deg" },
+            { "PHLD_BRK_RATE", "PHLD_BRAKE_RATE → PHLD_BRK_RATE: no scaling change, name only" },
+            // PSC_VELXY → PSC_NE_VEL (Copter)
+            { "PSC_NE_VEL_P", "PSC_VELXY_P → PSC_NE_VEL_P: no scaling change, name only" },
+            { "PSC_NE_VEL_I", "PSC_VELXY_I → PSC_NE_VEL_I: no scaling change, name only" },
+            { "PSC_NE_VEL_D", "PSC_VELXY_D → PSC_NE_VEL_D: no scaling change, name only" },
+            { "PSC_NE_VEL_IMAX", "PSC_VELXY_IMAX → PSC_NE_VEL_IMAX: value is now 100x smaller" },
+            { "PSC_NE_VEL_FILT", "PSC_VELXY_FILT → PSC_NE_VEL_FILT: no scaling change, name only" },
+            { "PSC_NE_VEL_FF", "PSC_VELXY_FF → PSC_NE_VEL_FF: no scaling change, name only" },
+            { "PSC_NE_VEL_FLTE", "PSC_VELXY_FLTE → PSC_NE_VEL_FLTE: no scaling change, name only" },
+            { "PSC_NE_VEL_FLTD", "PSC_VELXY_FLTD → PSC_NE_VEL_FLTD: no scaling change, name only" },
+            // PSC_VELZ → PSC_D_VEL (Copter)
+            { "PSC_D_VEL_P", "PSC_VELZ_P → PSC_D_VEL_P: no scaling change, name only" },
+            { "PSC_D_VEL_I", "PSC_VELZ_I → PSC_D_VEL_I: no scaling change, name only" },
+            { "PSC_D_VEL_D", "PSC_VELZ_D → PSC_D_VEL_D: no scaling change, name only" },
+            { "PSC_D_VEL_IMAX", "PSC_VELZ_IMAX → PSC_D_VEL_IMAX: value is now 100x smaller" },
+            { "PSC_D_VEL_FILT", "PSC_VELZ_FILT → PSC_D_VEL_FILT: no scaling change, name only" },
+            { "PSC_D_VEL_FF", "PSC_VELZ_FF → PSC_D_VEL_FF: no scaling change, name only" },
+            { "PSC_D_VEL_FLTE", "PSC_VELZ_FLTE → PSC_D_VEL_FLTE: no scaling change, name only" },
+            { "PSC_D_VEL_FLTD", "PSC_VELZ_FLTD → PSC_D_VEL_FLTD: no scaling change, name only" },
+            // PSC_ACCZ → PSC_D_ACC (Copter)
+            { "PSC_D_ACC_P", "PSC_ACCZ_P → PSC_D_ACC_P: value is now 10x smaller" },
+            { "PSC_D_ACC_I", "PSC_ACCZ_I → PSC_D_ACC_I: value is now 10x smaller" },
+            { "PSC_D_ACC_D", "PSC_ACCZ_D → PSC_D_ACC_D: value is now 10x smaller" },
+            { "PSC_D_ACC_IMAX", "PSC_ACCZ_IMAX → PSC_D_ACC_IMAX: no scaling change, name only" },
+            { "PSC_D_ACC_FILT", "PSC_ACCZ_FILT → PSC_D_ACC_FILT: no scaling change, name only" },
+            { "PSC_D_ACC_FF", "PSC_ACCZ_FF → PSC_D_ACC_FF: no scaling change, name only" },
+            { "PSC_D_ACC_FLTE", "PSC_ACCZ_FLTE → PSC_D_ACC_FLTE: no scaling change, name only" },
+            { "PSC_D_ACC_FLTD", "PSC_ACCZ_FLTD → PSC_D_ACC_FLTD: no scaling change, name only" },
+            // RTL (Copter)
+            { "RTL_ALT_M", "RTL_ALT → RTL_ALT_M: units changed from cm to m" },
+            { "RTL_SPEED_MS", "RTL_SPEED → RTL_SPEED_MS: units changed from cm/s to m/s" },
+            { "RTL_ALT_FINAL_M", "RTL_ALT_FINAL → RTL_ALT_FINAL_M: units changed from cm to m" },
+            { "RTL_CLIMB_MIN_M", "RTL_CLIMB_MIN → RTL_CLIMB_MIN_M: units changed from cm to m" },
+            // WPNAV (Copter)
+            { "WP_ACC", "WPNAV_ACCEL → WP_ACC: units changed from cm/s/s to m/s/s" },
+            { "WP_ACC_CNR", "WPNAV_ACCEL_C → WP_ACC_CNR: units changed from cm/s/s to m/s/s" },
+            { "WP_ACC_Z", "WPNAV_ACCEL_Z → WP_ACC_Z: units changed from cm/s/s to m/s/s" },
+            { "WP_RADIUS_M", "WPNAV_RADIUS → WP_RADIUS_M: units changed from cm to m" },
+            { "WP_SPD", "WPNAV_SPEED → WP_SPD: units changed from cm/s to m/s" },
+            { "WP_SPD_DN", "WPNAV_SPEED_DN → WP_SPD_DN: units changed from cm/s to m/s" },
+            { "WP_SPD_UP", "WPNAV_SPEED_UP → WP_SPD_UP: units changed from cm/s to m/s" },
+            // Q_A (Plane QuadPlane)
+            { "Q_A_ANGLE_MAX", "Q_ANGLE_MAX → Q_A_ANGLE_MAX: units changed from cd to deg" },
+            { "Q_A_ACC_R_MAX", "Q_A_ACCEL_R_MAX → Q_A_ACC_R_MAX: units changed from cm/s/s to m/s/s" },
+            { "Q_A_ACC_P_MAX", "Q_A_ACCEL_P_MAX → Q_A_ACC_P_MAX: units changed from cm/s/s to m/s/s" },
+            { "Q_A_ACC_Y_MAX", "Q_A_ACCEL_Y_MAX → Q_A_ACC_Y_MAX: units changed from cm/s/s to m/s/s" },
+            { "Q_A_RATE_WPY_MAX", "Q_A_SLEW_YAW → Q_A_RATE_WPY_MAX: units changed from cdeg/s to deg/s" },
+            // Q_LOIT (Plane QuadPlane)
+            { "Q_LOIT_SPEED_MS", "Q_LOIT_SPEED → Q_LOIT_SPEED_MS: units changed from cm/s to m/s" },
+            { "Q_LOIT_ACC_MAX_M", "Q_LOIT_ACC_MAX → Q_LOIT_ACC_MAX_M: units changed from cm/s/s to m/s/s" },
+            { "Q_LOIT_BRK_ACC_M", "Q_LOIT_BRK_ACCEL → Q_LOIT_BRK_ACC_M: units changed from cm/s/s to m/s/s" },
+            { "Q_LOIT_BRK_JRK_M", "Q_LOIT_BRK_JERK → Q_LOIT_BRK_JRK_M: units changed from cm/s/s/s to m/s/s/s" },
+            // Q_PILOT (Plane QuadPlane)
+            { "Q_PILOT_ACCEL_Z", "Q_PILOT_ACCEL_Z → Q_PILOT_ACCEL_Z: units changed from cm/s/s to m/s/s" },
+            { "Q_PILOT_SPD_UP", "Q_PILOT_SPEED_UP → Q_PILOT_SPD_UP: units changed from cm/s to m/s" },
+            { "Q_PILOT_SPD_DN", "Q_PILOT_SPEED_DN → Q_PILOT_SPD_DN: units changed from cm/s to m/s" },
+            { "Q_PILOT_TKO_ALT_M", "Q_PILOT_TKOFF_ALT → Q_PILOT_TKO_ALT_M: units changed from cm to m" },
+            // Q_P_VELXY → Q_P_NE_VEL (Plane QuadPlane)
+            { "Q_P_NE_VEL_P", "Q_P_VELXY_P → Q_P_NE_VEL_P: no scaling change, name only" },
+            { "Q_P_NE_VEL_I", "Q_P_VELXY_I → Q_P_NE_VEL_I: no scaling change, name only" },
+            { "Q_P_NE_VEL_D", "Q_P_VELXY_D → Q_P_NE_VEL_D: no scaling change, name only" },
+            { "Q_P_NE_VEL_IMAX", "Q_P_VELXY_IMAX → Q_P_NE_VEL_IMAX: value is now 100x smaller" },
+            { "Q_P_NE_VEL_FILT", "Q_P_VELXY_FILT → Q_P_NE_VEL_FILT: no scaling change, name only" },
+            { "Q_P_NE_VEL_FF", "Q_P_VELXY_FF → Q_P_NE_VEL_FF: no scaling change, name only" },
+            { "Q_P_NE_VEL_FLTE", "Q_P_VELXY_FLTE → Q_P_NE_VEL_FLTE: no scaling change, name only" },
+            { "Q_P_NE_VEL_FLTD", "Q_P_VELXY_FLTD → Q_P_NE_VEL_FLTD: no scaling change, name only" },
+            // Q_P_VELZ → Q_P_D_VEL (Plane QuadPlane)
+            { "Q_P_D_VEL_P", "Q_P_VELZ_P → Q_P_D_VEL_P: no scaling change, name only" },
+            { "Q_P_D_VEL_I", "Q_P_VELZ_I → Q_P_D_VEL_I: no scaling change, name only" },
+            { "Q_P_D_VEL_D", "Q_P_VELZ_D → Q_P_D_VEL_D: no scaling change, name only" },
+            { "Q_P_D_VEL_IMAX", "Q_P_VELZ_IMAX → Q_P_D_VEL_IMAX: value is now 100x smaller" },
+            { "Q_P_D_VEL_FILT", "Q_P_VELZ_FILT → Q_P_D_VEL_FILT: no scaling change, name only" },
+            { "Q_P_D_VEL_FF", "Q_P_VELZ_FF → Q_P_D_VEL_FF: no scaling change, name only" },
+            { "Q_P_D_VEL_FLTE", "Q_P_VELZ_FLTE → Q_P_D_VEL_FLTE: no scaling change, name only" },
+            { "Q_P_D_VEL_FLTD", "Q_P_VELZ_FLTD → Q_P_D_VEL_FLTD: no scaling change, name only" },
+            // Q_P_ACCZ → Q_P_D_ACC (Plane QuadPlane)
+            { "Q_P_D_ACC_P", "Q_P_ACCZ_P → Q_P_D_ACC_P: value is now 10x smaller" },
+            { "Q_P_D_ACC_I", "Q_P_ACCZ_I → Q_P_D_ACC_I: value is now 10x smaller" },
+            { "Q_P_D_ACC_D", "Q_P_ACCZ_D → Q_P_D_ACC_D: value is now 10x smaller" },
+            { "Q_P_D_ACC_IMAX", "Q_P_ACCZ_IMAX → Q_P_D_ACC_IMAX: no scaling change, name only" },
+            { "Q_P_D_ACC_FILT", "Q_P_ACCZ_FILT → Q_P_D_ACC_FILT: no scaling change, name only" },
+            { "Q_P_D_ACC_FF", "Q_P_ACCZ_FF → Q_P_D_ACC_FF: no scaling change, name only" },
+            { "Q_P_D_ACC_FLTE", "Q_P_ACCZ_FLTE → Q_P_D_ACC_FLTE: no scaling change, name only" },
+            { "Q_P_D_ACC_FLTD", "Q_P_ACCZ_FLTD → Q_P_D_ACC_FLTD: no scaling change, name only" },
+            // Q_WP (Plane QuadPlane)
+            { "Q_WP_ACC", "Q_WP_ACCEL → Q_WP_ACC: units changed from cm/s/s to m/s/s" },
+            { "Q_WP_ACC_CNR", "Q_WP_ACCEL_C → Q_WP_ACC_CNR: units changed from cm/s/s to m/s/s" },
+            { "Q_WP_ACC_Z", "Q_WP_ACCEL_Z → Q_WP_ACC_Z: units changed from cm/s/s to m/s/s" },
+            { "Q_WP_RADIUS_M", "Q_WP_RADIUS → Q_WP_RADIUS_M: units changed from cm to m" },
+            { "Q_WP_SPD", "Q_WP_SPEED → Q_WP_SPD: units changed from cm/s to m/s" },
+            { "Q_WP_SPD_DN", "Q_WP_SPEED_DN → Q_WP_SPD_DN: units changed from cm/s to m/s" },
+            { "Q_WP_SPD_UP", "Q_WP_SPEED_UP → Q_WP_SPD_UP: units changed from cm/s to m/s" },
+        };
+
+        // reverse index: old param name → new param name
+        private static readonly Dictionary<string, string> _oldToNew = _byNewParam
+            .ToDictionary(
+                kv => kv.Value.Substring(0, kv.Value.IndexOf(" →")),
+                kv => kv.Key);
+
+        /// <summary>
+        /// Given an old param name, returns the new 4.7 name, or null if not in the change list.
+        /// </summary>
+        public static string changedByOldParam(string oldName)
+        {
+            return _oldToNew.TryGetValue(oldName, out var newName) ? newName : null;
+        }
+
+        /// <summary>
+        /// Given a new 4.7 param name, returns the old param name, or null if not in the change list.
+        /// </summary>
+        public static string changedByNewParam(string newName)
+        {
+            if (_byNewParam.TryGetValue(newName, out var description))
+                return description.Substring(0, description.IndexOf(" →"));
+            return null;
+        }
+
+        /// <summary>
+        /// Given a new 4.7 param name, returns the full warning text, or null if not in the change list.
+        /// </summary>
+        public static string changedByNewParamWarning(string newName)
+        {
+            return _byNewParam.TryGetValue(newName, out var warning) ? warning : null;
+        }
+    }
+}

--- a/ExtLibs/Utilities/paramchanges47.cs
+++ b/ExtLibs/Utilities/paramchanges47.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MissionPlanner.Utilities
 {
-    public class paramchanges47
+    public class ParamChanges47
     {
         // 4.7 parameter changes - keyed by new param name, value is "OLD → NEW: description"
         private static readonly Dictionary<string, string> _byNewParam = new Dictionary<string, string>

--- a/GCSViews/ConfigurationView/ConfigAC_Fence.cs
+++ b/GCSViews/ConfigurationView/ConfigAC_Fence.cs
@@ -40,8 +40,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             mavlinkNumericUpDown2.setup(30, 65536, (float)CurrentState.fromDistDisplayUnit(1), 1, "FENCE_RADIUS",
                 MainV2.comPort.MAV.param);
 
-            mavlinkNumericUpDown3.setup(1, 500, (float)CurrentState.fromDistDisplayUnit(100), 1, "RTL_ALT",
-                MainV2.comPort.MAV.param);
+            if (MainV2.comPort.MAV.param.ContainsKey("RTL_ALT_M"))
+                mavlinkNumericUpDown3.setup(1, 500, (float)CurrentState.fromDistDisplayUnit(1), 1, "RTL_ALT_M",
+                    MainV2.comPort.MAV.param);
+            else
+                mavlinkNumericUpDown3.setup(1, 500, (float)CurrentState.fromDistDisplayUnit(100), 1, "RTL_ALT",
+                    MainV2.comPort.MAV.param);
         }
     }
 }

--- a/GCSViews/ConfigurationView/ConfigArducopter.Designer.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.Designer.cs
@@ -33,57 +33,97 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConfigArducopter));
             this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.THR_RATE_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label25 = new System.Windows.Forms.Label();
             this.CHK_lockrollpitch = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.WPNAV_SPEED_UP = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label27 = new System.Windows.Forms.Label();
+            this.WPNAV_LOIT_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label9 = new System.Windows.Forms.Label();
+            this.WPNAV_SPEED_DN = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label13 = new System.Windows.Forms.Label();
+            this.WPNAV_RADIUS = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label15 = new System.Windows.Forms.Label();
+            this.WPNAV_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label16 = new System.Windows.Forms.Label();
             this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.THR_ALT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label22 = new System.Windows.Forms.Label();
             this.groupBox19 = new System.Windows.Forms.GroupBox();
+            this.mavlinkNumericUpDownatc_input_tc = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label23 = new System.Windows.Forms.Label();
+            this.HLD_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label31 = new System.Windows.Forms.Label();
             this.groupBox20 = new System.Windows.Forms.GroupBox();
+            this.mavlinkNumericUpDownatc_accel_y_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label21 = new System.Windows.Forms.Label();
+            this.STB_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label35 = new System.Windows.Forms.Label();
             this.groupBox21 = new System.Windows.Forms.GroupBox();
+            this.mavlinkNumericUpDownatc_accel_p_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label20 = new System.Windows.Forms.Label();
+            this.STB_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label42 = new System.Windows.Forms.Label();
             this.groupBox22 = new System.Windows.Forms.GroupBox();
+            this.mavlinkNumericUpDownatc_accel_r_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label19 = new System.Windows.Forms.Label();
+            this.STB_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label46 = new System.Windows.Forms.Label();
             this.groupBox23 = new System.Windows.Forms.GroupBox();
+            this.ATC_RAT_YAW_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label33 = new System.Windows.Forms.Label();
+            this.ATC_RAT_YAW_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label32 = new System.Windows.Forms.Label();
+            this.RATE_YAW_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label18 = new System.Windows.Forms.Label();
+            this.RATE_YAW_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label10 = new System.Windows.Forms.Label();
+            this.RATE_YAW_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label47 = new System.Windows.Forms.Label();
+            this.RATE_YAW_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label77 = new System.Windows.Forms.Label();
+            this.RATE_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label82 = new System.Windows.Forms.Label();
             this.groupBox24 = new System.Windows.Forms.GroupBox();
+            this.ATC_RAT_PIT_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label30 = new System.Windows.Forms.Label();
+            this.ATC_RAT_PIT_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label29 = new System.Windows.Forms.Label();
+            this.RATE_PIT_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label14 = new System.Windows.Forms.Label();
+            this.RATE_PIT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label11 = new System.Windows.Forms.Label();
+            this.RATE_PIT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label84 = new System.Windows.Forms.Label();
+            this.RATE_PIT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label86 = new System.Windows.Forms.Label();
+            this.RATE_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label87 = new System.Windows.Forms.Label();
             this.groupBox25 = new System.Windows.Forms.GroupBox();
+            this.ATC_RAT_RLL_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label28 = new System.Windows.Forms.Label();
+            this.ATC_RAT_RLL_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.P_FLTD = new System.Windows.Forms.Label();
+            this.RATE_RLL_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label12 = new System.Windows.Forms.Label();
+            this.RATE_RLL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label17 = new System.Windows.Forms.Label();
+            this.RATE_RLL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label88 = new System.Windows.Forms.Label();
+            this.RATE_RLL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label90 = new System.Windows.Forms.Label();
+            this.RATE_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label91 = new System.Windows.Forms.Label();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.LOITER_LAT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
+            this.LOITER_LAT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
+            this.LOITER_LAT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label3 = new System.Windows.Forms.Label();
+            this.LOITER_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label4 = new System.Windows.Forms.Label();
             this.BUT_rerequestparams = new MissionPlanner.Controls.MyButton();
             this.BUT_writePIDS = new MissionPlanner.Controls.MyButton();
@@ -91,156 +131,87 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.myLabel2 = new System.Windows.Forms.Label();
             this.myLabel1 = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.THR_ACCEL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
+            this.THR_ACCEL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.THR_ACCEL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label7 = new System.Windows.Forms.Label();
+            this.THR_ACCEL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label8 = new System.Windows.Forms.Label();
             this.BUT_refreshpart = new MissionPlanner.Controls.MyButton();
             this.myLabel4 = new System.Windows.Forms.Label();
             this.myLabel5 = new System.Windows.Forms.Label();
             this.myLabel6 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.INS_ACCEL_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label26 = new System.Windows.Forms.Label();
+            this.INS_GYRO_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label24 = new System.Windows.Forms.Label();
             this.groupBox9 = new System.Windows.Forms.GroupBox();
+            this.INS_HNTCH_ENABLE = new MissionPlanner.Controls.MavlinkComboBox();
+            this.INS_HNTCH_HMNCS = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label51 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_OPTS = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label50 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label49 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label48 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label41 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_REF = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label43 = new System.Windows.Forms.Label();
+            this.INS_HNTCH_MODE = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label44 = new System.Windows.Forms.Label();
             this.label45 = new System.Windows.Forms.Label();
             this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.INS_NOTCH_ENABLE = new MissionPlanner.Controls.MavlinkComboBox();
+            this.INS_NOTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label40 = new System.Windows.Forms.Label();
+            this.INS_NOTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label39 = new System.Windows.Forms.Label();
+            this.INS_NOTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.label38 = new System.Windows.Forms.Label();
             this.label37 = new System.Windows.Forms.Label();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.INS_LOG_BAT_OPT = new MissionPlanner.Controls.MavlinkNumericUpDown();
+            this.INS_LOG_BAT_MASK = new MissionPlanner.Controls.MavlinkComboBox();
             this.label36 = new System.Windows.Forms.Label();
             this.label34 = new System.Windows.Forms.Label();
             this.label52 = new System.Windows.Forms.Label();
-            this.INS_NOTCH_ENABLE = new MissionPlanner.Controls.MavlinkComboBox();
-            this.INS_NOTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_NOTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_NOTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_HMNCS = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_OPTS = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_BW = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_ATT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_FREQ = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_REF = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_MODE = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CH6_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
-            this.INS_LOG_BAT_MASK = new MissionPlanner.Controls.MavlinkComboBox();
-            this.INS_ACCEL_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_GYRO_FILTER = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.CH10_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.CH9_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
             this.CH8_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
-            this.THR_ACCEL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.THR_ACCEL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.THR_ACCEL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.THR_ACCEL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.LOITER_LAT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.LOITER_LAT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.LOITER_LAT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.LOITER_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.TUNE_LOW = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.TUNE_HIGH = new MissionPlanner.Controls.MavlinkNumericUpDown();
             this.TUNE = new MissionPlanner.Controls.MavlinkComboBox();
             this.CH7_OPTION = new MissionPlanner.Controls.MavlinkComboBox();
-            this.THR_RATE_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.WPNAV_SPEED_UP = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.WPNAV_LOIT_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.WPNAV_SPEED_DN = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.WPNAV_RADIUS = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.WPNAV_SPEED = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.THR_ALT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.mavlinkNumericUpDownatc_input_tc = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.HLD_LAT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.mavlinkNumericUpDownatc_accel_y_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.STB_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.mavlinkNumericUpDownatc_accel_p_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.STB_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.mavlinkNumericUpDownatc_accel_r_max = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.STB_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.ATC_RAT_YAW_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.ATC_RAT_YAW_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_YAW_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_YAW_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_YAW_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_YAW_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_YAW_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.ATC_RAT_RLL_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.ATC_RAT_RLL_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_PIT_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_PIT_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_PIT_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_PIT_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_PIT_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.ATC_RAT_PIT_FLTT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.ATC_RAT_PIT_FLTD = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_RLL_FILT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_RLL_D = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_RLL_IMAX = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_RLL_I = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.RATE_RLL_P = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_LOG_BAT_OPT = new MissionPlanner.Controls.MavlinkNumericUpDown();
-            this.INS_HNTCH_ENABLE = new MissionPlanner.Controls.MavlinkComboBox();
+            this.lblUnitWarning = new System.Windows.Forms.Label();
             this.groupBox5.SuspendLayout();
-            this.groupBox4.SuspendLayout();
-            this.groupBox7.SuspendLayout();
-            this.groupBox19.SuspendLayout();
-            this.groupBox20.SuspendLayout();
-            this.groupBox21.SuspendLayout();
-            this.groupBox22.SuspendLayout();
-            this.groupBox23.SuspendLayout();
-            this.groupBox24.SuspendLayout();
-            this.groupBox25.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.groupBox3.SuspendLayout();
-            this.groupBox9.SuspendLayout();
-            this.groupBox8.SuspendLayout();
-            this.groupBox6.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ATT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.THR_RATE_P)).BeginInit();
+            this.groupBox4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_UP)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_LOIT_SPEED)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_DN)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_RADIUS)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED)).BeginInit();
+            this.groupBox7.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.THR_ALT_P)).BeginInit();
+            this.groupBox19.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_input_tc)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.HLD_LAT_P)).BeginInit();
+            this.groupBox20.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_y_max)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_YAW_P)).BeginInit();
+            this.groupBox21.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_p_max)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_PIT_P)).BeginInit();
+            this.groupBox22.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).BeginInit();
+            this.groupBox23.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).BeginInit();
@@ -248,21 +219,51 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).BeginInit();
+            this.groupBox24.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).BeginInit();
+            this.groupBox25.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_I)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_P)).BeginInit();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).BeginInit();
+            this.groupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).BeginInit();
+            this.groupBox3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).BeginInit();
+            this.groupBox9.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ATT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).BeginInit();
+            this.groupBox8.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).BeginInit();
+            this.groupBox6.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_OPT)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).BeginInit();
             this.SuspendLayout();
             // 
             // groupBox5
@@ -272,6 +273,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox5, "groupBox5");
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.TabStop = false;
+            // 
+            // THR_RATE_P
+            // 
+            resources.ApplyResources(this.THR_RATE_P, "THR_RATE_P");
+            this.THR_RATE_P.Max = 1F;
+            this.THR_RATE_P.Min = 0F;
+            this.THR_RATE_P.Name = "THR_RATE_P";
+            this.THR_RATE_P.ParamName = null;
+            this.THR_RATE_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.THR_RATE_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label25
             // 
@@ -302,25 +313,75 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.TabStop = false;
             // 
+            // WPNAV_SPEED_UP
+            // 
+            resources.ApplyResources(this.WPNAV_SPEED_UP, "WPNAV_SPEED_UP");
+            this.WPNAV_SPEED_UP.Max = 1F;
+            this.WPNAV_SPEED_UP.Min = 0F;
+            this.WPNAV_SPEED_UP.Name = "WPNAV_SPEED_UP";
+            this.WPNAV_SPEED_UP.ParamName = null;
+            this.WPNAV_SPEED_UP.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.WPNAV_SPEED_UP.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label27
             // 
             resources.ApplyResources(this.label27, "label27");
             this.label27.Name = "label27";
+            // 
+            // WPNAV_LOIT_SPEED
+            // 
+            resources.ApplyResources(this.WPNAV_LOIT_SPEED, "WPNAV_LOIT_SPEED");
+            this.WPNAV_LOIT_SPEED.Max = 1F;
+            this.WPNAV_LOIT_SPEED.Min = 0F;
+            this.WPNAV_LOIT_SPEED.Name = "WPNAV_LOIT_SPEED";
+            this.WPNAV_LOIT_SPEED.ParamName = null;
+            this.WPNAV_LOIT_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.WPNAV_LOIT_SPEED.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label9
             // 
             resources.ApplyResources(this.label9, "label9");
             this.label9.Name = "label9";
             // 
+            // WPNAV_SPEED_DN
+            // 
+            resources.ApplyResources(this.WPNAV_SPEED_DN, "WPNAV_SPEED_DN");
+            this.WPNAV_SPEED_DN.Max = 1F;
+            this.WPNAV_SPEED_DN.Min = 0F;
+            this.WPNAV_SPEED_DN.Name = "WPNAV_SPEED_DN";
+            this.WPNAV_SPEED_DN.ParamName = null;
+            this.WPNAV_SPEED_DN.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.WPNAV_SPEED_DN.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label13
             // 
             resources.ApplyResources(this.label13, "label13");
             this.label13.Name = "label13";
             // 
+            // WPNAV_RADIUS
+            // 
+            resources.ApplyResources(this.WPNAV_RADIUS, "WPNAV_RADIUS");
+            this.WPNAV_RADIUS.Max = 1F;
+            this.WPNAV_RADIUS.Min = 0F;
+            this.WPNAV_RADIUS.Name = "WPNAV_RADIUS";
+            this.WPNAV_RADIUS.ParamName = null;
+            this.WPNAV_RADIUS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.WPNAV_RADIUS.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label15
             // 
             resources.ApplyResources(this.label15, "label15");
             this.label15.Name = "label15";
+            // 
+            // WPNAV_SPEED
+            // 
+            resources.ApplyResources(this.WPNAV_SPEED, "WPNAV_SPEED");
+            this.WPNAV_SPEED.Max = 1F;
+            this.WPNAV_SPEED.Min = 0F;
+            this.WPNAV_SPEED.Name = "WPNAV_SPEED";
+            this.WPNAV_SPEED.ParamName = null;
+            this.WPNAV_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.WPNAV_SPEED.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label16
             // 
@@ -334,6 +395,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.groupBox7, "groupBox7");
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.TabStop = false;
+            // 
+            // THR_ALT_P
+            // 
+            resources.ApplyResources(this.THR_ALT_P, "THR_ALT_P");
+            this.THR_ALT_P.Max = 1F;
+            this.THR_ALT_P.Min = 0F;
+            this.THR_ALT_P.Name = "THR_ALT_P";
+            this.THR_ALT_P.ParamName = null;
+            this.THR_ALT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.THR_ALT_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label22
             // 
@@ -350,10 +421,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox19.Name = "groupBox19";
             this.groupBox19.TabStop = false;
             // 
+            // mavlinkNumericUpDownatc_input_tc
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_input_tc, "mavlinkNumericUpDownatc_input_tc");
+            this.mavlinkNumericUpDownatc_input_tc.Max = 1F;
+            this.mavlinkNumericUpDownatc_input_tc.Min = 0F;
+            this.mavlinkNumericUpDownatc_input_tc.Name = "mavlinkNumericUpDownatc_input_tc";
+            this.mavlinkNumericUpDownatc_input_tc.ParamName = null;
+            this.mavlinkNumericUpDownatc_input_tc.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.mavlinkNumericUpDownatc_input_tc.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label23
             // 
             resources.ApplyResources(this.label23, "label23");
             this.label23.Name = "label23";
+            // 
+            // HLD_LAT_P
+            // 
+            resources.ApplyResources(this.HLD_LAT_P, "HLD_LAT_P");
+            this.HLD_LAT_P.Max = 1F;
+            this.HLD_LAT_P.Min = 0F;
+            this.HLD_LAT_P.Name = "HLD_LAT_P";
+            this.HLD_LAT_P.ParamName = null;
+            this.HLD_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.HLD_LAT_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label31
             // 
@@ -370,10 +461,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox20.Name = "groupBox20";
             this.groupBox20.TabStop = false;
             // 
+            // mavlinkNumericUpDownatc_accel_y_max
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_y_max, "mavlinkNumericUpDownatc_accel_y_max");
+            this.mavlinkNumericUpDownatc_accel_y_max.Max = 1F;
+            this.mavlinkNumericUpDownatc_accel_y_max.Min = 0F;
+            this.mavlinkNumericUpDownatc_accel_y_max.Name = "mavlinkNumericUpDownatc_accel_y_max";
+            this.mavlinkNumericUpDownatc_accel_y_max.ParamName = null;
+            this.mavlinkNumericUpDownatc_accel_y_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.mavlinkNumericUpDownatc_accel_y_max.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label21
             // 
             resources.ApplyResources(this.label21, "label21");
             this.label21.Name = "label21";
+            // 
+            // STB_YAW_P
+            // 
+            resources.ApplyResources(this.STB_YAW_P, "STB_YAW_P");
+            this.STB_YAW_P.Max = 1F;
+            this.STB_YAW_P.Min = 0F;
+            this.STB_YAW_P.Name = "STB_YAW_P";
+            this.STB_YAW_P.ParamName = null;
+            this.STB_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.STB_YAW_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label35
             // 
@@ -390,10 +501,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox21.Name = "groupBox21";
             this.groupBox21.TabStop = false;
             // 
+            // mavlinkNumericUpDownatc_accel_p_max
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_p_max, "mavlinkNumericUpDownatc_accel_p_max");
+            this.mavlinkNumericUpDownatc_accel_p_max.Max = 1F;
+            this.mavlinkNumericUpDownatc_accel_p_max.Min = 0F;
+            this.mavlinkNumericUpDownatc_accel_p_max.Name = "mavlinkNumericUpDownatc_accel_p_max";
+            this.mavlinkNumericUpDownatc_accel_p_max.ParamName = null;
+            this.mavlinkNumericUpDownatc_accel_p_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.mavlinkNumericUpDownatc_accel_p_max.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label20
             // 
             resources.ApplyResources(this.label20, "label20");
             this.label20.Name = "label20";
+            // 
+            // STB_PIT_P
+            // 
+            resources.ApplyResources(this.STB_PIT_P, "STB_PIT_P");
+            this.STB_PIT_P.Max = 1F;
+            this.STB_PIT_P.Min = 0F;
+            this.STB_PIT_P.Name = "STB_PIT_P";
+            this.STB_PIT_P.ParamName = null;
+            this.STB_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.STB_PIT_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label42
             // 
@@ -410,10 +541,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox22.Name = "groupBox22";
             this.groupBox22.TabStop = false;
             // 
+            // mavlinkNumericUpDownatc_accel_r_max
+            // 
+            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_r_max, "mavlinkNumericUpDownatc_accel_r_max");
+            this.mavlinkNumericUpDownatc_accel_r_max.Max = 1F;
+            this.mavlinkNumericUpDownatc_accel_r_max.Min = 0F;
+            this.mavlinkNumericUpDownatc_accel_r_max.Name = "mavlinkNumericUpDownatc_accel_r_max";
+            this.mavlinkNumericUpDownatc_accel_r_max.ParamName = null;
+            this.mavlinkNumericUpDownatc_accel_r_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.mavlinkNumericUpDownatc_accel_r_max.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label19
             // 
             resources.ApplyResources(this.label19, "label19");
             this.label19.Name = "label19";
+            // 
+            // STB_RLL_P
+            // 
+            resources.ApplyResources(this.STB_RLL_P, "STB_RLL_P");
+            this.STB_RLL_P.Max = 1F;
+            this.STB_RLL_P.Min = 0F;
+            this.STB_RLL_P.Name = "STB_RLL_P";
+            this.STB_RLL_P.ParamName = null;
+            this.STB_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.STB_RLL_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label46
             // 
@@ -440,35 +591,105 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox23.Name = "groupBox23";
             this.groupBox23.TabStop = false;
             // 
+            // ATC_RAT_YAW_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_YAW_FLTT, "ATC_RAT_YAW_FLTT");
+            this.ATC_RAT_YAW_FLTT.Max = 1F;
+            this.ATC_RAT_YAW_FLTT.Min = 0F;
+            this.ATC_RAT_YAW_FLTT.Name = "ATC_RAT_YAW_FLTT";
+            this.ATC_RAT_YAW_FLTT.ParamName = null;
+            this.ATC_RAT_YAW_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.ATC_RAT_YAW_FLTT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label33
             // 
             resources.ApplyResources(this.label33, "label33");
             this.label33.Name = "label33";
+            // 
+            // ATC_RAT_YAW_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_YAW_FLTD, "ATC_RAT_YAW_FLTD");
+            this.ATC_RAT_YAW_FLTD.Max = 1F;
+            this.ATC_RAT_YAW_FLTD.Min = 0F;
+            this.ATC_RAT_YAW_FLTD.Name = "ATC_RAT_YAW_FLTD";
+            this.ATC_RAT_YAW_FLTD.ParamName = null;
+            this.ATC_RAT_YAW_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.ATC_RAT_YAW_FLTD.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label32
             // 
             resources.ApplyResources(this.label32, "label32");
             this.label32.Name = "label32";
             // 
+            // RATE_YAW_FILT
+            // 
+            resources.ApplyResources(this.RATE_YAW_FILT, "RATE_YAW_FILT");
+            this.RATE_YAW_FILT.Max = 1F;
+            this.RATE_YAW_FILT.Min = 0F;
+            this.RATE_YAW_FILT.Name = "RATE_YAW_FILT";
+            this.RATE_YAW_FILT.ParamName = null;
+            this.RATE_YAW_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_YAW_FILT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label18
             // 
             resources.ApplyResources(this.label18, "label18");
             this.label18.Name = "label18";
+            // 
+            // RATE_YAW_D
+            // 
+            resources.ApplyResources(this.RATE_YAW_D, "RATE_YAW_D");
+            this.RATE_YAW_D.Max = 1F;
+            this.RATE_YAW_D.Min = 0F;
+            this.RATE_YAW_D.Name = "RATE_YAW_D";
+            this.RATE_YAW_D.ParamName = null;
+            this.RATE_YAW_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_YAW_D.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label10
             // 
             resources.ApplyResources(this.label10, "label10");
             this.label10.Name = "label10";
             // 
+            // RATE_YAW_IMAX
+            // 
+            resources.ApplyResources(this.RATE_YAW_IMAX, "RATE_YAW_IMAX");
+            this.RATE_YAW_IMAX.Max = 1F;
+            this.RATE_YAW_IMAX.Min = 0F;
+            this.RATE_YAW_IMAX.Name = "RATE_YAW_IMAX";
+            this.RATE_YAW_IMAX.ParamName = null;
+            this.RATE_YAW_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_YAW_IMAX.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label47
             // 
             resources.ApplyResources(this.label47, "label47");
             this.label47.Name = "label47";
             // 
+            // RATE_YAW_I
+            // 
+            resources.ApplyResources(this.RATE_YAW_I, "RATE_YAW_I");
+            this.RATE_YAW_I.Max = 1F;
+            this.RATE_YAW_I.Min = 0F;
+            this.RATE_YAW_I.Name = "RATE_YAW_I";
+            this.RATE_YAW_I.ParamName = null;
+            this.RATE_YAW_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_YAW_I.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label77
             // 
             resources.ApplyResources(this.label77, "label77");
             this.label77.Name = "label77";
+            // 
+            // RATE_YAW_P
+            // 
+            resources.ApplyResources(this.RATE_YAW_P, "RATE_YAW_P");
+            this.RATE_YAW_P.Max = 1F;
+            this.RATE_YAW_P.Min = 0F;
+            this.RATE_YAW_P.Name = "RATE_YAW_P";
+            this.RATE_YAW_P.ParamName = null;
+            this.RATE_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_YAW_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label82
             // 
@@ -495,35 +716,105 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox24.Name = "groupBox24";
             this.groupBox24.TabStop = false;
             // 
+            // ATC_RAT_PIT_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_PIT_FLTT, "ATC_RAT_PIT_FLTT");
+            this.ATC_RAT_PIT_FLTT.Max = 1F;
+            this.ATC_RAT_PIT_FLTT.Min = 0F;
+            this.ATC_RAT_PIT_FLTT.Name = "ATC_RAT_PIT_FLTT";
+            this.ATC_RAT_PIT_FLTT.ParamName = null;
+            this.ATC_RAT_PIT_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.ATC_RAT_PIT_FLTT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label30
             // 
             resources.ApplyResources(this.label30, "label30");
             this.label30.Name = "label30";
+            // 
+            // ATC_RAT_PIT_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_PIT_FLTD, "ATC_RAT_PIT_FLTD");
+            this.ATC_RAT_PIT_FLTD.Max = 1F;
+            this.ATC_RAT_PIT_FLTD.Min = 0F;
+            this.ATC_RAT_PIT_FLTD.Name = "ATC_RAT_PIT_FLTD";
+            this.ATC_RAT_PIT_FLTD.ParamName = null;
+            this.ATC_RAT_PIT_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.ATC_RAT_PIT_FLTD.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label29
             // 
             resources.ApplyResources(this.label29, "label29");
             this.label29.Name = "label29";
             // 
+            // RATE_PIT_FILT
+            // 
+            resources.ApplyResources(this.RATE_PIT_FILT, "RATE_PIT_FILT");
+            this.RATE_PIT_FILT.Max = 1F;
+            this.RATE_PIT_FILT.Min = 0F;
+            this.RATE_PIT_FILT.Name = "RATE_PIT_FILT";
+            this.RATE_PIT_FILT.ParamName = null;
+            this.RATE_PIT_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_PIT_FILT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label14
             // 
             resources.ApplyResources(this.label14, "label14");
             this.label14.Name = "label14";
+            // 
+            // RATE_PIT_D
+            // 
+            resources.ApplyResources(this.RATE_PIT_D, "RATE_PIT_D");
+            this.RATE_PIT_D.Max = 1F;
+            this.RATE_PIT_D.Min = 0F;
+            this.RATE_PIT_D.Name = "RATE_PIT_D";
+            this.RATE_PIT_D.ParamName = null;
+            this.RATE_PIT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_PIT_D.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label11
             // 
             resources.ApplyResources(this.label11, "label11");
             this.label11.Name = "label11";
             // 
+            // RATE_PIT_IMAX
+            // 
+            resources.ApplyResources(this.RATE_PIT_IMAX, "RATE_PIT_IMAX");
+            this.RATE_PIT_IMAX.Max = 1F;
+            this.RATE_PIT_IMAX.Min = 0F;
+            this.RATE_PIT_IMAX.Name = "RATE_PIT_IMAX";
+            this.RATE_PIT_IMAX.ParamName = null;
+            this.RATE_PIT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_PIT_IMAX.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label84
             // 
             resources.ApplyResources(this.label84, "label84");
             this.label84.Name = "label84";
             // 
+            // RATE_PIT_I
+            // 
+            resources.ApplyResources(this.RATE_PIT_I, "RATE_PIT_I");
+            this.RATE_PIT_I.Max = 1F;
+            this.RATE_PIT_I.Min = 0F;
+            this.RATE_PIT_I.Name = "RATE_PIT_I";
+            this.RATE_PIT_I.ParamName = null;
+            this.RATE_PIT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_PIT_I.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label86
             // 
             resources.ApplyResources(this.label86, "label86");
             this.label86.Name = "label86";
+            // 
+            // RATE_PIT_P
+            // 
+            resources.ApplyResources(this.RATE_PIT_P, "RATE_PIT_P");
+            this.RATE_PIT_P.Max = 1F;
+            this.RATE_PIT_P.Min = 0F;
+            this.RATE_PIT_P.Name = "RATE_PIT_P";
+            this.RATE_PIT_P.ParamName = null;
+            this.RATE_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_PIT_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label87
             // 
@@ -550,35 +841,105 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox25.Name = "groupBox25";
             this.groupBox25.TabStop = false;
             // 
+            // ATC_RAT_RLL_FLTT
+            // 
+            resources.ApplyResources(this.ATC_RAT_RLL_FLTT, "ATC_RAT_RLL_FLTT");
+            this.ATC_RAT_RLL_FLTT.Max = 1F;
+            this.ATC_RAT_RLL_FLTT.Min = 0F;
+            this.ATC_RAT_RLL_FLTT.Name = "ATC_RAT_RLL_FLTT";
+            this.ATC_RAT_RLL_FLTT.ParamName = null;
+            this.ATC_RAT_RLL_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.ATC_RAT_RLL_FLTT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label28
             // 
             resources.ApplyResources(this.label28, "label28");
             this.label28.Name = "label28";
+            // 
+            // ATC_RAT_RLL_FLTD
+            // 
+            resources.ApplyResources(this.ATC_RAT_RLL_FLTD, "ATC_RAT_RLL_FLTD");
+            this.ATC_RAT_RLL_FLTD.Max = 1F;
+            this.ATC_RAT_RLL_FLTD.Min = 0F;
+            this.ATC_RAT_RLL_FLTD.Name = "ATC_RAT_RLL_FLTD";
+            this.ATC_RAT_RLL_FLTD.ParamName = null;
+            this.ATC_RAT_RLL_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.ATC_RAT_RLL_FLTD.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // P_FLTD
             // 
             resources.ApplyResources(this.P_FLTD, "P_FLTD");
             this.P_FLTD.Name = "P_FLTD";
             // 
+            // RATE_RLL_FILT
+            // 
+            resources.ApplyResources(this.RATE_RLL_FILT, "RATE_RLL_FILT");
+            this.RATE_RLL_FILT.Max = 1F;
+            this.RATE_RLL_FILT.Min = 0F;
+            this.RATE_RLL_FILT.Name = "RATE_RLL_FILT";
+            this.RATE_RLL_FILT.ParamName = null;
+            this.RATE_RLL_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_RLL_FILT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label12
             // 
             resources.ApplyResources(this.label12, "label12");
             this.label12.Name = "label12";
+            // 
+            // RATE_RLL_D
+            // 
+            resources.ApplyResources(this.RATE_RLL_D, "RATE_RLL_D");
+            this.RATE_RLL_D.Max = 1F;
+            this.RATE_RLL_D.Min = 0F;
+            this.RATE_RLL_D.Name = "RATE_RLL_D";
+            this.RATE_RLL_D.ParamName = null;
+            this.RATE_RLL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_RLL_D.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label17
             // 
             resources.ApplyResources(this.label17, "label17");
             this.label17.Name = "label17";
             // 
+            // RATE_RLL_IMAX
+            // 
+            resources.ApplyResources(this.RATE_RLL_IMAX, "RATE_RLL_IMAX");
+            this.RATE_RLL_IMAX.Max = 1F;
+            this.RATE_RLL_IMAX.Min = 0F;
+            this.RATE_RLL_IMAX.Name = "RATE_RLL_IMAX";
+            this.RATE_RLL_IMAX.ParamName = null;
+            this.RATE_RLL_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_RLL_IMAX.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label88
             // 
             resources.ApplyResources(this.label88, "label88");
             this.label88.Name = "label88";
             // 
+            // RATE_RLL_I
+            // 
+            resources.ApplyResources(this.RATE_RLL_I, "RATE_RLL_I");
+            this.RATE_RLL_I.Max = 1F;
+            this.RATE_RLL_I.Min = 0F;
+            this.RATE_RLL_I.Name = "RATE_RLL_I";
+            this.RATE_RLL_I.ParamName = null;
+            this.RATE_RLL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_RLL_I.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label90
             // 
             resources.ApplyResources(this.label90, "label90");
             this.label90.Name = "label90";
+            // 
+            // RATE_RLL_P
+            // 
+            resources.ApplyResources(this.RATE_RLL_P, "RATE_RLL_P");
+            this.RATE_RLL_P.Max = 1F;
+            this.RATE_RLL_P.Min = 0F;
+            this.RATE_RLL_P.Name = "RATE_RLL_P";
+            this.RATE_RLL_P.ParamName = null;
+            this.RATE_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.RATE_RLL_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label91
             // 
@@ -605,20 +966,60 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.TabStop = false;
             // 
+            // LOITER_LAT_D
+            // 
+            resources.ApplyResources(this.LOITER_LAT_D, "LOITER_LAT_D");
+            this.LOITER_LAT_D.Max = 1F;
+            this.LOITER_LAT_D.Min = 0F;
+            this.LOITER_LAT_D.Name = "LOITER_LAT_D";
+            this.LOITER_LAT_D.ParamName = null;
+            this.LOITER_LAT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.LOITER_LAT_D.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
             this.label1.Name = "label1";
+            // 
+            // LOITER_LAT_IMAX
+            // 
+            resources.ApplyResources(this.LOITER_LAT_IMAX, "LOITER_LAT_IMAX");
+            this.LOITER_LAT_IMAX.Max = 1F;
+            this.LOITER_LAT_IMAX.Min = 0F;
+            this.LOITER_LAT_IMAX.Name = "LOITER_LAT_IMAX";
+            this.LOITER_LAT_IMAX.ParamName = null;
+            this.LOITER_LAT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.LOITER_LAT_IMAX.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label2
             // 
             resources.ApplyResources(this.label2, "label2");
             this.label2.Name = "label2";
             // 
+            // LOITER_LAT_I
+            // 
+            resources.ApplyResources(this.LOITER_LAT_I, "LOITER_LAT_I");
+            this.LOITER_LAT_I.Max = 1F;
+            this.LOITER_LAT_I.Min = 0F;
+            this.LOITER_LAT_I.Name = "LOITER_LAT_I";
+            this.LOITER_LAT_I.ParamName = null;
+            this.LOITER_LAT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.LOITER_LAT_I.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label3
             // 
             resources.ApplyResources(this.label3, "label3");
             this.label3.Name = "label3";
+            // 
+            // LOITER_LAT_P
+            // 
+            resources.ApplyResources(this.LOITER_LAT_P, "LOITER_LAT_P");
+            this.LOITER_LAT_P.Max = 1F;
+            this.LOITER_LAT_P.Min = 0F;
+            this.LOITER_LAT_P.Name = "LOITER_LAT_P";
+            this.LOITER_LAT_P.ParamName = null;
+            this.LOITER_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.LOITER_LAT_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label4
             // 
@@ -629,6 +1030,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_rerequestparams, "BUT_rerequestparams");
             this.BUT_rerequestparams.Name = "BUT_rerequestparams";
+            this.BUT_rerequestparams.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_rerequestparams.UseVisualStyleBackColor = true;
             this.BUT_rerequestparams.Click += new System.EventHandler(this.BUT_rerequestparams_Click);
             // 
@@ -636,6 +1038,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_writePIDS, "BUT_writePIDS");
             this.BUT_writePIDS.Name = "BUT_writePIDS";
+            this.BUT_writePIDS.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_writePIDS.UseVisualStyleBackColor = true;
             this.BUT_writePIDS.Click += new System.EventHandler(this.BUT_writePIDS_Click);
             // 
@@ -668,6 +1071,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.TabStop = false;
             // 
+            // THR_ACCEL_D
+            // 
+            resources.ApplyResources(this.THR_ACCEL_D, "THR_ACCEL_D");
+            this.THR_ACCEL_D.Max = 1F;
+            this.THR_ACCEL_D.Min = 0F;
+            this.THR_ACCEL_D.Name = "THR_ACCEL_D";
+            this.THR_ACCEL_D.ParamName = null;
+            this.THR_ACCEL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.THR_ACCEL_D.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label5
             // 
             resources.ApplyResources(this.label5, "label5");
@@ -678,10 +1091,45 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.label6, "label6");
             this.label6.Name = "label6";
             // 
+            // THR_ACCEL_IMAX
+            // 
+            resources.ApplyResources(this.THR_ACCEL_IMAX, "THR_ACCEL_IMAX");
+            this.THR_ACCEL_IMAX.Max = 1F;
+            this.THR_ACCEL_IMAX.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.THR_ACCEL_IMAX.Min = 0F;
+            this.THR_ACCEL_IMAX.Name = "THR_ACCEL_IMAX";
+            this.THR_ACCEL_IMAX.ParamName = null;
+            this.THR_ACCEL_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.THR_ACCEL_IMAX.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
+            // THR_ACCEL_I
+            // 
+            resources.ApplyResources(this.THR_ACCEL_I, "THR_ACCEL_I");
+            this.THR_ACCEL_I.Max = 1F;
+            this.THR_ACCEL_I.Min = 0F;
+            this.THR_ACCEL_I.Name = "THR_ACCEL_I";
+            this.THR_ACCEL_I.ParamName = null;
+            this.THR_ACCEL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.THR_ACCEL_I.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label7
             // 
             resources.ApplyResources(this.label7, "label7");
             this.label7.Name = "label7";
+            // 
+            // THR_ACCEL_P
+            // 
+            resources.ApplyResources(this.THR_ACCEL_P, "THR_ACCEL_P");
+            this.THR_ACCEL_P.Max = 1F;
+            this.THR_ACCEL_P.Min = 0F;
+            this.THR_ACCEL_P.Name = "THR_ACCEL_P";
+            this.THR_ACCEL_P.ParamName = null;
+            this.THR_ACCEL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.THR_ACCEL_P.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label8
             // 
@@ -692,6 +1140,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             // 
             resources.ApplyResources(this.BUT_refreshpart, "BUT_refreshpart");
             this.BUT_refreshpart.Name = "BUT_refreshpart";
+            this.BUT_refreshpart.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.BUT_refreshpart.UseVisualStyleBackColor = true;
             this.BUT_refreshpart.Click += new System.EventHandler(this.BUT_refreshpart_Click);
             // 
@@ -720,10 +1169,30 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.TabStop = false;
             // 
+            // INS_ACCEL_FILTER
+            // 
+            resources.ApplyResources(this.INS_ACCEL_FILTER, "INS_ACCEL_FILTER");
+            this.INS_ACCEL_FILTER.Max = 1F;
+            this.INS_ACCEL_FILTER.Min = 0F;
+            this.INS_ACCEL_FILTER.Name = "INS_ACCEL_FILTER";
+            this.INS_ACCEL_FILTER.ParamName = null;
+            this.INS_ACCEL_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_ACCEL_FILTER.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label26
             // 
             resources.ApplyResources(this.label26, "label26");
             this.label26.Name = "label26";
+            // 
+            // INS_GYRO_FILTER
+            // 
+            resources.ApplyResources(this.INS_GYRO_FILTER, "INS_GYRO_FILTER");
+            this.INS_GYRO_FILTER.Max = 1F;
+            this.INS_GYRO_FILTER.Min = 0F;
+            this.INS_GYRO_FILTER.Name = "INS_GYRO_FILTER";
+            this.INS_GYRO_FILTER.ParamName = null;
+            this.INS_GYRO_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_GYRO_FILTER.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label24
             // 
@@ -752,35 +1221,116 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox9.Name = "groupBox9";
             this.groupBox9.TabStop = false;
             // 
+            // INS_HNTCH_ENABLE
+            // 
+            this.INS_HNTCH_ENABLE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.INS_HNTCH_ENABLE.DropDownWidth = 170;
+            resources.ApplyResources(this.INS_HNTCH_ENABLE, "INS_HNTCH_ENABLE");
+            this.INS_HNTCH_ENABLE.FormattingEnabled = true;
+            this.INS_HNTCH_ENABLE.Name = "INS_HNTCH_ENABLE";
+            this.INS_HNTCH_ENABLE.ParamName = null;
+            this.INS_HNTCH_ENABLE.SubControl = null;
+            this.INS_HNTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_HNTCH_HMNCS
+            // 
+            resources.ApplyResources(this.INS_HNTCH_HMNCS, "INS_HNTCH_HMNCS");
+            this.INS_HNTCH_HMNCS.Max = 1F;
+            this.INS_HNTCH_HMNCS.Min = 0F;
+            this.INS_HNTCH_HMNCS.Name = "INS_HNTCH_HMNCS";
+            this.INS_HNTCH_HMNCS.ParamName = null;
+            this.INS_HNTCH_HMNCS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_HMNCS.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label51
             // 
             resources.ApplyResources(this.label51, "label51");
             this.label51.Name = "label51";
+            // 
+            // INS_HNTCH_OPTS
+            // 
+            resources.ApplyResources(this.INS_HNTCH_OPTS, "INS_HNTCH_OPTS");
+            this.INS_HNTCH_OPTS.Max = 1F;
+            this.INS_HNTCH_OPTS.Min = 0F;
+            this.INS_HNTCH_OPTS.Name = "INS_HNTCH_OPTS";
+            this.INS_HNTCH_OPTS.ParamName = null;
+            this.INS_HNTCH_OPTS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_OPTS.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label50
             // 
             resources.ApplyResources(this.label50, "label50");
             this.label50.Name = "label50";
             // 
+            // INS_HNTCH_BW
+            // 
+            resources.ApplyResources(this.INS_HNTCH_BW, "INS_HNTCH_BW");
+            this.INS_HNTCH_BW.Max = 1F;
+            this.INS_HNTCH_BW.Min = 0F;
+            this.INS_HNTCH_BW.Name = "INS_HNTCH_BW";
+            this.INS_HNTCH_BW.ParamName = null;
+            this.INS_HNTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_BW.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label49
             // 
             resources.ApplyResources(this.label49, "label49");
             this.label49.Name = "label49";
+            // 
+            // INS_HNTCH_ATT
+            // 
+            resources.ApplyResources(this.INS_HNTCH_ATT, "INS_HNTCH_ATT");
+            this.INS_HNTCH_ATT.Max = 1F;
+            this.INS_HNTCH_ATT.Min = 0F;
+            this.INS_HNTCH_ATT.Name = "INS_HNTCH_ATT";
+            this.INS_HNTCH_ATT.ParamName = null;
+            this.INS_HNTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_ATT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label48
             // 
             resources.ApplyResources(this.label48, "label48");
             this.label48.Name = "label48";
             // 
+            // INS_HNTCH_FREQ
+            // 
+            resources.ApplyResources(this.INS_HNTCH_FREQ, "INS_HNTCH_FREQ");
+            this.INS_HNTCH_FREQ.Max = 1F;
+            this.INS_HNTCH_FREQ.Min = 0F;
+            this.INS_HNTCH_FREQ.Name = "INS_HNTCH_FREQ";
+            this.INS_HNTCH_FREQ.ParamName = null;
+            this.INS_HNTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_FREQ.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label41
             // 
             resources.ApplyResources(this.label41, "label41");
             this.label41.Name = "label41";
             // 
+            // INS_HNTCH_REF
+            // 
+            resources.ApplyResources(this.INS_HNTCH_REF, "INS_HNTCH_REF");
+            this.INS_HNTCH_REF.Max = 1F;
+            this.INS_HNTCH_REF.Min = 0F;
+            this.INS_HNTCH_REF.Name = "INS_HNTCH_REF";
+            this.INS_HNTCH_REF.ParamName = null;
+            this.INS_HNTCH_REF.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_REF.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label43
             // 
             resources.ApplyResources(this.label43, "label43");
             this.label43.Name = "label43";
+            // 
+            // INS_HNTCH_MODE
+            // 
+            resources.ApplyResources(this.INS_HNTCH_MODE, "INS_HNTCH_MODE");
+            this.INS_HNTCH_MODE.Max = 1F;
+            this.INS_HNTCH_MODE.Min = 0F;
+            this.INS_HNTCH_MODE.Name = "INS_HNTCH_MODE";
+            this.INS_HNTCH_MODE.ParamName = null;
+            this.INS_HNTCH_MODE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_HNTCH_MODE.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label44
             // 
@@ -806,15 +1356,56 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox8.Name = "groupBox8";
             this.groupBox8.TabStop = false;
             // 
+            // INS_NOTCH_ENABLE
+            // 
+            this.INS_NOTCH_ENABLE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.INS_NOTCH_ENABLE.DropDownWidth = 170;
+            resources.ApplyResources(this.INS_NOTCH_ENABLE, "INS_NOTCH_ENABLE");
+            this.INS_NOTCH_ENABLE.FormattingEnabled = true;
+            this.INS_NOTCH_ENABLE.Name = "INS_NOTCH_ENABLE";
+            this.INS_NOTCH_ENABLE.ParamName = null;
+            this.INS_NOTCH_ENABLE.SubControl = null;
+            this.INS_NOTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
+            // INS_NOTCH_ATT
+            // 
+            resources.ApplyResources(this.INS_NOTCH_ATT, "INS_NOTCH_ATT");
+            this.INS_NOTCH_ATT.Max = 1F;
+            this.INS_NOTCH_ATT.Min = 0F;
+            this.INS_NOTCH_ATT.Name = "INS_NOTCH_ATT";
+            this.INS_NOTCH_ATT.ParamName = null;
+            this.INS_NOTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_NOTCH_ATT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label40
             // 
             resources.ApplyResources(this.label40, "label40");
             this.label40.Name = "label40";
             // 
+            // INS_NOTCH_BW
+            // 
+            resources.ApplyResources(this.INS_NOTCH_BW, "INS_NOTCH_BW");
+            this.INS_NOTCH_BW.Max = 1F;
+            this.INS_NOTCH_BW.Min = 0F;
+            this.INS_NOTCH_BW.Name = "INS_NOTCH_BW";
+            this.INS_NOTCH_BW.ParamName = null;
+            this.INS_NOTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_NOTCH_BW.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
             // label39
             // 
             resources.ApplyResources(this.label39, "label39");
             this.label39.Name = "label39";
+            // 
+            // INS_NOTCH_FREQ
+            // 
+            resources.ApplyResources(this.INS_NOTCH_FREQ, "INS_NOTCH_FREQ");
+            this.INS_NOTCH_FREQ.Max = 1F;
+            this.INS_NOTCH_FREQ.Min = 0F;
+            this.INS_NOTCH_FREQ.Name = "INS_NOTCH_FREQ";
+            this.INS_NOTCH_FREQ.ParamName = null;
+            this.INS_NOTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_NOTCH_FREQ.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // label38
             // 
@@ -836,6 +1427,27 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.groupBox6.Name = "groupBox6";
             this.groupBox6.TabStop = false;
             // 
+            // INS_LOG_BAT_OPT
+            // 
+            resources.ApplyResources(this.INS_LOG_BAT_OPT, "INS_LOG_BAT_OPT");
+            this.INS_LOG_BAT_OPT.Max = 1F;
+            this.INS_LOG_BAT_OPT.Min = 0F;
+            this.INS_LOG_BAT_OPT.Name = "INS_LOG_BAT_OPT";
+            this.INS_LOG_BAT_OPT.ParamName = null;
+            this.INS_LOG_BAT_OPT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.INS_LOG_BAT_OPT.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
+            // 
+            // INS_LOG_BAT_MASK
+            // 
+            this.INS_LOG_BAT_MASK.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.INS_LOG_BAT_MASK.DropDownWidth = 170;
+            resources.ApplyResources(this.INS_LOG_BAT_MASK, "INS_LOG_BAT_MASK");
+            this.INS_LOG_BAT_MASK.FormattingEnabled = true;
+            this.INS_LOG_BAT_MASK.Name = "INS_LOG_BAT_MASK";
+            this.INS_LOG_BAT_MASK.ParamName = null;
+            this.INS_LOG_BAT_MASK.SubControl = null;
+            this.INS_LOG_BAT_MASK.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // 
             // label36
             // 
             resources.ApplyResources(this.label36, "label36");
@@ -851,107 +1463,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             resources.ApplyResources(this.label52, "label52");
             this.label52.Name = "label52";
             // 
-            // INS_NOTCH_ENABLE
-            // 
-            this.INS_NOTCH_ENABLE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.INS_NOTCH_ENABLE.DropDownWidth = 170;
-            resources.ApplyResources(this.INS_NOTCH_ENABLE, "INS_NOTCH_ENABLE");
-            this.INS_NOTCH_ENABLE.FormattingEnabled = true;
-            this.INS_NOTCH_ENABLE.Name = "INS_NOTCH_ENABLE";
-            this.INS_NOTCH_ENABLE.ParamName = null;
-            this.INS_NOTCH_ENABLE.SubControl = null;
-            this.INS_NOTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_NOTCH_ATT
-            // 
-            resources.ApplyResources(this.INS_NOTCH_ATT, "INS_NOTCH_ATT");
-            this.INS_NOTCH_ATT.Max = 1F;
-            this.INS_NOTCH_ATT.Min = 0F;
-            this.INS_NOTCH_ATT.Name = "INS_NOTCH_ATT";
-            this.INS_NOTCH_ATT.ParamName = null;
-            this.INS_NOTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_NOTCH_BW
-            // 
-            resources.ApplyResources(this.INS_NOTCH_BW, "INS_NOTCH_BW");
-            this.INS_NOTCH_BW.Max = 1F;
-            this.INS_NOTCH_BW.Min = 0F;
-            this.INS_NOTCH_BW.Name = "INS_NOTCH_BW";
-            this.INS_NOTCH_BW.ParamName = null;
-            this.INS_NOTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_NOTCH_FREQ
-            // 
-            resources.ApplyResources(this.INS_NOTCH_FREQ, "INS_NOTCH_FREQ");
-            this.INS_NOTCH_FREQ.Max = 1F;
-            this.INS_NOTCH_FREQ.Min = 0F;
-            this.INS_NOTCH_FREQ.Name = "INS_NOTCH_FREQ";
-            this.INS_NOTCH_FREQ.ParamName = null;
-            this.INS_NOTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_HMNCS
-            // 
-            resources.ApplyResources(this.INS_HNTCH_HMNCS, "INS_HNTCH_HMNCS");
-            this.INS_HNTCH_HMNCS.Max = 1F;
-            this.INS_HNTCH_HMNCS.Min = 0F;
-            this.INS_HNTCH_HMNCS.Name = "INS_HNTCH_HMNCS";
-            this.INS_HNTCH_HMNCS.ParamName = null;
-            this.INS_HNTCH_HMNCS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_OPTS
-            // 
-            resources.ApplyResources(this.INS_HNTCH_OPTS, "INS_HNTCH_OPTS");
-            this.INS_HNTCH_OPTS.Max = 1F;
-            this.INS_HNTCH_OPTS.Min = 0F;
-            this.INS_HNTCH_OPTS.Name = "INS_HNTCH_OPTS";
-            this.INS_HNTCH_OPTS.ParamName = null;
-            this.INS_HNTCH_OPTS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_BW
-            // 
-            resources.ApplyResources(this.INS_HNTCH_BW, "INS_HNTCH_BW");
-            this.INS_HNTCH_BW.Max = 1F;
-            this.INS_HNTCH_BW.Min = 0F;
-            this.INS_HNTCH_BW.Name = "INS_HNTCH_BW";
-            this.INS_HNTCH_BW.ParamName = null;
-            this.INS_HNTCH_BW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_ATT
-            // 
-            resources.ApplyResources(this.INS_HNTCH_ATT, "INS_HNTCH_ATT");
-            this.INS_HNTCH_ATT.Max = 1F;
-            this.INS_HNTCH_ATT.Min = 0F;
-            this.INS_HNTCH_ATT.Name = "INS_HNTCH_ATT";
-            this.INS_HNTCH_ATT.ParamName = null;
-            this.INS_HNTCH_ATT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_FREQ
-            // 
-            resources.ApplyResources(this.INS_HNTCH_FREQ, "INS_HNTCH_FREQ");
-            this.INS_HNTCH_FREQ.Max = 1F;
-            this.INS_HNTCH_FREQ.Min = 0F;
-            this.INS_HNTCH_FREQ.Name = "INS_HNTCH_FREQ";
-            this.INS_HNTCH_FREQ.ParamName = null;
-            this.INS_HNTCH_FREQ.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_REF
-            // 
-            resources.ApplyResources(this.INS_HNTCH_REF, "INS_HNTCH_REF");
-            this.INS_HNTCH_REF.Max = 1F;
-            this.INS_HNTCH_REF.Min = 0F;
-            this.INS_HNTCH_REF.Name = "INS_HNTCH_REF";
-            this.INS_HNTCH_REF.ParamName = null;
-            this.INS_HNTCH_REF.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_MODE
-            // 
-            resources.ApplyResources(this.INS_HNTCH_MODE, "INS_HNTCH_MODE");
-            this.INS_HNTCH_MODE.Max = 1F;
-            this.INS_HNTCH_MODE.Min = 0F;
-            this.INS_HNTCH_MODE.Name = "INS_HNTCH_MODE";
-            this.INS_HNTCH_MODE.ParamName = null;
-            this.INS_HNTCH_MODE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // CH6_OPTION
             // 
             this.CH6_OPTION.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -962,35 +1473,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.CH6_OPTION.ParamName = null;
             this.CH6_OPTION.SubControl = null;
             this.CH6_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_LOG_BAT_MASK
-            // 
-            this.INS_LOG_BAT_MASK.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.INS_LOG_BAT_MASK.DropDownWidth = 170;
-            resources.ApplyResources(this.INS_LOG_BAT_MASK, "INS_LOG_BAT_MASK");
-            this.INS_LOG_BAT_MASK.FormattingEnabled = true;
-            this.INS_LOG_BAT_MASK.Name = "INS_LOG_BAT_MASK";
-            this.INS_LOG_BAT_MASK.ParamName = null;
-            this.INS_LOG_BAT_MASK.SubControl = null;
-            this.INS_LOG_BAT_MASK.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_ACCEL_FILTER
-            // 
-            resources.ApplyResources(this.INS_ACCEL_FILTER, "INS_ACCEL_FILTER");
-            this.INS_ACCEL_FILTER.Max = 1F;
-            this.INS_ACCEL_FILTER.Min = 0F;
-            this.INS_ACCEL_FILTER.Name = "INS_ACCEL_FILTER";
-            this.INS_ACCEL_FILTER.ParamName = null;
-            this.INS_ACCEL_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_GYRO_FILTER
-            // 
-            resources.ApplyResources(this.INS_GYRO_FILTER, "INS_GYRO_FILTER");
-            this.INS_GYRO_FILTER.Max = 1F;
-            this.INS_GYRO_FILTER.Min = 0F;
-            this.INS_GYRO_FILTER.Name = "INS_GYRO_FILTER";
-            this.INS_GYRO_FILTER.ParamName = null;
-            this.INS_GYRO_FILTER.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
             // CH10_OPTION
             // 
@@ -1023,83 +1505,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.CH8_OPTION.SubControl = null;
             this.CH8_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
-            // THR_ACCEL_D
-            // 
-            resources.ApplyResources(this.THR_ACCEL_D, "THR_ACCEL_D");
-            this.THR_ACCEL_D.Max = 1F;
-            this.THR_ACCEL_D.Min = 0F;
-            this.THR_ACCEL_D.Name = "THR_ACCEL_D";
-            this.THR_ACCEL_D.ParamName = null;
-            this.THR_ACCEL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // THR_ACCEL_IMAX
-            // 
-            resources.ApplyResources(this.THR_ACCEL_IMAX, "THR_ACCEL_IMAX");
-            this.THR_ACCEL_IMAX.Max = 1F;
-            this.THR_ACCEL_IMAX.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.THR_ACCEL_IMAX.Min = 0F;
-            this.THR_ACCEL_IMAX.Name = "THR_ACCEL_IMAX";
-            this.THR_ACCEL_IMAX.ParamName = null;
-            this.THR_ACCEL_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // THR_ACCEL_I
-            // 
-            resources.ApplyResources(this.THR_ACCEL_I, "THR_ACCEL_I");
-            this.THR_ACCEL_I.Max = 1F;
-            this.THR_ACCEL_I.Min = 0F;
-            this.THR_ACCEL_I.Name = "THR_ACCEL_I";
-            this.THR_ACCEL_I.ParamName = null;
-            this.THR_ACCEL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // THR_ACCEL_P
-            // 
-            resources.ApplyResources(this.THR_ACCEL_P, "THR_ACCEL_P");
-            this.THR_ACCEL_P.Max = 1F;
-            this.THR_ACCEL_P.Min = 0F;
-            this.THR_ACCEL_P.Name = "THR_ACCEL_P";
-            this.THR_ACCEL_P.ParamName = null;
-            this.THR_ACCEL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // LOITER_LAT_D
-            // 
-            resources.ApplyResources(this.LOITER_LAT_D, "LOITER_LAT_D");
-            this.LOITER_LAT_D.Max = 1F;
-            this.LOITER_LAT_D.Min = 0F;
-            this.LOITER_LAT_D.Name = "LOITER_LAT_D";
-            this.LOITER_LAT_D.ParamName = null;
-            this.LOITER_LAT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // LOITER_LAT_IMAX
-            // 
-            resources.ApplyResources(this.LOITER_LAT_IMAX, "LOITER_LAT_IMAX");
-            this.LOITER_LAT_IMAX.Max = 1F;
-            this.LOITER_LAT_IMAX.Min = 0F;
-            this.LOITER_LAT_IMAX.Name = "LOITER_LAT_IMAX";
-            this.LOITER_LAT_IMAX.ParamName = null;
-            this.LOITER_LAT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // LOITER_LAT_I
-            // 
-            resources.ApplyResources(this.LOITER_LAT_I, "LOITER_LAT_I");
-            this.LOITER_LAT_I.Max = 1F;
-            this.LOITER_LAT_I.Min = 0F;
-            this.LOITER_LAT_I.Name = "LOITER_LAT_I";
-            this.LOITER_LAT_I.ParamName = null;
-            this.LOITER_LAT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // LOITER_LAT_P
-            // 
-            resources.ApplyResources(this.LOITER_LAT_P, "LOITER_LAT_P");
-            this.LOITER_LAT_P.Max = 1F;
-            this.LOITER_LAT_P.Min = 0F;
-            this.LOITER_LAT_P.Name = "LOITER_LAT_P";
-            this.LOITER_LAT_P.ParamName = null;
-            this.LOITER_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
             // TUNE_LOW
             // 
             resources.ApplyResources(this.TUNE_LOW, "TUNE_LOW");
@@ -1108,6 +1513,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.TUNE_LOW.Name = "TUNE_LOW";
             this.TUNE_LOW.ParamName = null;
             this.TUNE_LOW.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.TUNE_LOW.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // TUNE_HIGH
             // 
@@ -1117,6 +1523,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.TUNE_HIGH.Name = "TUNE_HIGH";
             this.TUNE_HIGH.ParamName = null;
             this.TUNE_HIGH.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            this.TUNE_HIGH.Enter += new System.EventHandler(this.OnEnter_NumUpDown);
             // 
             // TUNE
             // 
@@ -1140,353 +1547,16 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.CH7_OPTION.SubControl = null;
             this.CH7_OPTION.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
             // 
-            // THR_RATE_P
-            // 
-            resources.ApplyResources(this.THR_RATE_P, "THR_RATE_P");
-            this.THR_RATE_P.Max = 1F;
-            this.THR_RATE_P.Min = 0F;
-            this.THR_RATE_P.Name = "THR_RATE_P";
-            this.THR_RATE_P.ParamName = null;
-            this.THR_RATE_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // WPNAV_SPEED_UP
-            // 
-            resources.ApplyResources(this.WPNAV_SPEED_UP, "WPNAV_SPEED_UP");
-            this.WPNAV_SPEED_UP.Max = 1F;
-            this.WPNAV_SPEED_UP.Min = 0F;
-            this.WPNAV_SPEED_UP.Name = "WPNAV_SPEED_UP";
-            this.WPNAV_SPEED_UP.ParamName = null;
-            this.WPNAV_SPEED_UP.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // WPNAV_LOIT_SPEED
-            // 
-            resources.ApplyResources(this.WPNAV_LOIT_SPEED, "WPNAV_LOIT_SPEED");
-            this.WPNAV_LOIT_SPEED.Max = 1F;
-            this.WPNAV_LOIT_SPEED.Min = 0F;
-            this.WPNAV_LOIT_SPEED.Name = "WPNAV_LOIT_SPEED";
-            this.WPNAV_LOIT_SPEED.ParamName = null;
-            this.WPNAV_LOIT_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // WPNAV_SPEED_DN
-            // 
-            resources.ApplyResources(this.WPNAV_SPEED_DN, "WPNAV_SPEED_DN");
-            this.WPNAV_SPEED_DN.Max = 1F;
-            this.WPNAV_SPEED_DN.Min = 0F;
-            this.WPNAV_SPEED_DN.Name = "WPNAV_SPEED_DN";
-            this.WPNAV_SPEED_DN.ParamName = null;
-            this.WPNAV_SPEED_DN.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // WPNAV_RADIUS
-            // 
-            resources.ApplyResources(this.WPNAV_RADIUS, "WPNAV_RADIUS");
-            this.WPNAV_RADIUS.Max = 1F;
-            this.WPNAV_RADIUS.Min = 0F;
-            this.WPNAV_RADIUS.Name = "WPNAV_RADIUS";
-            this.WPNAV_RADIUS.ParamName = null;
-            this.WPNAV_RADIUS.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // WPNAV_SPEED
-            // 
-            resources.ApplyResources(this.WPNAV_SPEED, "WPNAV_SPEED");
-            this.WPNAV_SPEED.Max = 1F;
-            this.WPNAV_SPEED.Min = 0F;
-            this.WPNAV_SPEED.Name = "WPNAV_SPEED";
-            this.WPNAV_SPEED.ParamName = null;
-            this.WPNAV_SPEED.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // THR_ALT_P
-            // 
-            resources.ApplyResources(this.THR_ALT_P, "THR_ALT_P");
-            this.THR_ALT_P.Max = 1F;
-            this.THR_ALT_P.Min = 0F;
-            this.THR_ALT_P.Name = "THR_ALT_P";
-            this.THR_ALT_P.ParamName = null;
-            this.THR_ALT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // mavlinkNumericUpDownatc_input_tc
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_input_tc, "mavlinkNumericUpDownatc_input_tc");
-            this.mavlinkNumericUpDownatc_input_tc.Max = 1F;
-            this.mavlinkNumericUpDownatc_input_tc.Min = 0F;
-            this.mavlinkNumericUpDownatc_input_tc.Name = "mavlinkNumericUpDownatc_input_tc";
-            this.mavlinkNumericUpDownatc_input_tc.ParamName = null;
-            this.mavlinkNumericUpDownatc_input_tc.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // HLD_LAT_P
-            // 
-            resources.ApplyResources(this.HLD_LAT_P, "HLD_LAT_P");
-            this.HLD_LAT_P.Max = 1F;
-            this.HLD_LAT_P.Min = 0F;
-            this.HLD_LAT_P.Name = "HLD_LAT_P";
-            this.HLD_LAT_P.ParamName = null;
-            this.HLD_LAT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // mavlinkNumericUpDownatc_accel_y_max
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_y_max, "mavlinkNumericUpDownatc_accel_y_max");
-            this.mavlinkNumericUpDownatc_accel_y_max.Max = 1F;
-            this.mavlinkNumericUpDownatc_accel_y_max.Min = 0F;
-            this.mavlinkNumericUpDownatc_accel_y_max.Name = "mavlinkNumericUpDownatc_accel_y_max";
-            this.mavlinkNumericUpDownatc_accel_y_max.ParamName = null;
-            this.mavlinkNumericUpDownatc_accel_y_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // STB_YAW_P
-            // 
-            resources.ApplyResources(this.STB_YAW_P, "STB_YAW_P");
-            this.STB_YAW_P.Max = 1F;
-            this.STB_YAW_P.Min = 0F;
-            this.STB_YAW_P.Name = "STB_YAW_P";
-            this.STB_YAW_P.ParamName = null;
-            this.STB_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // mavlinkNumericUpDownatc_accel_p_max
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_p_max, "mavlinkNumericUpDownatc_accel_p_max");
-            this.mavlinkNumericUpDownatc_accel_p_max.Max = 1F;
-            this.mavlinkNumericUpDownatc_accel_p_max.Min = 0F;
-            this.mavlinkNumericUpDownatc_accel_p_max.Name = "mavlinkNumericUpDownatc_accel_p_max";
-            this.mavlinkNumericUpDownatc_accel_p_max.ParamName = null;
-            this.mavlinkNumericUpDownatc_accel_p_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // STB_PIT_P
-            // 
-            resources.ApplyResources(this.STB_PIT_P, "STB_PIT_P");
-            this.STB_PIT_P.Max = 1F;
-            this.STB_PIT_P.Min = 0F;
-            this.STB_PIT_P.Name = "STB_PIT_P";
-            this.STB_PIT_P.ParamName = null;
-            this.STB_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // mavlinkNumericUpDownatc_accel_r_max
-            // 
-            resources.ApplyResources(this.mavlinkNumericUpDownatc_accel_r_max, "mavlinkNumericUpDownatc_accel_r_max");
-            this.mavlinkNumericUpDownatc_accel_r_max.Max = 1F;
-            this.mavlinkNumericUpDownatc_accel_r_max.Min = 0F;
-            this.mavlinkNumericUpDownatc_accel_r_max.Name = "mavlinkNumericUpDownatc_accel_r_max";
-            this.mavlinkNumericUpDownatc_accel_r_max.ParamName = null;
-            this.mavlinkNumericUpDownatc_accel_r_max.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // STB_RLL_P
-            // 
-            resources.ApplyResources(this.STB_RLL_P, "STB_RLL_P");
-            this.STB_RLL_P.Max = 1F;
-            this.STB_RLL_P.Min = 0F;
-            this.STB_RLL_P.Name = "STB_RLL_P";
-            this.STB_RLL_P.ParamName = null;
-            this.STB_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // ATC_RAT_YAW_FLTT
-            // 
-            resources.ApplyResources(this.ATC_RAT_YAW_FLTT, "ATC_RAT_YAW_FLTT");
-            this.ATC_RAT_YAW_FLTT.Max = 1F;
-            this.ATC_RAT_YAW_FLTT.Min = 0F;
-            this.ATC_RAT_YAW_FLTT.Name = "ATC_RAT_YAW_FLTT";
-            this.ATC_RAT_YAW_FLTT.ParamName = null;
-            this.ATC_RAT_YAW_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // ATC_RAT_YAW_FLTD
-            // 
-            resources.ApplyResources(this.ATC_RAT_YAW_FLTD, "ATC_RAT_YAW_FLTD");
-            this.ATC_RAT_YAW_FLTD.Max = 1F;
-            this.ATC_RAT_YAW_FLTD.Min = 0F;
-            this.ATC_RAT_YAW_FLTD.Name = "ATC_RAT_YAW_FLTD";
-            this.ATC_RAT_YAW_FLTD.ParamName = null;
-            this.ATC_RAT_YAW_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_YAW_FILT
-            // 
-            resources.ApplyResources(this.RATE_YAW_FILT, "RATE_YAW_FILT");
-            this.RATE_YAW_FILT.Max = 1F;
-            this.RATE_YAW_FILT.Min = 0F;
-            this.RATE_YAW_FILT.Name = "RATE_YAW_FILT";
-            this.RATE_YAW_FILT.ParamName = null;
-            this.RATE_YAW_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_YAW_D
-            // 
-            resources.ApplyResources(this.RATE_YAW_D, "RATE_YAW_D");
-            this.RATE_YAW_D.Max = 1F;
-            this.RATE_YAW_D.Min = 0F;
-            this.RATE_YAW_D.Name = "RATE_YAW_D";
-            this.RATE_YAW_D.ParamName = null;
-            this.RATE_YAW_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_YAW_IMAX
-            // 
-            resources.ApplyResources(this.RATE_YAW_IMAX, "RATE_YAW_IMAX");
-            this.RATE_YAW_IMAX.Max = 1F;
-            this.RATE_YAW_IMAX.Min = 0F;
-            this.RATE_YAW_IMAX.Name = "RATE_YAW_IMAX";
-            this.RATE_YAW_IMAX.ParamName = null;
-            this.RATE_YAW_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_YAW_I
-            // 
-            resources.ApplyResources(this.RATE_YAW_I, "RATE_YAW_I");
-            this.RATE_YAW_I.Max = 1F;
-            this.RATE_YAW_I.Min = 0F;
-            this.RATE_YAW_I.Name = "RATE_YAW_I";
-            this.RATE_YAW_I.ParamName = null;
-            this.RATE_YAW_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_YAW_P
-            // 
-            resources.ApplyResources(this.RATE_YAW_P, "RATE_YAW_P");
-            this.RATE_YAW_P.Max = 1F;
-            this.RATE_YAW_P.Min = 0F;
-            this.RATE_YAW_P.Name = "RATE_YAW_P";
-            this.RATE_YAW_P.ParamName = null;
-            this.RATE_YAW_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // ATC_RAT_RLL_FLTT
-            // 
-            resources.ApplyResources(this.ATC_RAT_RLL_FLTT, "ATC_RAT_RLL_FLTT");
-            this.ATC_RAT_RLL_FLTT.Max = 1F;
-            this.ATC_RAT_RLL_FLTT.Min = 0F;
-            this.ATC_RAT_RLL_FLTT.Name = "ATC_RAT_RLL_FLTT";
-            this.ATC_RAT_RLL_FLTT.ParamName = null;
-            this.ATC_RAT_RLL_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // ATC_RAT_RLL_FLTD
-            // 
-            resources.ApplyResources(this.ATC_RAT_RLL_FLTD, "ATC_RAT_RLL_FLTD");
-            this.ATC_RAT_RLL_FLTD.Max = 1F;
-            this.ATC_RAT_RLL_FLTD.Min = 0F;
-            this.ATC_RAT_RLL_FLTD.Name = "ATC_RAT_RLL_FLTD";
-            this.ATC_RAT_RLL_FLTD.ParamName = null;
-            this.ATC_RAT_RLL_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_PIT_FILT
-            // 
-            resources.ApplyResources(this.RATE_PIT_FILT, "RATE_PIT_FILT");
-            this.RATE_PIT_FILT.Max = 1F;
-            this.RATE_PIT_FILT.Min = 0F;
-            this.RATE_PIT_FILT.Name = "RATE_PIT_FILT";
-            this.RATE_PIT_FILT.ParamName = null;
-            this.RATE_PIT_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_PIT_D
-            // 
-            resources.ApplyResources(this.RATE_PIT_D, "RATE_PIT_D");
-            this.RATE_PIT_D.Max = 1F;
-            this.RATE_PIT_D.Min = 0F;
-            this.RATE_PIT_D.Name = "RATE_PIT_D";
-            this.RATE_PIT_D.ParamName = null;
-            this.RATE_PIT_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_PIT_IMAX
-            // 
-            resources.ApplyResources(this.RATE_PIT_IMAX, "RATE_PIT_IMAX");
-            this.RATE_PIT_IMAX.Max = 1F;
-            this.RATE_PIT_IMAX.Min = 0F;
-            this.RATE_PIT_IMAX.Name = "RATE_PIT_IMAX";
-            this.RATE_PIT_IMAX.ParamName = null;
-            this.RATE_PIT_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_PIT_I
-            // 
-            resources.ApplyResources(this.RATE_PIT_I, "RATE_PIT_I");
-            this.RATE_PIT_I.Max = 1F;
-            this.RATE_PIT_I.Min = 0F;
-            this.RATE_PIT_I.Name = "RATE_PIT_I";
-            this.RATE_PIT_I.ParamName = null;
-            this.RATE_PIT_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_PIT_P
-            // 
-            resources.ApplyResources(this.RATE_PIT_P, "RATE_PIT_P");
-            this.RATE_PIT_P.Max = 1F;
-            this.RATE_PIT_P.Min = 0F;
-            this.RATE_PIT_P.Name = "RATE_PIT_P";
-            this.RATE_PIT_P.ParamName = null;
-            this.RATE_PIT_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // ATC_RAT_PIT_FLTT
-            // 
-            resources.ApplyResources(this.ATC_RAT_PIT_FLTT, "ATC_RAT_PIT_FLTT");
-            this.ATC_RAT_PIT_FLTT.Max = 1F;
-            this.ATC_RAT_PIT_FLTT.Min = 0F;
-            this.ATC_RAT_PIT_FLTT.Name = "ATC_RAT_PIT_FLTT";
-            this.ATC_RAT_PIT_FLTT.ParamName = null;
-            this.ATC_RAT_PIT_FLTT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // ATC_RAT_PIT_FLTD
-            // 
-            resources.ApplyResources(this.ATC_RAT_PIT_FLTD, "ATC_RAT_PIT_FLTD");
-            this.ATC_RAT_PIT_FLTD.Max = 1F;
-            this.ATC_RAT_PIT_FLTD.Min = 0F;
-            this.ATC_RAT_PIT_FLTD.Name = "ATC_RAT_PIT_FLTD";
-            this.ATC_RAT_PIT_FLTD.ParamName = null;
-            this.ATC_RAT_PIT_FLTD.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_RLL_FILT
-            // 
-            resources.ApplyResources(this.RATE_RLL_FILT, "RATE_RLL_FILT");
-            this.RATE_RLL_FILT.Max = 1F;
-            this.RATE_RLL_FILT.Min = 0F;
-            this.RATE_RLL_FILT.Name = "RATE_RLL_FILT";
-            this.RATE_RLL_FILT.ParamName = null;
-            this.RATE_RLL_FILT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_RLL_D
-            // 
-            resources.ApplyResources(this.RATE_RLL_D, "RATE_RLL_D");
-            this.RATE_RLL_D.Max = 1F;
-            this.RATE_RLL_D.Min = 0F;
-            this.RATE_RLL_D.Name = "RATE_RLL_D";
-            this.RATE_RLL_D.ParamName = null;
-            this.RATE_RLL_D.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_RLL_IMAX
-            // 
-            resources.ApplyResources(this.RATE_RLL_IMAX, "RATE_RLL_IMAX");
-            this.RATE_RLL_IMAX.Max = 1F;
-            this.RATE_RLL_IMAX.Min = 0F;
-            this.RATE_RLL_IMAX.Name = "RATE_RLL_IMAX";
-            this.RATE_RLL_IMAX.ParamName = null;
-            this.RATE_RLL_IMAX.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_RLL_I
-            // 
-            resources.ApplyResources(this.RATE_RLL_I, "RATE_RLL_I");
-            this.RATE_RLL_I.Max = 1F;
-            this.RATE_RLL_I.Min = 0F;
-            this.RATE_RLL_I.Name = "RATE_RLL_I";
-            this.RATE_RLL_I.ParamName = null;
-            this.RATE_RLL_I.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // RATE_RLL_P
-            // 
-            resources.ApplyResources(this.RATE_RLL_P, "RATE_RLL_P");
-            this.RATE_RLL_P.Max = 1F;
-            this.RATE_RLL_P.Min = 0F;
-            this.RATE_RLL_P.Name = "RATE_RLL_P";
-            this.RATE_RLL_P.ParamName = null;
-            this.RATE_RLL_P.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_LOG_BAT_OPT
-            // 
-            resources.ApplyResources(this.INS_LOG_BAT_OPT, "INS_LOG_BAT_OPT");
-            this.INS_LOG_BAT_OPT.Max = 1F;
-            this.INS_LOG_BAT_OPT.Min = 0F;
-            this.INS_LOG_BAT_OPT.Name = "INS_LOG_BAT_OPT";
-            this.INS_LOG_BAT_OPT.ParamName = null;
-            this.INS_LOG_BAT_OPT.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
-            // 
-            // INS_HNTCH_ENABLE
-            // 
-            this.INS_HNTCH_ENABLE.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.INS_HNTCH_ENABLE.DropDownWidth = 170;
-            resources.ApplyResources(this.INS_HNTCH_ENABLE, "INS_HNTCH_ENABLE");
-            this.INS_HNTCH_ENABLE.FormattingEnabled = true;
-            this.INS_HNTCH_ENABLE.Name = "INS_HNTCH_ENABLE";
-            this.INS_HNTCH_ENABLE.ParamName = null;
-            this.INS_HNTCH_ENABLE.SubControl = null;
-            this.INS_HNTCH_ENABLE.ValueUpdated += new System.EventHandler(this.numeric_ValueUpdated);
+            // lblUnitWarning
+            // 
+            resources.ApplyResources(this.lblUnitWarning, "lblUnitWarning");
+            this.lblUnitWarning.ForeColor = System.Drawing.Color.Red;
+            this.lblUnitWarning.Name = "lblUnitWarning";
             // 
             // ConfigArducopter
             // 
             resources.ApplyResources(this, "$this");
+            this.Controls.Add(this.lblUnitWarning);
             this.Controls.Add(this.groupBox8);
             this.Controls.Add(this.groupBox9);
             this.Controls.Add(this.label52);
@@ -1524,65 +1594,29 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             this.Controls.Add(this.groupBox25);
             this.Name = "ConfigArducopter";
             this.groupBox5.ResumeLayout(false);
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox7.ResumeLayout(false);
-            this.groupBox19.ResumeLayout(false);
-            this.groupBox20.ResumeLayout(false);
-            this.groupBox21.ResumeLayout(false);
-            this.groupBox22.ResumeLayout(false);
-            this.groupBox23.ResumeLayout(false);
-            this.groupBox23.PerformLayout();
-            this.groupBox24.ResumeLayout(false);
-            this.groupBox24.PerformLayout();
-            this.groupBox25.ResumeLayout(false);
-            this.groupBox25.PerformLayout();
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox3.ResumeLayout(false);
-            this.groupBox3.PerformLayout();
-            this.groupBox9.ResumeLayout(false);
-            this.groupBox9.PerformLayout();
-            this.groupBox8.ResumeLayout(false);
-            this.groupBox8.PerformLayout();
-            this.groupBox6.ResumeLayout(false);
-            this.groupBox6.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ATT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.THR_RATE_P)).EndInit();
+            this.groupBox4.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_UP)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_LOIT_SPEED)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED_DN)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_RADIUS)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.WPNAV_SPEED)).EndInit();
+            this.groupBox7.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.THR_ALT_P)).EndInit();
+            this.groupBox19.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_input_tc)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.HLD_LAT_P)).EndInit();
+            this.groupBox20.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_y_max)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_YAW_P)).EndInit();
+            this.groupBox21.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_p_max)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_PIT_P)).EndInit();
+            this.groupBox22.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.mavlinkNumericUpDownatc_accel_r_max)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.STB_RLL_P)).EndInit();
+            this.groupBox23.ResumeLayout(false);
+            this.groupBox23.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTT)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_YAW_FLTD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_FILT)).EndInit();
@@ -1590,21 +1624,57 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_IMAX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_I)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_YAW_P)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).EndInit();
+            this.groupBox24.ResumeLayout(false);
+            this.groupBox24.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_FILT)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_D)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_IMAX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_I)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_PIT_P)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTT)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_PIT_FLTD)).EndInit();
+            this.groupBox25.ResumeLayout(false);
+            this.groupBox25.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ATC_RAT_RLL_FLTD)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_FILT)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_D)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_IMAX)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_I)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RATE_RLL_P)).EndInit();
+            this.groupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.LOITER_LAT_P)).EndInit();
+            this.groupBox2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_D)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_IMAX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_I)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.THR_ACCEL_P)).EndInit();
+            this.groupBox3.ResumeLayout(false);
+            this.groupBox3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_ACCEL_FILTER)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_GYRO_FILTER)).EndInit();
+            this.groupBox9.ResumeLayout(false);
+            this.groupBox9.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_HMNCS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_OPTS)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_BW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_ATT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_FREQ)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_REF)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_HNTCH_MODE)).EndInit();
+            this.groupBox8.ResumeLayout(false);
+            this.groupBox8.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_ATT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_BW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.INS_NOTCH_FREQ)).EndInit();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.INS_LOG_BAT_OPT)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_LOW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TUNE_HIGH)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1770,5 +1840,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private Controls.MavlinkComboBox INS_NOTCH_ENABLE;
         private Controls.MavlinkComboBox INS_HNTCH_ENABLE;
         private Controls.MavlinkNumericUpDown INS_LOG_BAT_OPT;
+        private Label lblUnitWarning;
     }
 }

--- a/GCSViews/ConfigurationView/ConfigArducopter.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.cs
@@ -487,7 +487,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (VersionDetection.GetVersion(MainV2.comPort.MAV.VersionString) >= new Version(4, 7)
                 && sender is MavlinkNumericUpDown mnud)
             {
-                var warning = paramchanges47.changedByNewParamWarning(mnud.ParamName);
+                var warning = ParamChanges47.changedByNewParamWarning(mnud.ParamName);
                 if (warning != null)
                 {
                     lblUnitWarning.Text = "Change in 4.7: " + warning;

--- a/GCSViews/ConfigurationView/ConfigArducopter.cs
+++ b/GCSViews/ConfigurationView/ConfigArducopter.cs
@@ -64,14 +64,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             HLD_LAT_P.setup(0, 0, 1, 0.001f, new[] {"HLD_LAT_P", "POS_XY_P", "PSC_POSXY_P", "Q_P_POSXY_P"},
                 MainV2.comPort.MAV.param);
-            LOITER_LAT_D.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_D", "PSC_VELXY_D", "Q_P_VELXY_D"},
+            LOITER_LAT_D.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_D", "PSC_VELXY_D", "Q_P_VELXY_D", "PSC_NE_VEL_D", "Q_P_NE_VEL_D"},
                 MainV2.comPort.MAV.param);
-            LOITER_LAT_I.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_I", "VEL_XY_I", "PSC_VELXY_I", "Q_P_VELXY_I"},
+            LOITER_LAT_I.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_I", "VEL_XY_I", "PSC_VELXY_I", "Q_P_VELXY_I", "PSC_NE_VEL_I", "Q_P_NE_VEL_I"},
                 MainV2.comPort.MAV.param);
             LOITER_LAT_IMAX.setup(0, 0, 10, 1f,
-                new[] {"LOITER_LAT_IMAX", "VEL_XY_IMAX", "PSC_VELXY_IMAX", "Q_P_VELXY_IMAX"},
+                new[] {"LOITER_LAT_IMAX", "VEL_XY_IMAX", "PSC_VELXY_IMAX", "Q_P_VELXY_IMAX", "PSC_NE_VEL_IMAX", "Q_P_NE_VEL_IMAX"},
                 MainV2.comPort.MAV.param);
-            LOITER_LAT_P.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_P", "VEL_XY_P", "PSC_VELXY_P", "Q_P_VELXY_P"},
+            LOITER_LAT_P.setup(0, 0, 1, 0.001f, new[] {"LOITER_LAT_P", "VEL_XY_P", "PSC_VELXY_P", "Q_P_VELXY_P", "PSC_NE_VEL_P", "Q_P_NE_VEL_P"},
                 MainV2.comPort.MAV.param);
 
             RATE_PIT_P.setup(0, 0, 1, 0.001f, new[] { "RATE_PIT_P", "ATC_RAT_PIT_P", "Q_A_RAT_PIT_P" }, MainV2.comPort.MAV.param);
@@ -115,26 +115,26 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 MainV2.comPort.MAV.param);
 
 
-            THR_ACCEL_P.setup(0, 0, 1, 0.001f, new[] { "THR_ACCEL_P", "ACCEL_Z_P", "PSC_ACCZ_P", "Q_P_ACCZ_P" },
+            THR_ACCEL_P.setup(0, 0, 1, 0.001f, new[] { "THR_ACCEL_P", "ACCEL_Z_P", "PSC_ACCZ_P", "Q_P_ACCZ_P", "PSC_D_ACC_P", "Q_P_D_ACC_P" },
                 MainV2.comPort.MAV.param);
-            THR_ACCEL_I.setup(0, 0, 1, 0.001f, new[] { "THR_ACCEL_I", "ACCEL_Z_I", "PSC_ACCZ_I", "Q_P_ACCZ_I" },
+            THR_ACCEL_I.setup(0, 0, 1, 0.001f, new[] { "THR_ACCEL_I", "ACCEL_Z_I", "PSC_ACCZ_I", "Q_P_ACCZ_I", "PSC_D_ACC_I", "Q_P_D_ACC_I" },
                 MainV2.comPort.MAV.param);
-            THR_ACCEL_D.setup(0, 0, 1, 0.001f, new[] {"THR_ACCEL_D", "ACCEL_Z_D", "PSC_ACCZ_D", "Q_P_ACCZ_D"},
+            THR_ACCEL_D.setup(0, 0, 1, 0.001f, new[] {"THR_ACCEL_D", "ACCEL_Z_D", "PSC_ACCZ_D", "Q_P_ACCZ_D", "PSC_D_ACC_D", "Q_P_D_ACC_D"},
                 MainV2.comPort.MAV.param);
-            THR_ACCEL_IMAX.setup(0, 0, 10, 1f, new[] {"THR_ACCEL_IMAX", "ACCEL_Z_IMAX", "PSC_ACCZ_IMAX", "Q_P_ACCZ_IMAX"},
+            THR_ACCEL_IMAX.setup(0, 0, 10, 1f, new[] {"THR_ACCEL_IMAX", "ACCEL_Z_IMAX", "PSC_ACCZ_IMAX", "Q_P_ACCZ_IMAX", "PSC_D_ACC_IMAX", "Q_P_D_ACC_IMAX"},
                 MainV2.comPort.MAV.param);
 
             THR_ALT_P.setup(0, 0, 1, 0.001f, new[] {"THR_ALT_P", "POS_Z_P", "PSC_POSZ_P", "Q_P_POSZ_P"},
                 MainV2.comPort.MAV.param);
-            THR_RATE_P.setup(0, 0, 1, 0.001f, new[] {"THR_RATE_P", "VEL_Z_P", "PSC_VELZ_P", "Q_P_VELZ_P"},
+            THR_RATE_P.setup(0, 0, 1, 0.001f, new[] {"THR_RATE_P", "VEL_Z_P", "PSC_VELZ_P", "Q_P_VELZ_P", "PSC_D_VEL_P", "Q_P_D_VEL_P"},
                 MainV2.comPort.MAV.param);
 
-            WPNAV_LOIT_SPEED.setup(0, 0, 1, 0.001f, new[] {"WPNAV_LOIT_SPEED", "LOIT_SPEED", "Q_LOIT_SPEED"},
+            WPNAV_LOIT_SPEED.setup(0, 0, 1, 0.001f, new[] {"WPNAV_LOIT_SPEED", "LOIT_SPEED", "Q_LOIT_SPEED", "LOIT_SPEED_MS", "Q_LOIT_SPEED_MS"},
                 MainV2.comPort.MAV.param);
-            WPNAV_RADIUS.setup(0, 0, 1, 0.001f, new[] {"WPNAV_RADIUS", "Q_WP_RADIUS"}, MainV2.comPort.MAV.param);
-            WPNAV_SPEED.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED", "Q_WP_SPEED"}, MainV2.comPort.MAV.param);
-            WPNAV_SPEED_DN.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_DN", "Q_WP_SPEED_DN"}, MainV2.comPort.MAV.param);
-            WPNAV_SPEED_UP.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_UP", "Q_WP_SPEED_UP"}, MainV2.comPort.MAV.param);
+            WPNAV_RADIUS.setup(0, 0, 1, 0.001f, new[] {"WPNAV_RADIUS", "Q_WP_RADIUS", "WP_RADIUS_M", "Q_WP_RADIUS_M"}, MainV2.comPort.MAV.param);
+            WPNAV_SPEED.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED", "Q_WP_SPEED", "WP_SPD", "Q_WP_SPD"}, MainV2.comPort.MAV.param);
+            WPNAV_SPEED_DN.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_DN", "Q_WP_SPEED_DN", "WP_SPD_DN", "Q_WP_SPD_DN"}, MainV2.comPort.MAV.param);
+            WPNAV_SPEED_UP.setup(0, 0, 1, 0.001f, new[] {"WPNAV_SPEED_UP", "Q_WP_SPEED_UP", "WP_SPD_UP", "Q_WP_SPD_UP"}, MainV2.comPort.MAV.param);
 
             INS_GYRO_FILTER.setup(0, 0, 1, 1f, new[] { "INS_GYRO_FILTER" }, MainV2.comPort.MAV.param);
             INS_ACCEL_FILTER.setup(0, 0, 1, 1f, new[] { "INS_ACCEL_FILTER" }, MainV2.comPort.MAV.param);
@@ -156,11 +156,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             INS_HNTCH_OPTS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_OPTS" }, MainV2.comPort.MAV.param);
             INS_HNTCH_HMNCS.setup(0, 0, 1, 1f, new[] { "INS_HNTCH_HMNCS" }, MainV2.comPort.MAV.param);
 
-            mavlinkNumericUpDownatc_accel_r_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_R_MAX", "Q_A_ACCEL_R_MAX"},
+            mavlinkNumericUpDownatc_accel_r_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_R_MAX", "Q_A_ACCEL_R_MAX", "ATC_ACC_R_MAX", "Q_A_ACC_R_MAX"},
                 MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownatc_accel_p_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_P_MAX", "Q_A_ACCEL_P_MAX"},
+            mavlinkNumericUpDownatc_accel_p_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_P_MAX", "Q_A_ACCEL_P_MAX", "ATC_ACC_P_MAX", "Q_A_ACC_P_MAX"},
                 MainV2.comPort.MAV.param);
-            mavlinkNumericUpDownatc_accel_y_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_Y_MAX", "Q_A_ACCEL_Y_MAX"},
+            mavlinkNumericUpDownatc_accel_y_max.setup(0, 0, 1, 0.001f, new[] {"ATC_ACCEL_Y_MAX", "Q_A_ACCEL_Y_MAX", "ATC_ACC_Y_MAX", "Q_A_ACC_Y_MAX"},
                 MainV2.comPort.MAV.param);
             mavlinkNumericUpDownatc_input_tc.setup(0, 0, 1, 0.001f, new[] {"ATC_INPUT_TC", "Q_A_INPUT_TC"},
                 MainV2.comPort.MAV.param);
@@ -223,19 +223,19 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             var currentLinePosition = 0;
             for (var textIndex = 0; textIndex < text.Length; textIndex++)
             {
-                // If we have reached the target line length and the next      
-                // character is whitespace then begin a new line.   
+                // If we have reached the target line length and the next
+                // character is whitespace then begin a new line.
                 if (currentLinePosition >= lineLength &&
                     char.IsWhiteSpace(text[textIndex]))
                 {
                     sb.Append(Environment.NewLine);
                     currentLinePosition = 0;
                 }
-                // If we have just started a new line, skip all the whitespace.    
+                // If we have just started a new line, skip all the whitespace.
                 if (currentLinePosition == 0)
                     while (textIndex < text.Length && char.IsWhiteSpace(text[textIndex]))
                         textIndex++;
-                // Append the next character.     
+                // Append the next character.
                 if (textIndex < text.Length) sb.Append(text[textIndex]);
                 currentLinePosition++;
             }
@@ -479,6 +479,25 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private void numeric_ValueUpdated(object sender, EventArgs e)
         {
             EEPROM_View_float_TextChanged(sender, e);
+        }
+
+        private void OnEnter_NumUpDown(object sender, EventArgs e)
+        {
+            // show unit change warning for Copter 4.7 renamed parameters
+            if (VersionDetection.GetVersion(MainV2.comPort.MAV.VersionString) >= new Version(4, 7)
+                && sender is MavlinkNumericUpDown mnud)
+            {
+                var warning = paramchanges47.changedByNewParamWarning(mnud.ParamName);
+                if (warning != null)
+                {
+                    lblUnitWarning.Text = "Change in 4.7: " + warning;
+                    lblUnitWarning.Visible = true;
+                    lblUnitWarning.ForeColor = Color.Red;
+                    return;
+                }
+            }
+
+            lblUnitWarning.Visible = false;
         }
     }
 }

--- a/GCSViews/ConfigurationView/ConfigArducopter.resx
+++ b/GCSViews/ConfigurationView/ConfigArducopter.resx
@@ -135,7 +135,7 @@
     <value>THR_RATE_P</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_RATE_P.Parent" xml:space="preserve">
     <value>groupBox5</value>
@@ -193,7 +193,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox5.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>25</value>
   </data>
   <data name="CHK_lockrollpitch.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -223,7 +223,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CHK_lockrollpitch.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>26</value>
   </data>
   <data name="WPNAV_SPEED_UP.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -241,7 +241,7 @@
     <value>WPNAV_SPEED_UP</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_UP.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -292,7 +292,7 @@
     <value>WPNAV_LOIT_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_LOIT_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -343,7 +343,7 @@
     <value>WPNAV_SPEED_DN</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED_DN.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -394,7 +394,7 @@
     <value>WPNAV_RADIUS</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_RADIUS.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -445,7 +445,7 @@
     <value>WPNAV_SPEED</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;WPNAV_SPEED.Parent" xml:space="preserve">
     <value>groupBox4</value>
@@ -502,7 +502,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox4.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>27</value>
   </data>
   <data name="THR_ALT_P.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -520,7 +520,7 @@
     <value>THR_ALT_P</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ALT_P.Parent" xml:space="preserve">
     <value>groupBox7</value>
@@ -577,7 +577,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox7.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>28</value>
   </data>
   <data name="mavlinkNumericUpDownatc_input_tc.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -595,7 +595,7 @@
     <value>mavlinkNumericUpDownatc_input_tc</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_input_tc.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -646,7 +646,7 @@
     <value>HLD_LAT_P</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;HLD_LAT_P.Parent" xml:space="preserve">
     <value>groupBox19</value>
@@ -703,7 +703,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox19.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>29</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_y_max.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -721,7 +721,7 @@
     <value>mavlinkNumericUpDownatc_accel_y_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_y_max.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -772,7 +772,7 @@
     <value>STB_YAW_P</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_YAW_P.Parent" xml:space="preserve">
     <value>groupBox20</value>
@@ -829,7 +829,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox20.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>30</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_p_max.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -847,7 +847,7 @@
     <value>mavlinkNumericUpDownatc_accel_p_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_p_max.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -898,7 +898,7 @@
     <value>STB_PIT_P</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_PIT_P.Parent" xml:space="preserve">
     <value>groupBox21</value>
@@ -955,7 +955,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox21.ZOrder" xml:space="preserve">
-    <value>30</value>
+    <value>31</value>
   </data>
   <data name="mavlinkNumericUpDownatc_accel_r_max.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -973,7 +973,7 @@
     <value>mavlinkNumericUpDownatc_accel_r_max</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;mavlinkNumericUpDownatc_accel_r_max.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1024,7 +1024,7 @@
     <value>STB_RLL_P</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;STB_RLL_P.Parent" xml:space="preserve">
     <value>groupBox22</value>
@@ -1081,7 +1081,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox22.ZOrder" xml:space="preserve">
-    <value>31</value>
+    <value>32</value>
   </data>
   <data name="ATC_RAT_YAW_FLTT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -1099,7 +1099,7 @@
     <value>ATC_RAT_YAW_FLTT</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTT.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1153,7 +1153,7 @@
     <value>ATC_RAT_YAW_FLTD</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ATC_RAT_YAW_FLTD.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1207,7 +1207,7 @@
     <value>RATE_YAW_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_FILT.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1258,7 +1258,7 @@
     <value>RATE_YAW_D</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_D.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1309,7 +1309,7 @@
     <value>RATE_YAW_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_IMAX.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1360,7 +1360,7 @@
     <value>RATE_YAW_I</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_I.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1411,7 +1411,7 @@
     <value>RATE_YAW_P</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_YAW_P.Parent" xml:space="preserve">
     <value>groupBox23</value>
@@ -1468,30 +1468,30 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox23.ZOrder" xml:space="preserve">
-    <value>32</value>
+    <value>33</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTT.Enabled" type="System.Boolean, mscorlib">
+  <data name="ATC_RAT_PIT_FLTT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTT.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ATC_RAT_PIT_FLTT.Location" type="System.Drawing.Point, System.Drawing">
     <value>80, 152</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTT.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ATC_RAT_PIT_FLTT.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 20</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTT.TabIndex" type="System.Int32, mscorlib">
-    <value>41</value>
+  <data name="ATC_RAT_PIT_FLTT.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Name" xml:space="preserve">
-    <value>ATC_RAT_RLL_FLTT</value>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Name" xml:space="preserve">
+    <value>ATC_RAT_PIT_FLTT</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="label30.AutoSize" type="System.Boolean, mscorlib">
@@ -1524,28 +1524,28 @@
   <data name="&gt;&gt;label30.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTD.Enabled" type="System.Boolean, mscorlib">
+  <data name="ATC_RAT_PIT_FLTD.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTD.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ATC_RAT_PIT_FLTD.Location" type="System.Drawing.Point, System.Drawing">
     <value>80, 129</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTD.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ATC_RAT_PIT_FLTD.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 20</value>
   </data>
-  <data name="ATC_RAT_RLL_FLTD.TabIndex" type="System.Int32, mscorlib">
-    <value>39</value>
+  <data name="ATC_RAT_PIT_FLTD.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Name" xml:space="preserve">
-    <value>ATC_RAT_RLL_FLTD</value>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Name" xml:space="preserve">
+    <value>ATC_RAT_PIT_FLTD</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Parent" xml:space="preserve">
     <value>groupBox24</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="label29.AutoSize" type="System.Boolean, mscorlib">
@@ -1594,7 +1594,7 @@
     <value>RATE_PIT_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_FILT.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1645,7 +1645,7 @@
     <value>RATE_PIT_D</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_D.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1696,7 +1696,7 @@
     <value>RATE_PIT_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_IMAX.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1747,7 +1747,7 @@
     <value>RATE_PIT_I</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_I.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1798,7 +1798,7 @@
     <value>RATE_PIT_P</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_PIT_P.Parent" xml:space="preserve">
     <value>groupBox24</value>
@@ -1855,30 +1855,30 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox24.ZOrder" xml:space="preserve">
-    <value>33</value>
+    <value>34</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTT.Enabled" type="System.Boolean, mscorlib">
+  <data name="ATC_RAT_RLL_FLTT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTT.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ATC_RAT_RLL_FLTT.Location" type="System.Drawing.Point, System.Drawing">
     <value>80, 152</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTT.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ATC_RAT_RLL_FLTT.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 20</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTT.TabIndex" type="System.Int32, mscorlib">
-    <value>37</value>
+  <data name="ATC_RAT_RLL_FLTT.TabIndex" type="System.Int32, mscorlib">
+    <value>41</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Name" xml:space="preserve">
-    <value>ATC_RAT_PIT_FLTT</value>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Name" xml:space="preserve">
+    <value>ATC_RAT_RLL_FLTT</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTT.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTT.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="label28.AutoSize" type="System.Boolean, mscorlib">
@@ -1911,28 +1911,28 @@
   <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTD.Enabled" type="System.Boolean, mscorlib">
+  <data name="ATC_RAT_RLL_FLTD.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTD.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ATC_RAT_RLL_FLTD.Location" type="System.Drawing.Point, System.Drawing">
     <value>80, 129</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTD.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ATC_RAT_RLL_FLTD.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 20</value>
   </data>
-  <data name="ATC_RAT_PIT_FLTD.TabIndex" type="System.Int32, mscorlib">
-    <value>35</value>
+  <data name="ATC_RAT_RLL_FLTD.TabIndex" type="System.Int32, mscorlib">
+    <value>39</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Name" xml:space="preserve">
-    <value>ATC_RAT_PIT_FLTD</value>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Name" xml:space="preserve">
+    <value>ATC_RAT_RLL_FLTD</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Type" xml:space="preserve">
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.Parent" xml:space="preserve">
     <value>groupBox25</value>
   </data>
-  <data name="&gt;&gt;ATC_RAT_PIT_FLTD.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ATC_RAT_RLL_FLTD.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="P_FLTD.AutoSize" type="System.Boolean, mscorlib">
@@ -1981,7 +1981,7 @@
     <value>RATE_RLL_FILT</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_FILT.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2032,7 +2032,7 @@
     <value>RATE_RLL_D</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_D.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2083,7 +2083,7 @@
     <value>RATE_RLL_IMAX</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_IMAX.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2134,7 +2134,7 @@
     <value>RATE_RLL_I</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_I.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2185,7 +2185,7 @@
     <value>RATE_RLL_P</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;RATE_RLL_P.Parent" xml:space="preserve">
     <value>groupBox25</value>
@@ -2242,7 +2242,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox25.ZOrder" xml:space="preserve">
-    <value>34</value>
+    <value>35</value>
   </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -2263,7 +2263,7 @@
     <value>LOITER_LAT_D</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_D.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2314,7 +2314,7 @@
     <value>LOITER_LAT_IMAX</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_IMAX.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2365,7 +2365,7 @@
     <value>LOITER_LAT_I</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_I.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2416,7 +2416,7 @@
     <value>LOITER_LAT_P</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;LOITER_LAT_P.Parent" xml:space="preserve">
     <value>groupBox1</value>
@@ -2473,7 +2473,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="BUT_rerequestparams.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2506,7 +2506,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_rerequestparams.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="BUT_writePIDS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2533,7 +2533,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_writePIDS.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="myLabel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2563,7 +2563,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel3.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="myLabel2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2593,7 +2593,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel2.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="myLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2623,7 +2623,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel1.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>23</value>
   </data>
   <data name="THR_ACCEL_D.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2641,7 +2641,7 @@
     <value>THR_ACCEL_D</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_D.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2719,7 +2719,7 @@
     <value>THR_ACCEL_IMAX</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_IMAX.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2743,7 +2743,7 @@
     <value>THR_ACCEL_I</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_I.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2794,7 +2794,7 @@
     <value>THR_ACCEL_P</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;THR_ACCEL_P.Parent" xml:space="preserve">
     <value>groupBox2</value>
@@ -2851,7 +2851,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="BUT_refreshpart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2881,7 +2881,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BUT_refreshpart.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="myLabel4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2911,7 +2911,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel4.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="myLabel5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2941,7 +2941,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel5.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="myLabel6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2971,7 +2971,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;myLabel6.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="INS_ACCEL_FILTER.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -2989,7 +2989,7 @@
     <value>INS_ACCEL_FILTER</value>
   </data>
   <data name="&gt;&gt;INS_ACCEL_FILTER.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_ACCEL_FILTER.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -3043,7 +3043,7 @@
     <value>INS_GYRO_FILTER</value>
   </data>
   <data name="&gt;&gt;INS_GYRO_FILTER.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_GYRO_FILTER.Parent" xml:space="preserve">
     <value>groupBox3</value>
@@ -3103,7 +3103,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox3.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="INS_HNTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3121,7 +3121,7 @@
     <value>INS_HNTCH_ENABLE</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ENABLE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ENABLE.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3145,7 +3145,7 @@
     <value>INS_HNTCH_HMNCS</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_HMNCS.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3199,7 +3199,7 @@
     <value>INS_HNTCH_OPTS</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_OPTS.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3253,7 +3253,7 @@
     <value>INS_HNTCH_BW</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_BW.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3307,7 +3307,7 @@
     <value>INS_HNTCH_ATT</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_ATT.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3361,7 +3361,7 @@
     <value>INS_HNTCH_FREQ</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_FREQ.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3415,7 +3415,7 @@
     <value>INS_HNTCH_REF</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_REF.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3469,7 +3469,7 @@
     <value>INS_HNTCH_MODE</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_HNTCH_MODE.Parent" xml:space="preserve">
     <value>groupBox9</value>
@@ -3559,7 +3559,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox9.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="INS_NOTCH_ENABLE.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3577,7 +3577,7 @@
     <value>INS_NOTCH_ENABLE</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ENABLE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ENABLE.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3601,7 +3601,7 @@
     <value>INS_NOTCH_ATT</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_ATT.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3655,7 +3655,7 @@
     <value>INS_NOTCH_BW</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_BW.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3709,7 +3709,7 @@
     <value>INS_NOTCH_FREQ</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_NOTCH_FREQ.Parent" xml:space="preserve">
     <value>groupBox8</value>
@@ -3799,7 +3799,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox8.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="INS_LOG_BAT_OPT.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3817,7 +3817,7 @@
     <value>INS_LOG_BAT_OPT</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_OPT.Parent" xml:space="preserve">
     <value>groupBox6</value>
@@ -3841,7 +3841,7 @@
     <value>INS_LOG_BAT_MASK</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_MASK.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;INS_LOG_BAT_MASK.Parent" xml:space="preserve">
     <value>groupBox6</value>
@@ -3931,7 +3931,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox6.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label52.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3961,7 +3961,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label52.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="CH6_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3979,13 +3979,13 @@
     <value>CH6_OPTION</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH6_OPTION.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="CH10_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4003,13 +4003,13 @@
     <value>CH10_OPTION</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH10_OPTION.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="CH9_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4027,13 +4027,13 @@
     <value>CH9_OPTION</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH9_OPTION.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="CH8_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4051,13 +4051,13 @@
     <value>CH8_OPTION</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH8_OPTION.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="TUNE_LOW.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4075,13 +4075,13 @@
     <value>TUNE_LOW</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;TUNE_LOW.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="TUNE_HIGH.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4099,13 +4099,13 @@
     <value>TUNE_HIGH</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkNumericUpDown, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;TUNE_HIGH.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>20</value>
   </data>
   <data name="TUNE.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4123,13 +4123,13 @@
     <value>TUNE</value>
   </data>
   <data name="&gt;&gt;TUNE.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;TUNE.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;TUNE.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>22</value>
   </data>
   <data name="CH7_OPTION.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -4147,13 +4147,49 @@
     <value>CH7_OPTION</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.Type" xml:space="preserve">
-    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.7831.18046, Culture=neutral, PublicKeyToken=null</value>
+    <value>MissionPlanner.Controls.MavlinkComboBox, MissionPlanner, Version=1.3.9573.41130, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;CH7_OPTION.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>24</value>
+  </data>
+  <data name="lblUnitWarning.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblUnitWarning.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="lblUnitWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblUnitWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 646</value>
+  </data>
+  <data name="lblUnitWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>151, 13</value>
+  </data>
+  <data name="lblUnitWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="lblUnitWarning.Text" xml:space="preserve">
+    <value>Breaking change warning</value>
+  </data>
+  <data name="lblUnitWarning.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblUnitWarning.Name" xml:space="preserve">
+    <value>lblUnitWarning</value>
+  </data>
+  <data name="&gt;&gt;lblUnitWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUnitWarning.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblUnitWarning.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -4165,7 +4201,7 @@
     <value>True</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>729, 651</value>
+    <value>729, 673</value>
   </data>
   <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
     <value>toolTip1</value>

--- a/GCSViews/ConfigurationView/ConfigInitialParams.cs
+++ b/GCSViews/ConfigurationView/ConfigInitialParams.cs
@@ -162,9 +162,18 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             //Fill up the list of params to change
             new_params.Add("ACRO_YAW_P", acro_yaw_p);
-            new_params.Add(atc_prefix + "_ACCEL_P_MAX", atc_accel_p_max);
-            new_params.Add(atc_prefix + "_ACCEL_R_MAX", atc_accel_r_max);
-            new_params.Add(atc_prefix + "_ACCEL_Y_MAX", atc_accel_y_max);
+            if (MainV2.comPort.MAV.param.ContainsKey(atc_prefix + "_ACCEL_P_MAX"))
+            {
+                new_params.Add(atc_prefix + "_ACCEL_P_MAX", atc_accel_p_max);
+                new_params.Add(atc_prefix + "_ACCEL_R_MAX", atc_accel_r_max);
+                new_params.Add(atc_prefix + "_ACCEL_Y_MAX", atc_accel_y_max);
+            }
+            else
+            {
+                new_params.Add(atc_prefix + "_ACC_P_MAX", atc_accel_p_max / 100.0);
+                new_params.Add(atc_prefix + "_ACC_R_MAX", atc_accel_r_max / 100.0);
+                new_params.Add(atc_prefix + "_ACC_Y_MAX", atc_accel_y_max / 100.0);
+            }
 
             //Filters has different name in 4.x and in 3.x
             if (MainV2.comPort.MAV.cs.version.Major == 4)
@@ -228,7 +237,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (paramCompareForm.DialogResult == DialogResult.OK)
             {
-                CustomMessageBox.Show("Initial Parameters succesfully updated.\r\nCheck parameters before flight!\r\n\r\nAfter test flight :\r\n\tSet ATC_THR_MIX_MAN to 0.5\r\n\tSet PSC_ACCZ_P to MOT_THST_HOVER\r\n\tSet PSC_ACCZ_I to 2*MOT_THST_HOVER\r\n\r\nHappy flying!", "Initial parameter calculator");
+                CustomMessageBox.Show("Initial Parameters succesfully updated.\r\nCheck parameters before flight!\r\n\r\nAfter test flight :\r\n\tSet ATC_THR_MIX_MAN to 0.5\r\n\tSet PSC_ACCZ_P/PSC_D_ACC_P to MOT_THST_HOVER\r\n\tSet PSC_ACCZ_I/PSC_D_ACC_I to 2*MOT_THST_HOVER\r\n\r\nHappy flying!", "Initial parameter calculator");
             }
 
             }

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -6287,8 +6287,13 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
 
                 ((ProgressReporterDialogue) sender).UpdateProgressAndStatus(95, "Setting params");
 
+                // use brute force, for all three possible params
+
                 // m
                 port.setParam("WP_RADIUS", float.Parse(TXT_WPRad.Text) / CurrentState.multiplierdist);
+
+                // m
+                port.setParam("WP_RADIUS_M", float.Parse(TXT_WPRad.Text) / CurrentState.multiplierdist);
 
                 // cm's
                 port.setParam("WPNAV_RADIUS", float.Parse(TXT_WPRad.Text) / CurrentState.multiplierdist * 100.0);
@@ -6700,6 +6705,14 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                     TXT_WPRad.Text = string.Format("{0:N2}",
                         (((double) param["WPNAV_RADIUS"] * CurrentState.multiplierdist / 100.0)));
                 }
+
+                // In meters
+                if (param.ContainsKey("WP_RADIUS_M"))
+                {
+                    TXT_WPRad.Text = string.Format("{0:N2}",
+                        (((double)param["WPNAV_RADIUS"] * CurrentState.multiplierdist)));
+                }
+
 
                 log.Info("param WP_RADIUS " + TXT_WPRad.Text);
 

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -5569,13 +5569,20 @@ namespace MissionPlanner.GCSViews
 
                     try
                     {
-                        // cm/s - ac
-                        Spline2._wp_accel_cms = MainV2.comPort.MAV.param.ContainsKey("WPNAV_ACCEL") ? MainV2.comPort.MAV.param["WPNAV_ACCEL"].float_value : 100;
-                        Spline2._wp_speed_cms = MainV2.comPort.MAV.param.ContainsKey("WPNAV_SPEED") ? MainV2.comPort.MAV.param["WPNAV_SPEED"].float_value : 600;
+                        // cm/s - ac, m/s in 4.7+
+                        if (MainV2.comPort.MAV.param.ContainsKey("WPNAV_ACCEL"))
+                            Spline2._wp_accel_cms = MainV2.comPort.MAV.param["WPNAV_ACCEL"].float_value;
+                        else if (MainV2.comPort.MAV.param.ContainsKey("WP_ACC"))
+                            Spline2._wp_accel_cms = MainV2.comPort.MAV.param["WP_ACC"].float_value * 100;
+                        else
+                            Spline2._wp_accel_cms = 100;
 
-                        // ar
-                        //WP_ACCEL - m/s
-                        //WP_SPEED - m/s
+                        if (MainV2.comPort.MAV.param.ContainsKey("WPNAV_SPEED"))
+                            Spline2._wp_speed_cms = MainV2.comPort.MAV.param["WPNAV_SPEED"].float_value;
+                        else if (MainV2.comPort.MAV.param.ContainsKey("WP_SPD"))
+                            Spline2._wp_speed_cms = MainV2.comPort.MAV.param["WP_SPD"].float_value * 100;
+                        else
+                            Spline2._wp_speed_cms = 600;
                     }
                     catch
                     {
@@ -6706,11 +6713,11 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
                         (((double) param["WPNAV_RADIUS"] * CurrentState.multiplierdist / 100.0)));
                 }
 
-                // In meters
+                // In meters (4.7+)
                 if (param.ContainsKey("WP_RADIUS_M"))
                 {
                     TXT_WPRad.Text = string.Format("{0:N2}",
-                        (((double)param["WPNAV_RADIUS"] * CurrentState.multiplierdist)));
+                        (((double)param["WP_RADIUS_M"] * CurrentState.multiplierdist)));
                 }
 
 

--- a/Grid/GridUI.cs
+++ b/Grid/GridUI.cs
@@ -1814,12 +1814,17 @@ namespace MissionPlanner.Grid
 
                     if (CHK_usespeed.Checked)
                     {
+                        double speed = 0;
                         if (MainV2.comPort.MAV.param["WPNAV_SPEED"] != null)
                         {
-                            double speed = MainV2.comPort.MAV.param["WPNAV_SPEED"].Value;
-                            speed = speed / 100;
-                            plugin.Host.AddWPtoList(MAVLink.MAV_CMD.DO_CHANGE_SPEED, 0, speed, 0, 0, 0, 0, 0, gridobject);
+                            speed = MainV2.comPort.MAV.param["WPNAV_SPEED"].Value / 100;
                         }
+                        else if (MainV2.comPort.MAV.param["WP_SPD"] != null)
+                        {
+                            speed = MainV2.comPort.MAV.param["WP_SPD"].Value;
+                        }
+                        if (speed > 0)
+                            plugin.Host.AddWPtoList(MAVLink.MAV_CMD.DO_CHANGE_SPEED, 0, speed, 0, 0, 0, 0, 0, gridobject);
                     }
 
                     if (CHK_toandland.Checked)

--- a/Swarm/WaypointLeader/DroneGroup.cs
+++ b/Swarm/WaypointLeader/DroneGroup.cs
@@ -213,20 +213,22 @@ namespace MissionPlanner.Swarm.WaypointLeader
                         {
                             try
                             {
-                                // get param
-                                MAV.parent.GetParam(MAV.sysid, MAV.compid, "RTL_ALT");
-                                // set param
-                                MAV.parent.setParam(MAV.sysid, MAV.compid, "RTL_ALT", 0); // cms - rtl at current alt
+                                // rtl at current alt
+                                if (MAV.param.ContainsKey("RTL_ALT"))
+                                    MAV.parent.setParam(MAV.sysid, MAV.compid, "RTL_ALT", 0);
+                                else if (MAV.param.ContainsKey("RTL_ALT_M"))
+                                    MAV.parent.setParam(MAV.sysid, MAV.compid, "RTL_ALT_M", 0);
                             }
                             catch
                             {
                             }
                             try
                             {
-                                // get param
-                                MAV.parent.GetParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL");
-                                // set param to default 100cm/s
-                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", 100);
+                                // set accel to default
+                                if (MAV.param.ContainsKey("WPNAV_ACCEL"))
+                                    MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", 100); // 100 cm/s/s
+                                else if (MAV.param.ContainsKey("WP_ACC"))
+                                    MAV.parent.setParam(MAV.sysid, MAV.compid, "WP_ACC", 1); // 1 m/s/s
                             }
                             catch
                             {
@@ -390,7 +392,10 @@ namespace MissionPlanner.Swarm.WaypointLeader
                                 continue;
                             var MAV = drone.MavState;
                             // update to faster speed
-                            MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", (float)WPNAV_ACCEL * 100.0f);
+                            if (MAV.param.ContainsKey("WPNAV_ACCEL"))
+                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", (float)WPNAV_ACCEL * 100.0f);
+                            else if (MAV.param.ContainsKey("WP_ACC"))
+                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WP_ACC", (float)WPNAV_ACCEL);
 
                             MAV.parent.setMode(MAV.sysid, MAV.compid, "GUIDED");
                         }
@@ -482,9 +487,11 @@ namespace MissionPlanner.Swarm.WaypointLeader
                         try
                         {
                             var MAV = drone.MavState;
-                            // set param to default 100cm/s
-                            if (MAV.param["WPNAV_ACCEL"].Value != 100)
-                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", 100);
+                            // set accel to default
+                            if (MAV.param.ContainsKey("WPNAV_ACCEL") && MAV.param["WPNAV_ACCEL"].Value != 100)
+                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", 100); // 100 cm/s/s
+                            else if (MAV.param.ContainsKey("WP_ACC") && MAV.param["WP_ACC"].Value != 1)
+                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WP_ACC", 1); // 1 m/s/s
                         }
                         catch
                         {
@@ -521,9 +528,11 @@ namespace MissionPlanner.Swarm.WaypointLeader
                         try
                         {
                             var MAV = drone.MavState;
-                            // set param to default 100cm/s
-                            if (MAV.param["WPNAV_ACCEL"].Value != 100)
-                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", 100);
+                            // set accel to default
+                            if (MAV.param.ContainsKey("WPNAV_ACCEL") && MAV.param["WPNAV_ACCEL"].Value != 100)
+                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WPNAV_ACCEL", 100); // 100 cm/s/s
+                            else if (MAV.param.ContainsKey("WP_ACC") && MAV.param["WP_ACC"].Value != 1)
+                                MAV.parent.setParam(MAV.sysid, MAV.compid, "WP_ACC", 1); // 1 m/s/s
                         }
                         catch
                         {

--- a/plugins/FaceMap/FaceMapUI.cs
+++ b/plugins/FaceMap/FaceMapUI.cs
@@ -1575,12 +1575,17 @@ namespace MissionPlanner
 
                     if (CHK_usespeed.Checked)
                     {
+                        double speed = 0;
                         if (MainV2.comPort.MAV.param["WPNAV_SPEED"] != null)
                         {
-                            double speed = MainV2.comPort.MAV.param["WPNAV_SPEED"].Value;
-                            speed = speed / 100;
-                            plugin.Host.AddWPtoList(MAVLink.MAV_CMD.DO_CHANGE_SPEED, 0, speed, 0, 0, 0, 0, 0, gridobject);
+                            speed = MainV2.comPort.MAV.param["WPNAV_SPEED"].Value / 100;
                         }
+                        else if (MainV2.comPort.MAV.param["WP_SPD"] != null)
+                        {
+                            speed = MainV2.comPort.MAV.param["WP_SPD"].Value;
+                        }
+                        if (speed > 0)
+                            plugin.Host.AddWPtoList(MAVLink.MAV_CMD.DO_CHANGE_SPEED, 0, speed, 0, 0, 0, 0, 0, gridobject);
                     }
 
                     if (CHK_toandland.Checked)


### PR DESCRIPTION
**Support for ArduCopter 4.7 Parameter Changes:**

* Adds class paramchanges47 to utilities, mapping old parameter names to new ones, describes unit changes, and adds helper methods to look up mappings and warnings.
* Updated parameter setup calls in `ConfigArducopter.cs`
* Updated FlightPlanner to handle WP_RADIUS_M
* Adds a warning in the ConfigArducopter to warn users about parameter renames and unit changes when editing parameters affected by the 4.7 update. 

Note: Changes in ConfigArducopter.Designer are :
* Adding a label to display a warning
* add event handler to all NumUpDown controls' Enter event.