### PR TITLE
Remove unnecessary COMMAND_ACK

### DIFF
--- a/ExtLibs/ArduPilot/mav_mission.cs
+++ b/ExtLibs/ArduPilot/mav_mission.cs
@@ -148,8 +148,6 @@ namespace MissionPlanner.ArduPilot
                     }
                 }
 
-                port.setWPACK(sysid, compid, type);
-
             }
             catch (Exception ex)
             {
@@ -244,8 +242,6 @@ namespace MissionPlanner.ArduPilot
                                             " " + Enum.Parse(typeof(MAVLink.MAV_MISSION_RESULT), ans.ToString()));
                     }
                 }
-
-                port.setWPACK(sysid, compid, type);
 
             }
             catch (Exception ex)


### PR DESCRIPTION
In a mission upload operation the flight controller confirms the upload with a COMMAND_ACK. MissionPlanner then replies with another unnecessary COMMAND_ACK. This PR removes it.

Does not cause any regression, since the GCS should never send COMMAND_ACK with type = 0 during mission upload