### PR TITLE
Device: add ASM330 & LSM6DSV to imu types

### DIFF
--- a/ExtLibs/Utilities/Device.cs
+++ b/ExtLibs/Utilities/Device.cs
@@ -165,8 +165,9 @@ namespace MissionPlanner.Utilities
                 DEVTYPE_INS_ICM45686 = 0x3B,
                 DEVTYPE_INS_SCHA63T = 0x3C,
                 DEVTYPE_INS_IIM42653 = 0x3D,
+                DEVTYPE_INS_LSM6DSV = 0x3E,
+                DEVTYPE_INS_ASM330 = 0x3F,
             };
-
 
             //https://github.com/tridge/ardupilot/blob/master/libraries/AP_Baro/AP_Baro_Backend.h#L40
             public enum baro_types


### PR DESCRIPTION
I added ASM330 to imu types.
This addition of ASM330 is base on this PR https://github.com/ArduPilot/ardupilot/pull/31656.