### PR TITLE
Fix memory leak in GStreamer caps parsing

### DIFF
--- a/ExtLibs/Utilities/GStreamer.cs
+++ b/ExtLibs/Utilities/GStreamer.cs
@@ -1306,7 +1306,8 @@ namespace MissionPlanner.Utilities
                         NativeMethods.gst_structure_get_int(caps_s, "width", out Width);
                         NativeMethods.gst_structure_get_int(caps_s, "height", out Height);
 
-                        var capsstring = NativeMethods.gst_caps_to_string(caps_s);
+                        // Memory leak: gst_caps_to_string allocates memory that requires g_free()
+                        // var capsstring = NativeMethods.gst_caps_to_string(caps_s);
                         var buffer = NativeMethods.gst_sample_get_buffer(sample);
                         if (buffer != IntPtr.Zero)
                         {


### PR DESCRIPTION
This PR addresses a severe unmanaged memory leak inside the GStreamer video processing pipeline (`ExtLibs\Utilities\GStreamer.cs`). 

For every video frame pulled from the `appsink`, the code was calling `NativeMethods.gst_caps_to_string(caps_s)`. This native GStreamer C function allocates a new character array (`gchar*`) that must be explicitly freed using `g_free()`. However, the C# P/Invoke wrapper only marshaled the pointer into a managed string but never freed the underlying native pointer. Because this was called inside the continuous frame loop, it resulted in a persistent and aggressive unmanaged memory leak. 

Since the generated `capsstring` was completely unused by the application, the call has been commented out to immediately resolve the leak.

### The Memory Leak Impact
Because this unmanaged allocation occurred per frame, the leak scaled directly with the stream's frame rate. For a standard **720p video stream running at 60 FPS**, the leak estimate looks like this:

* A typical capabilities string (e.g., `video/x-raw, format=(string)BGRx, width=(int)1280, height=(int)720, framerate=(fraction)60/1`) translates to roughly **~150 bytes**.
* **Per Second:** 60 frames × ~150 bytes ≈ **~9 KB / sec**
* **Per Minute:** 9 KB × 60 ≈ **~540 KB / min**
* **Per Hour:** 540 KB × 60 ≈ **~32.4 MB / hour**

Over long flight sessions typical for Ground Control Stations, this continuous background allocation eventually leads to high memory footprints and potential out-of-memory (OOM) crashes.