### PR TITLE
Add low airspeed detection logic and bind lowairspeed property to HUD

### DIFF
--- a/ExtLibs/ArduPilot/CurrentState.cs
+++ b/ExtLibs/ArduPilot/CurrentState.cs
@@ -503,6 +503,8 @@ namespace MissionPlanner
         public float targetairspeed { get; private set; }
 
         public bool lowairspeed { get; set; }
+        private float _cachedAirspeedMin = 0;
+        private DateTime _lastAirspeedMinCheck = DateTime.MinValue;
 
         [DisplayFieldName("asratio.Field")]
         [DisplayText("Airspeed Ratio")]
@@ -3835,6 +3837,37 @@ namespace MissionPlanner
                             //This comes from the EKF, so it supposed to be correct
                             climbrate = vfr.climb;
                             gotVFR = true; // we have a vfr packet
+
+                            if ((timeSinceArmInAir > 0) && (DateTime.Now - _lastAirspeedMinCheck).TotalSeconds > 5)
+                            {
+                                try
+                                {
+                                    if (parent?.param != null)
+                                    {
+                                        if (parent.param.ContainsKey("AIRSPEED_MIN"))
+                                        {
+                                            _cachedAirspeedMin = (float)parent.param["AIRSPEED_MIN"].Value;
+                                        }
+                                        else if (parent.param.ContainsKey("ARSPD_FBW_MIN"))
+                                        {
+                                            _cachedAirspeedMin = (float)parent.param["ARSPD_FBW_MIN"].Value;
+                                        }
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    log.Debug("Error getting AIRSPEED_MIN or ARSPD_FBW_MIN from param for lowairspeed handling", ex);
+                                }
+
+                                _lastAirspeedMinCheck = DateTime.Now;
+                            }
+
+                            lowairspeed = armed
+                                && (timeSinceArmInAir > 0)
+                                && (_cachedAirspeedMin > 0)
+                                && sensors_enabled.differential_pressure
+                                && sensors_health.differential_pressure
+                                && (vfr.airspeed < _cachedAirspeedMin);
                         }
 
                         break;

--- a/GCSViews/FlightData.Designer.cs
+++ b/GCSViews/FlightData.Designer.cs
@@ -395,6 +395,7 @@ namespace MissionPlanner.GCSViews
             this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("AOA", this.bindingSourceHud, "AOA", true));
             this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("SSA", this.bindingSourceHud, "SSA", true));
             this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("critAOA", this.bindingSourceHud, "crit_AOA", true));
+            this.hud1.DataBindings.Add(new System.Windows.Forms.Binding("lowairspeed", this.bindingSourceHud, "lowairspeed", true));
             this.hud1.datetime = new System.DateTime(((long)(0)));
             this.hud1.displayAOASSA = false;
             this.hud1.displayCellVoltage = false;


### PR DESCRIPTION
This PR adds a new low-airspeed alert calculation to the vehicle state: when the aircraft is armed and airborne, it periodically reads the minimum airspeed parameter, caches it for a few seconds, and marks the state as low airspeed if the measured airspeed drops below that threshold while the airspeed sensor is healthy. It also avoids hammering the parameter lookup by rechecking the minimum airspeed only every five seconds. Finally, the HUD is bound to this new `lowairspeed` state so the display can react visually when the condition is detected.