### PR TITLE
ConfigHWCompass: show calibration bad-fit reasons in mag cal dialog

### DIFF
--- a/GCSViews/ConfigurationView/ConfigHWCompass.cs
+++ b/GCSViews/ConfigurationView/ConfigHWCompass.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace MissionPlanner.GCSViews.ConfigurationView
@@ -419,6 +421,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private List<MAVLink.MAVLinkMessage> mprog = new List<MAVLink.MAVLinkMessage>();
         private List<MAVLink.MAVLinkMessage> mrep = new List<MAVLink.MAVLinkMessage>();
+        private Dictionary<string, string> badFitMessages = new Dictionary<string, string>();
+        private static readonly Regex BadFitRegex = new Regex(@"Mag\((\d+)\) bad ", RegexOptions.Compiled);
 
         private bool ReceviedPacket(MAVLink.MAVLinkMessage packet)
         {
@@ -443,12 +447,31 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
                 return true;
             }
+            else if (packet.msgid == (byte)MAVLink.MAVLINK_MSG_ID.STATUSTEXT)
+            {
+                var msg = packet.ToStructure<MAVLink.mavlink_statustext_t>();
+                var text = Encoding.ASCII.GetString(msg.text);
+                int nul = text.IndexOf('\0');
+                if (nul != -1) text = text.Substring(0, nul);
+
+                var m = BadFitRegex.Match(text);
+                if (m.Success)
+                {
+                    lock (badFitMessages)
+                    {
+                        badFitMessages[m.Groups[1].Value] = text;
+                    }
+                }
+
+                return false;
+            }
 
             return true;
         }
 
         private int packetsub1;
         private int packetsub2;
+        private int packetsub3;
 
         private void BUT_OBmagcalstart_Click(object sender, EventArgs e)
         {
@@ -465,12 +488,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             mprog.Clear();
             mrep.Clear();
+            badFitMessages.Clear();
             horizontalProgressBar1.Value = 0;
             horizontalProgressBar2.Value = 0;
             horizontalProgressBar3.Value = 0;
 
             packetsub1 = MainV2.comPort.SubscribeToPacketType(MAVLink.MAVLINK_MSG_ID.MAG_CAL_PROGRESS, ReceviedPacket, (byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent);
             packetsub2 = MainV2.comPort.SubscribeToPacketType(MAVLink.MAVLINK_MSG_ID.MAG_CAL_REPORT, ReceviedPacket, (byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent);
+            packetsub3 = MainV2.comPort.SubscribeToPacketType(MAVLink.MAVLINK_MSG_ID.STATUSTEXT, ReceviedPacket, (byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent);
 
             BUT_OBmagcalaccept.Enabled = true;
             BUT_OBmagcalcancel.Enabled = true;
@@ -491,6 +516,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             MainV2.comPort.UnSubscribeToPacketType(packetsub1);
             MainV2.comPort.UnSubscribeToPacketType(packetsub2);
+            MainV2.comPort.UnSubscribeToPacketType(packetsub3);
 
             timer1.Stop();
         }
@@ -508,6 +534,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             MainV2.comPort.UnSubscribeToPacketType(packetsub1);
             MainV2.comPort.UnSubscribeToPacketType(packetsub2);
+            MainV2.comPort.UnSubscribeToPacketType(packetsub3);
 
             timer1.Stop();
         }
@@ -546,7 +573,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     message += "id:" + item.Key + " " + obj.completion_pct.ToString() + "% ";
                     compasscount++;
                 }
-                lbl_obmagresult.AppendText(message + "\n");
+                lbl_obmagresult.AppendText(message + Environment.NewLine);
             }
 
             lock (mrep)
@@ -571,7 +598,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     lbl_obmagresult.AppendText("id:" + obj.compass_id + " x:" + obj.ofs_x.ToString("0.0") + " y:" +
                                                obj.ofs_y.ToString("0.0") + " z:" +
                                                obj.ofs_z.ToString("0.0") + " fit:" + obj.fitness.ToString("0.0") + " " +
-                                               (MAVLink.MAG_CAL_STATUS)obj.cal_status + "\n");
+                                               (MAVLink.MAG_CAL_STATUS)obj.cal_status + Environment.NewLine);
 
                     try
                     {
@@ -586,18 +613,26 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     {
                     }
 
-                    if ((MAVLink.MAG_CAL_STATUS)obj.cal_status != MAVLink.MAG_CAL_STATUS.MAG_CAL_SUCCESS)
-                    {
-                        //CustomMessageBox.Show(Strings.CommandFailed);
-                    }
-
                     if (obj.autosaved == 1)
                     {
                         completecount++;
                         timer1.Interval = 1000;
                     }
                 }
+
             }
+
+            // show any bad-fit messages collected so far (latest per compass)
+            lock (badFitMessages)
+            {
+                foreach (var fitMsg in badFitMessages.Values)
+                {
+                    lbl_obmagresult.AppendText(fitMsg + Environment.NewLine);
+                }
+            }
+
+            lbl_obmagresult.SelectionStart = lbl_obmagresult.TextLength;
+            lbl_obmagresult.ScrollToCaret();
 
             if (compasscount == completecount && compasscount != 0)
             {

--- a/GCSViews/ConfigurationView/ConfigHWCompass2.cs
+++ b/GCSViews/ConfigurationView/ConfigHWCompass2.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Color = System.Drawing.Color;
@@ -18,9 +20,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private List<MAVLink.MAVLinkMessage> mprog = new List<MAVLink.MAVLinkMessage>();
         private List<MAVLink.MAVLinkMessage> mrep = new List<MAVLink.MAVLinkMessage>();
+        private Dictionary<string, string> badFitMessages = new Dictionary<string, string>();
+        private static readonly Regex BadFitRegex = new Regex(@"Mag\((\d+)\) bad ", RegexOptions.Compiled);
 
         private int packetsub1;
         private int packetsub2;
+        private int packetsub3;
 
         public class CompassDeviceInfo : DeviceInfo
         {
@@ -281,12 +286,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             mprog.Clear();
             mrep.Clear();
+            badFitMessages.Clear();
             horizontalProgressBar1.Value = 0;
             horizontalProgressBar2.Value = 0;
             horizontalProgressBar3.Value = 0;
 
             packetsub1 = MainV2.comPort.SubscribeToPacketType(MAVLink.MAVLINK_MSG_ID.MAG_CAL_PROGRESS, ReceviedPacket, (byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent);
             packetsub2 = MainV2.comPort.SubscribeToPacketType(MAVLink.MAVLINK_MSG_ID.MAG_CAL_REPORT, ReceviedPacket, (byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent);
+            packetsub3 = MainV2.comPort.SubscribeToPacketType(MAVLink.MAVLINK_MSG_ID.STATUSTEXT, ReceviedPacket, (byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent);
 
             BUT_OBmagcalaccept.Enabled = true;
             BUT_OBmagcalcancel.Enabled = true;
@@ -316,6 +323,24 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
                 return true;
             }
+            else if (packet.msgid == (byte)MAVLink.MAVLINK_MSG_ID.STATUSTEXT)
+            {
+                var msg = packet.ToStructure<MAVLink.mavlink_statustext_t>();
+                var text = Encoding.ASCII.GetString(msg.text);
+                int nul = text.IndexOf('\0');
+                if (nul != -1) text = text.Substring(0, nul);
+
+                var m = BadFitRegex.Match(text);
+                if (m.Success)
+                {
+                    lock (badFitMessages)
+                    {
+                        badFitMessages[m.Groups[1].Value] = text;
+                    }
+                }
+
+                return false;
+            }
 
             return true;
         }
@@ -334,6 +359,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             MainV2.comPort.UnSubscribeToPacketType(packetsub1);
             MainV2.comPort.UnSubscribeToPacketType(packetsub2);
+            MainV2.comPort.UnSubscribeToPacketType(packetsub3);
 
             timer1.Stop();
         }
@@ -351,6 +377,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             MainV2.comPort.UnSubscribeToPacketType(packetsub1);
             MainV2.comPort.UnSubscribeToPacketType(packetsub2);
+            MainV2.comPort.UnSubscribeToPacketType(packetsub3);
 
             timer1.Stop();
         }
@@ -390,7 +417,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     message += "id:" + item.Key + " " + obj.completion_pct.ToString() + "% ";
                     compasscount++;
                 }
-                lbl_obmagresult.AppendText(message + "\r\n");
+                lbl_obmagresult.AppendText(message + Environment.NewLine);
             }
 
             lock (mrep)
@@ -415,7 +442,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     lbl_obmagresult.AppendText("id:" + obj.compass_id + " x:" + obj.ofs_x.ToString("0.0") + " y:" +
                                                obj.ofs_y.ToString("0.0") + " z:" +
                                                obj.ofs_z.ToString("0.0") + " fit:" + obj.fitness.ToString("0.0") + " " +
-                                               (MAVLink.MAG_CAL_STATUS)obj.cal_status + "\n");
+                                               (MAVLink.MAG_CAL_STATUS)obj.cal_status + Environment.NewLine);
 
                     try
                     {
@@ -441,18 +468,26 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     {
                     }
 
-                    if ((MAVLink.MAG_CAL_STATUS)obj.cal_status != MAVLink.MAG_CAL_STATUS.MAG_CAL_SUCCESS)
-                    {
-                        //CustomMessageBox.Show(Strings.CommandFailed);
-                    }
-
                     if (obj.autosaved == 1)
                     {
                         completecount++;
                         timer1.Interval = 1000;
                     }
                 }
+
             }
+
+            // show any bad-fit messages collected so far (latest per compass)
+            lock (badFitMessages)
+            {
+                foreach (var fitMsg in badFitMessages.Values)
+                {
+                    lbl_obmagresult.AppendText(fitMsg + Environment.NewLine);
+                }
+            }
+
+            lbl_obmagresult.SelectionStart = lbl_obmagresult.TextLength;
+            lbl_obmagresult.ScrollToCaret();
 
             if (compasscount == completecount && compasscount != 0)
             {

--- a/MissionPlannerTests/GCSViews/ConfigHWCompassTests.cs
+++ b/MissionPlannerTests/GCSViews/ConfigHWCompassTests.cs
@@ -22,13 +22,33 @@ namespace MissionPlannerTests.GCSViews
         [TestMethod]
         public void BadMagRegex_MatchesBadRadius()
         {
-            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad radius: 456.7"));
+            // fix_radius() emits: "Mag(%u) bad radius %.0f expected %.0f" (no colon, no decimal)
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad radius 456 expected 523"));
         }
 
         [TestMethod]
         public void BadMagRegex_MatchesBadFit()
         {
             Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad fit: fitness 145.3 tolerance 100"));
+        }
+
+        // New message formats emitted by fit_acceptable() in ArduPilot PR #32757
+        [TestMethod]
+        public void BadMagRegex_MatchesBadFitRadius()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad fit: radius 1200 [150,950]"));
+        }
+
+        [TestMethod]
+        public void BadMagRegex_MatchesBadFitOffsets()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad fit: ofs (1900,-2100,1850)>=1800"));
+        }
+
+        [TestMethod]
+        public void BadMagRegex_MatchesBadFitDiagOffdiag()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad fit: diag (0.15,1.02,6.33) offdiag (1.05,-0.03,0.00)"));
         }
 
         [TestMethod]
@@ -57,7 +77,7 @@ namespace MissionPlannerTests.GCSViews
                 "EKF3 IMU0 started",
                 "Mag(1) bad fit: fitness 145.3 tolerance 100",
                 "PreArm: compass not healthy",
-                "Mag(0) bad radius: 456.7"
+                "Mag(0) bad radius 456 expected 523"   // fix_radius() format: no colon
             };
 
             foreach (var text in messages)
@@ -70,8 +90,39 @@ namespace MissionPlannerTests.GCSViews
             }
 
             Assert.AreEqual(2, badFitMessages.Count);
-            Assert.AreEqual("Mag(0) bad radius: 456.7", badFitMessages["0"]);
+            Assert.AreEqual("Mag(0) bad radius 456 expected 523", badFitMessages["0"]);
             Assert.AreEqual("Mag(1) bad fit: fitness 145.3 tolerance 100", badFitMessages["1"]);
+        }
+
+        // Verifies that the new fit_acceptable() message formats (ArduPilot PR #32757) are
+        // tracked per-compass and that the latest message wins when multiple arrive.
+        [TestMethod]
+        public void BadFitMessages_NewFitAcceptableFormats_TrackedPerCompass()
+        {
+            var badFitMessages = new Dictionary<string, string>();
+            var messages = new[]
+            {
+                "Mag(0) bad fit: radius 1200 [150,950]",
+                "Mag(0) bad fit: ofs (1900,-2100,1850)>=1800",
+                "Mag(1) bad fit: diag (0.15,1.02,6.33) offdiag (1.05,-0.03,0.00)",
+                "EKF3 IMU0 started",
+                // %.4g format: 145.3 stays "145.3", sq(10)=100 stays "100"
+                "Mag(0) bad fit: fitness 145.3 tolerance 100",
+            };
+
+            foreach (var text in messages)
+            {
+                var match = BadMagRegex.Match(text);
+                if (match.Success)
+                {
+                    badFitMessages[match.Groups[1].Value] = text;
+                }
+            }
+
+            Assert.AreEqual(2, badFitMessages.Count);
+            // Latest message for compass 0 wins
+            Assert.AreEqual("Mag(0) bad fit: fitness 145.3 tolerance 100", badFitMessages["0"]);
+            Assert.AreEqual("Mag(1) bad fit: diag (0.15,1.02,6.33) offdiag (1.05,-0.03,0.00)", badFitMessages["1"]);
         }
 
         [TestMethod]

--- a/MissionPlannerTests/GCSViews/ConfigHWCompassTests.cs
+++ b/MissionPlannerTests/GCSViews/ConfigHWCompassTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MissionPlannerTests.GCSViews
+{
+    [TestClass]
+    public class ConfigHWCompassTests
+    {
+        /// <summary>
+        /// Same regex used in ConfigHWCompass and ConfigHWCompass2 to filter
+        /// compass calibration failure STATUSTEXT messages.
+        /// </summary>
+        private static readonly Regex BadMagRegex = new Regex(@"Mag\((\d+)\) bad ");
+
+        [TestMethod]
+        public void BadMagRegex_MatchesBadOrientation()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad orientation: 6/0 0.9"));
+        }
+
+        [TestMethod]
+        public void BadMagRegex_MatchesBadRadius()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad radius: 456.7"));
+        }
+
+        [TestMethod]
+        public void BadMagRegex_MatchesBadFit()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(0) bad fit: fitness 145.3 tolerance 100"));
+        }
+
+        [TestMethod]
+        public void BadMagRegex_MatchesMultipleCompassIds()
+        {
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(1) bad orientation: 3/2 0.5"));
+            Assert.IsTrue(BadMagRegex.IsMatch("Mag(2) bad fit: fitness 200 tolerance 100"));
+        }
+
+        [TestMethod]
+        public void BadMagRegex_DoesNotMatchUnrelatedStatusText()
+        {
+            Assert.IsFalse(BadMagRegex.IsMatch("PreArm: compass not healthy"));
+            Assert.IsFalse(BadMagRegex.IsMatch("EKF3 IMU0 started"));
+            Assert.IsFalse(BadMagRegex.IsMatch("Calibration started"));
+            Assert.IsFalse(BadMagRegex.IsMatch("Mag field 523"));
+        }
+
+        [TestMethod]
+        public void BadFitMessages_KeepsLatestPerCompassId()
+        {
+            var badFitMessages = new Dictionary<string, string>();
+            var messages = new[]
+            {
+                "Mag(0) bad orientation: 6/0 0.9",
+                "EKF3 IMU0 started",
+                "Mag(1) bad fit: fitness 145.3 tolerance 100",
+                "PreArm: compass not healthy",
+                "Mag(0) bad radius: 456.7"
+            };
+
+            foreach (var text in messages)
+            {
+                var match = BadMagRegex.Match(text);
+                if (match.Success)
+                {
+                    badFitMessages[match.Groups[1].Value] = text;
+                }
+            }
+
+            Assert.AreEqual(2, badFitMessages.Count);
+            Assert.AreEqual("Mag(0) bad radius: 456.7", badFitMessages["0"]);
+            Assert.AreEqual("Mag(1) bad fit: fitness 145.3 tolerance 100", badFitMessages["1"]);
+        }
+
+        [TestMethod]
+        public void NullTerminatedString_IsTrimmedCorrectly()
+        {
+            // Simulates how STATUSTEXT messages are processed:
+            // ASCII bytes with null padding
+            var text = "Mag(0) bad fit: fitness 145.3\0\0\0\0\0\0";
+            int nul = text.IndexOf('\0');
+            if (nul != -1) text = text.Substring(0, nul);
+
+            Assert.AreEqual("Mag(0) bad fit: fitness 145.3", text);
+            Assert.IsTrue(BadMagRegex.IsMatch(text));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Surface compass calibration failure reasons (`Mag(N) bad ...` STATUSTEXT) directly inside the onboard mag calibration dialog, so users can see *why* a calibration was rejected without leaving the page.

Pairs with the ArduPilot side that emits these diagnostics: ArduPilot/ardupilot#32757.

## What changed

In both `ConfigHWCompass` (legacy) and `ConfigHWCompass2`:

- Subscribe to `STATUSTEXT` while calibration is running (in addition to the existing `MAG_CAL_PROGRESS` and `MAG_CAL_REPORT` subscriptions).
- Filter messages with the regex `Mag\((\d+)\) bad ` and store the latest message per compass ID in a thread-safe `Dictionary<string,string>`.
- Render the latest bad-fit message per compass under the progress and report lines in `lbl_obmagresult`.
- Auto-scroll the textbox so the newest entries are visible.
- Switch line breaks to `Environment.NewLine` so newlines render correctly in the WinForms TextBox.
- Return `false` from the new STATUSTEXT branch so non-compass STATUSTEXT continues to flow to other subscribers (HUD/messages remain unaffected).
- Clear collected messages on Start; unsubscribe on Accept and Cancel.

## Why

Previously a failed compass calibration just looped silently with no indication of the cause. With ArduPilot now emitting specific `Mag(N) bad ...` reasons (bad fit, bad radius, bad orientation, etc.), Mission Planner can show these inline so the user immediately knows what to fix.

## Tests

New `MissionPlannerTests/GCSViews/ConfigHWCompassTests.cs` (MSTest):
- Regex matches each known bad-* variant and captures the compass ID.
- Regex rejects unrelated STATUSTEXT (PreArm, EKF, etc.).
- Latest-per-compass dictionary semantics validated (replacement, not accumulation).
- ASCII NUL-trim behavior validated.

Result: 7/7 passing.

## Manual verification (SITL)

- Successful calibration: progress + report lines shown, no bad-fit lines.
- Forced failure (tight `COMPASS_CAL_FIT`, extreme `SIM_MAG*_OFS_*`): `Mag(N) bad ...` lines appear in the dialog, replaced on each retry rather than accumulating.
- Multi-compass failure: one current bad line per compass ID.
- Cancel + restart: state clears cleanly.
- Normal HUD/messages stream still receives non-compass STATUSTEXT.

## Notes

- No new parameters, no MAVLink changes.
- Behavior unchanged for successful calibrations.
- AI-assisted contribution.