### PR TITLE
Joystick: add named profile presets

### DIFF
--- a/ExtLibs/ArduPilot/Joystick/JoystickBase.cs
+++ b/ExtLibs/ArduPilot/Joystick/JoystickBase.cs
@@ -134,8 +134,9 @@ namespace MissionPlanner.Joystick
                         JoyButtons = (JoyButton[]) reader.Deserialize(sr);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    log.Error("Failed to load joystick button config from " + this.joystickconfigbutton, ex);
                 }
 
                 try
@@ -149,8 +150,9 @@ namespace MissionPlanner.Joystick
                         JoyChannels = (JoyChannel[]) reader.Deserialize(sr);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    log.Error("Failed to load joystick axis config from " + this.joystickconfigaxis, ex);
                 }
             }
 
@@ -1321,17 +1323,22 @@ namespace MissionPlanner.Joystick
                 throw new FileNotFoundException("No joystick configuration files found in " + userDataDir);
             }
 
-            if (File.Exists(fileName))
-                File.Delete(fileName);
+            string tempFile = fileName + ".tmp";
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
 
-            // create archive with all config files
-            using (var archive = ZipFile.Open(fileName, ZipArchiveMode.Create))
+            using (var archive = ZipFile.Open(tempFile, ZipArchiveMode.Create))
             {
                 foreach (var file in allFiles)
                 {
                     archive.CreateEntryFromFile(file, Path.GetFileName(file));
                 }
             }
+
+            if (File.Exists(fileName))
+                File.Replace(tempFile, fileName, null);
+            else
+                File.Move(tempFile, fileName);
         }
 
         public void ImportConfig(string fileName)

--- a/ExtLibs/ArduPilot/Joystick/JoystickProfileManager.cs
+++ b/ExtLibs/ArduPilot/Joystick/JoystickProfileManager.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.RegularExpressions;
+using MissionPlanner.Utilities;
+
+namespace MissionPlanner.Joystick
+{
+    public static class JoystickProfileManager
+    {
+        public const string ProfileExtension = ".joycfg";
+        public const string DefaultProfileName = "Default";
+
+        const string ProfilesDirName = "joystick_profiles";
+        const string ActiveProfileSetting = "JoystickActiveProfile";
+        const int MaxNameLength = 100;
+
+        static readonly Regex AllowedNameRegex =
+            new Regex(@"^[A-Za-z0-9 _\-\(\)\.]+$", RegexOptions.Compiled);
+
+        public static string ProfilesDirectory =>
+            Path.Combine(Settings.GetUserDataDirectory(), ProfilesDirName);
+
+        public static string ActiveProfile
+        {
+            get
+            {
+                if (!Settings.Instance.ContainsKey(ActiveProfileSetting))
+                    return null;
+                var value = Settings.Instance[ActiveProfileSetting];
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+            set
+            {
+                Settings.Instance[ActiveProfileSetting] = value ?? string.Empty;
+            }
+        }
+
+        public static IList<string> ListProfiles()
+        {
+            EnsureProfilesDirectory();
+            return Directory
+                .GetFiles(ProfilesDirectory, "*" + ProfileExtension, SearchOption.TopDirectoryOnly)
+                .Select(Path.GetFileNameWithoutExtension)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        public static bool ProfileExists(string name)
+        {
+            ValidateName(name);
+            return File.Exists(ProfilePath(name));
+        }
+
+        public static void SaveActive(JoystickBase joystick)
+        {
+            var name = ActiveProfile;
+            if (string.IsNullOrEmpty(name))
+                throw new InvalidOperationException("No active profile to save");
+            SaveAs(joystick, name);
+        }
+
+        public static void SaveAs(JoystickBase joystick, string name)
+        {
+            if (joystick == null)
+                throw new ArgumentNullException(nameof(joystick));
+            ValidateName(name);
+            EnsureProfilesDirectory();
+
+            joystick.saveconfig();
+            joystick.ExportConfig(ProfilePath(name));
+            ActiveProfile = name;
+        }
+
+        public static void Load(JoystickBase joystick, string name)
+        {
+            if (joystick == null)
+                throw new ArgumentNullException(nameof(joystick));
+            ValidateName(name);
+
+            var path = ProfilePath(name);
+            if (!File.Exists(path))
+                throw new FileNotFoundException("Profile not found: " + name, path);
+
+            joystick.ImportConfig(path);
+            joystick.loadconfig();
+            ActiveProfile = name;
+        }
+
+        public static void Delete(string name)
+        {
+            ValidateName(name);
+
+            var path = ProfilePath(name);
+            if (File.Exists(path))
+                File.Delete(path);
+
+            if (string.Equals(name, ActiveProfile, StringComparison.OrdinalIgnoreCase))
+                ActiveProfile = null;
+        }
+
+        public static void Rename(string oldName, string newName)
+        {
+            ValidateName(oldName);
+            ValidateName(newName);
+
+            if (string.Equals(oldName, newName, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var src = ProfilePath(oldName);
+            var dst = ProfilePath(newName);
+
+            if (!File.Exists(src))
+                throw new FileNotFoundException("Profile not found: " + oldName, src);
+            if (File.Exists(dst))
+                throw new IOException("A profile named '" + newName + "' already exists");
+
+            File.Move(src, dst);
+
+            if (string.Equals(oldName, ActiveProfile, StringComparison.OrdinalIgnoreCase))
+                ActiveProfile = newName;
+        }
+
+        public static void ImportFromFile(string sourcePath, string name)
+        {
+            if (string.IsNullOrEmpty(sourcePath))
+                throw new ArgumentException("Source path required", nameof(sourcePath));
+            if (!File.Exists(sourcePath))
+                throw new FileNotFoundException("Source file not found", sourcePath);
+            ValidateName(name);
+
+            EnsureProfilesDirectory();
+            var dst = ProfilePath(name);
+            File.Copy(sourcePath, dst, true);
+        }
+
+        public static void ExportToFile(string name, string targetPath)
+        {
+            if (string.IsNullOrEmpty(targetPath))
+                throw new ArgumentException("Target path required", nameof(targetPath));
+            ValidateName(name);
+
+            var src = ProfilePath(name);
+            if (!File.Exists(src))
+                throw new FileNotFoundException("Profile not found: " + name, src);
+
+            File.Copy(src, targetPath, true);
+        }
+
+        public static void EnsureDefault()
+        {
+            EnsureProfilesDirectory();
+
+            if (ListProfiles().Count > 0)
+            {
+                if (string.IsNullOrEmpty(ActiveProfile) || !ProfileExists(ActiveProfile))
+                    ActiveProfile = ListProfiles().First();
+                return;
+            }
+
+            var userDir = Settings.GetUserDataDirectory();
+            var buttonFiles = Directory.GetFiles(userDir, "joystickbutton*.xml", SearchOption.TopDirectoryOnly);
+            var axisFiles = Directory.GetFiles(userDir, "joystickaxis*.xml", SearchOption.TopDirectoryOnly);
+
+            if (buttonFiles.Length == 0 && axisFiles.Length == 0)
+                return;
+
+            var dst = ProfilePath(DefaultProfileName);
+            var tmp = dst + ".tmp";
+
+            if (File.Exists(tmp))
+                File.Delete(tmp);
+
+            using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create))
+            {
+                foreach (var file in buttonFiles.Concat(axisFiles))
+                    archive.CreateEntryFromFile(file, Path.GetFileName(file));
+            }
+
+            if (File.Exists(dst))
+                File.Replace(tmp, dst, null);
+            else
+                File.Move(tmp, dst);
+
+            ActiveProfile = DefaultProfileName;
+        }
+
+        public static string ProfilePath(string name)
+        {
+            ValidateName(name);
+            return Path.Combine(ProfilesDirectory, name + ProfileExtension);
+        }
+
+        static void EnsureProfilesDirectory()
+        {
+            if (!Directory.Exists(ProfilesDirectory))
+                Directory.CreateDirectory(ProfilesDirectory);
+        }
+
+        static void ValidateName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Profile name cannot be empty", nameof(name));
+            if (name.Length > MaxNameLength)
+                throw new ArgumentException("Profile name too long (max " + MaxNameLength + " characters)", nameof(name));
+            if (!AllowedNameRegex.IsMatch(name))
+                throw new ArgumentException("Profile name may only contain letters, digits, spaces and _-().", nameof(name));
+            if (name != Path.GetFileName(name))
+                throw new ArgumentException("Invalid profile name", nameof(name));
+        }
+    }
+}

--- a/Joystick/JoystickSetup.Designer.cs
+++ b/Joystick/JoystickSetup.Designer.cs
@@ -47,6 +47,10 @@ namespace MissionPlanner.Joystick
             this.chk_manualcontrol = new System.Windows.Forms.CheckBox();
             this.but_export = new MissionPlanner.Controls.MyButton();
             this.but_import = new MissionPlanner.Controls.MyButton();
+            this.lbl_profile = new System.Windows.Forms.Label();
+            this.CMB_profile = new System.Windows.Forms.ComboBox();
+            this.BUT_profileCreate = new MissionPlanner.Controls.MyButton();
+            this.BUT_profileDelete = new MissionPlanner.Controls.MyButton();
             this.SuspendLayout();
             // 
             // CMB_joysticks
@@ -137,9 +141,38 @@ namespace MissionPlanner.Joystick
             this.but_import.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
             this.but_import.UseVisualStyleBackColor = true;
             this.but_import.Click += new System.EventHandler(this.but_import_Click);
-            // 
+            //
+            // lbl_profile
+            //
+            this.lbl_profile.AutoSize = true;
+            this.lbl_profile.Name = "lbl_profile";
+            this.lbl_profile.Text = "Profile";
+            //
+            // CMB_profile
+            //
+            this.CMB_profile.FormattingEnabled = true;
+            this.CMB_profile.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CMB_profile.Name = "CMB_profile";
+            this.CMB_profile.SelectedIndexChanged += new System.EventHandler(this.CMB_profile_SelectedIndexChanged);
+            //
+            // BUT_profileCreate
+            //
+            this.BUT_profileCreate.Name = "BUT_profileCreate";
+            this.BUT_profileCreate.Text = "Create";
+            this.BUT_profileCreate.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
+            this.BUT_profileCreate.UseVisualStyleBackColor = true;
+            this.BUT_profileCreate.Click += new System.EventHandler(this.BUT_profileCreate_Click);
+            //
+            // BUT_profileDelete
+            //
+            this.BUT_profileDelete.Name = "BUT_profileDelete";
+            this.BUT_profileDelete.Text = "Delete";
+            this.BUT_profileDelete.TextColorNotEnabled = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(87)))), ((int)(((byte)(4)))));
+            this.BUT_profileDelete.UseVisualStyleBackColor = true;
+            this.BUT_profileDelete.Click += new System.EventHandler(this.BUT_profileDelete_Click);
+            //
             // JoystickSetup
-            // 
+            //
             this.Controls.Add(this.but_import);
             this.Controls.Add(this.but_export);
             this.Controls.Add(this.chk_manualcontrol);
@@ -153,10 +186,32 @@ namespace MissionPlanner.Joystick
             this.Controls.Add(this.BUT_enable);
             this.Controls.Add(this.BUT_save);
             this.Controls.Add(this.CMB_joysticks);
+            this.Controls.Add(this.lbl_profile);
+            this.Controls.Add(this.CMB_profile);
+            this.Controls.Add(this.BUT_profileCreate);
+            this.Controls.Add(this.BUT_profileDelete);
             resources.ApplyResources(this, "$this");
             this.Name = "JoystickSetup";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.JoystickSetup_FormClosed);
             this.Load += new System.EventHandler(this.Joystick_Load);
+
+            this.lbl_profile.Location = new System.Drawing.Point(19, 50);
+            this.CMB_profile.Location = new System.Drawing.Point(72, 47);
+            this.CMB_profile.Size = new System.Drawing.Size(170, 21);
+            this.BUT_profileCreate.Location = new System.Drawing.Point(252, 47);
+            this.BUT_profileCreate.Size = new System.Drawing.Size(70, 23);
+            this.BUT_profileDelete.Location = new System.Drawing.Point(328, 47);
+            this.BUT_profileDelete.Size = new System.Drawing.Size(60, 23);
+
+            this.label6.Location = new System.Drawing.Point(this.label6.Location.X, this.label6.Location.Y + 32);
+            this.label7.Location = new System.Drawing.Point(this.label7.Location.X, this.label7.Location.Y + 32);
+            this.label8.Location = new System.Drawing.Point(this.label8.Location.X, this.label8.Location.Y + 32);
+            this.label9.Location = new System.Drawing.Point(this.label9.Location.X, this.label9.Location.Y + 32);
+            this.chk_manualcontrol.Location = new System.Drawing.Point(this.chk_manualcontrol.Location.X, this.chk_manualcontrol.Location.Y + 32);
+            this.CHK_elevons.Location = new System.Drawing.Point(this.CHK_elevons.Location.X, this.CHK_elevons.Location.Y + 32);
+
+            this.MinimumSize = new System.Drawing.Size(this.MinimumSize.Width, this.MinimumSize.Height + 32);
+
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -178,5 +233,9 @@ namespace MissionPlanner.Joystick
         private System.Windows.Forms.CheckBox chk_manualcontrol;
         private MyButton but_export;
         private MyButton but_import;
+        private System.Windows.Forms.Label lbl_profile;
+        private System.Windows.Forms.ComboBox CMB_profile;
+        private MyButton BUT_profileCreate;
+        private MyButton BUT_profileDelete;
     }
 }

--- a/Joystick/JoystickSetup.cs
+++ b/Joystick/JoystickSetup.cs
@@ -4,6 +4,7 @@ using MissionPlanner.Utilities;
 using SharpDX.DirectInput;
 using System;
 using System.Drawing;
+using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Windows.Forms;
@@ -64,9 +65,32 @@ namespace MissionPlanner.Joystick
             {
             } // IF 1 DOESNT EXIST NONE WILL
 
-            var tempjoystick = JoystickBase.Create(() => MainV2.comPort);
+            try
+            {
+                JoystickProfileManager.EnsureDefault();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("EnsureDefault profile failed: " + ex);
+            }
+            RefreshProfileList();
 
             label14.Text += " " + MainV2.comPort.MAV.cs.firmware.ToString();
+
+            BuildAxisControls();
+
+            if (MainV2.joystick != null && MainV2.joystick.enabled)
+            {
+                timer1.Start();
+                BUT_enable.Text = "Disable";
+            }
+
+            startup = false;
+        }
+
+        private void BuildAxisControls()
+        {
+            var tempjoystick = JoystickBase.Create(() => MainV2.comPort);
 
             var y = label8.Bottom;
 
@@ -118,14 +142,55 @@ namespace MissionPlanner.Joystick
             }
 
             this.ResumeLayout();
+        }
 
-            if (MainV2.joystick != null && MainV2.joystick.enabled)
+        private void RefreshUIAfterProfileLoad()
+        {
+            if (MainV2.joystick != null)
             {
-                timer1.Start();
-                BUT_enable.Text = "Disable";
+                try { MainV2.joystick.UnAcquireJoyStick(); } catch { }
+                if (MainV2.joystick.enabled)
+                {
+                    MainV2.joystick.enabled = false;
+                    MainV2.joystick.clearRCOverride();
+                }
+                MainV2.joystick = null;
             }
 
-            startup = false;
+            BUT_enable.Text = "Enable";
+
+            this.SuspendLayout();
+            try
+            {
+                var toRemove = new System.Collections.Generic.List<Control>();
+                foreach (Control c in this.Controls)
+                {
+                    if (c.Name == null) continue;
+                    if (c.Name.StartsWith("axis") ||
+                        c.Name.StartsWith("cmbbutton") ||
+                        c.Name.StartsWith("mybut") ||
+                        c.Name.StartsWith("hbar") ||
+                        c.Name.StartsWith("cmbaction") ||
+                        c.Name.StartsWith("butsettings") ||
+                        c.Name.StartsWith("butlabel"))
+                    {
+                        toRemove.Add(c);
+                    }
+                }
+                foreach (var c in toRemove)
+                {
+                    this.Controls.Remove(c);
+                    c.Dispose();
+                }
+
+                noButtons = 0;
+
+                BuildAxisControls();
+            }
+            finally
+            {
+                this.ResumeLayout();
+            }
         }
 
         int[] getButtonNumbers()
@@ -199,6 +264,19 @@ namespace MissionPlanner.Joystick
             MainV2.joystick.saveconfig();
 
             Settings.Instance["joy_elevons"] = CHK_elevons.Checked.ToString();
+
+            var active = JoystickProfileManager.ActiveProfile;
+            if (!string.IsNullOrEmpty(active))
+            {
+                try
+                {
+                    JoystickProfileManager.SaveActive(MainV2.joystick);
+                }
+                catch (Exception ex)
+                {
+                    CustomMessageBox.Show("Failed to update active profile: " + ex.Message);
+                }
+            }
         }
 
         private void timer1_Tick(object sender, EventArgs e)
@@ -370,6 +448,7 @@ namespace MissionPlanner.Joystick
             butlabel.Location = new Point(x, y);
             butlabel.Size = new Size(47, 13);
             butlabel.Text = "But " + (int.Parse(name) + 1);
+            butlabel.Name = "butlabel" + name;
 
             butnumberlist.Location = new Point(butlabel.Right, y);
             butnumberlist.Size = new Size(70, 21);
@@ -537,33 +616,257 @@ namespace MissionPlanner.Joystick
 
         private void but_export_Click(object sender, EventArgs e)
         {
-            SaveFileDialog sfd = new SaveFileDialog();
-            sfd.Filter = "Joystick config files (*.joycfg)|*.joycfg|All files (*.*)|*.*";
-            if (sfd.ShowDialog() == DialogResult.OK)
+            var active = JoystickProfileManager.ActiveProfile;
+
+            using (var sfd = new SaveFileDialog())
             {
-                MainV2.joystick.saveconfig();
-                MainV2.joystick.ExportConfig(sfd.FileName);
+                sfd.Filter = "Joystick config files (*.joycfg)|*.joycfg|All files (*.*)|*.*";
+                sfd.FileName = string.IsNullOrEmpty(active) ? "joystick" : active;
+
+                if (sfd.ShowDialog() != DialogResult.OK)
+                    return;
+
+                try
+                {
+                    if (MainV2.joystick != null && !string.IsNullOrEmpty(active))
+                    {
+                        JoystickProfileManager.SaveActive(MainV2.joystick);
+                        JoystickProfileManager.ExportToFile(active, sfd.FileName);
+                    }
+                    else if (MainV2.joystick != null)
+                    {
+                        MainV2.joystick.saveconfig();
+                        MainV2.joystick.ExportConfig(sfd.FileName);
+                    }
+                    else
+                    {
+                        CustomMessageBox.Show("Enable a joystick first");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    CustomMessageBox.Show("Failed to export: " + ex.Message);
+                }
             }
         }
 
         private void but_import_Click(object sender, EventArgs e)
         {
-            if (CustomMessageBox.Show("NOTE: this will replace any existing joystick configuration.\nPlease make sure you have saved your current configuration if needed.", "Import Joystick Config", MessageBoxButtons.OKCancel) == (int)DialogResult.OK)
+            using (var ofd = new OpenFileDialog())
             {
-                OpenFileDialog ofd = new OpenFileDialog();
                 ofd.Filter = "Joystick config files (*.joycfg)|*.joycfg|All files (*.*)|*.*";
-                if (ofd.ShowDialog() == DialogResult.OK)
+                if (ofd.ShowDialog() != DialogResult.OK)
+                    return;
+
+                string name = Path.GetFileNameWithoutExtension(ofd.FileName) ?? "Imported";
+                if (InputBox.Show("Import Profile", "New profile name:", ref name) != DialogResult.OK)
+                    return;
+                name = (name ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(name))
+                    return;
+
+                try
                 {
-                    MainV2.joystick.ImportConfig(ofd.FileName);
-                    MainV2.joystick.loadconfig();
-                    CustomMessageBox.Show("Please reopen joystick for changes to take effect");
-                    this.BeginInvoke((Action)delegate ()
+                    if (JoystickProfileManager.ProfileExists(name))
                     {
-                        this.Close();
-                        ((Form)this.Parent).Close();
-                    });
+                        if (CustomMessageBox.Show("Profile '" + name + "' already exists. Overwrite?",
+                                "Overwrite Profile", MessageBoxButtons.YesNo) != (int)DialogResult.Yes)
+                            return;
+                    }
+
+                    JoystickProfileManager.ImportFromFile(ofd.FileName, name);
+                    LoadProfileInPlace(name);
+                }
+                catch (Exception ex)
+                {
+                    CustomMessageBox.Show("Failed to import profile: " + ex.Message);
                 }
             }
+        }
+
+        private void CMB_profile_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (startup)
+                return;
+
+            var selected = CMB_profile.SelectedItem as string;
+            if (string.IsNullOrEmpty(selected))
+                return;
+
+            var active = JoystickProfileManager.ActiveProfile;
+            if (string.Equals(selected, active, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var result = CustomMessageBox.Show(
+                "Switch joystick profile to '" + selected + "'?\n" +
+                "This will replace the current joystick configuration.\n" +
+                "Save the current configuration first if needed.",
+                "Switch Profile", MessageBoxButtons.OKCancel);
+
+            if (result != (int)DialogResult.OK)
+            {
+                bool wasStartup = startup;
+                startup = true;
+                try
+                {
+                    if (!string.IsNullOrEmpty(active))
+                    {
+                        var revert = CMB_profile.Items.Cast<string>()
+                            .FirstOrDefault(p => string.Equals(p, active, StringComparison.OrdinalIgnoreCase));
+                        if (revert != null)
+                            CMB_profile.SelectedItem = revert;
+                    }
+                }
+                finally
+                {
+                    startup = wasStartup;
+                }
+                return;
+            }
+
+            try
+            {
+                LoadProfileInPlace(selected);
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show("Failed to load profile: " + ex.Message);
+                RefreshProfileList();
+            }
+        }
+
+        private void BUT_profileCreate_Click(object sender, EventArgs e)
+        {
+            if (MainV2.joystick == null)
+            {
+                CustomMessageBox.Show("Enable a joystick first to capture its configuration as a profile");
+                return;
+            }
+
+            string name = string.Empty;
+            if (InputBox.Show("Create Profile", "Profile name:", ref name) != DialogResult.OK)
+                return;
+
+            name = (name ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(name))
+                return;
+
+            try
+            {
+                if (JoystickProfileManager.ProfileExists(name))
+                {
+                    if (CustomMessageBox.Show("Profile '" + name + "' already exists. Overwrite?",
+                            "Overwrite Profile", MessageBoxButtons.YesNo) != (int)DialogResult.Yes)
+                        return;
+                }
+
+                JoystickProfileManager.SaveAs(MainV2.joystick, name);
+                RefreshProfileList();
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show("Failed to create profile: " + ex.Message);
+            }
+        }
+
+        private void BUT_profileDelete_Click(object sender, EventArgs e)
+        {
+            var selected = CMB_profile.SelectedItem as string;
+            if (string.IsNullOrEmpty(selected))
+                return;
+
+            if (string.Equals(selected, JoystickProfileManager.DefaultProfileName, StringComparison.OrdinalIgnoreCase))
+            {
+                CustomMessageBox.Show("The Default profile cannot be deleted.");
+                return;
+            }
+
+            bool isActive = string.Equals(selected, JoystickProfileManager.ActiveProfile, StringComparison.OrdinalIgnoreCase);
+
+            string prompt = isActive
+                ? "Delete the active profile '" + selected + "'?\nIts joystick configuration will be removed."
+                : "Delete profile '" + selected + "'?";
+
+            if (CustomMessageBox.Show(prompt, "Delete Profile", MessageBoxButtons.YesNo) != (int)DialogResult.Yes)
+                return;
+
+            try
+            {
+                JoystickProfileManager.Delete(selected);
+
+                if (isActive)
+                {
+                    var remaining = JoystickProfileManager.ListProfiles();
+                    if (remaining.Count > 0)
+                        LoadProfileInPlace(remaining[0]);
+                }
+
+                RefreshProfileList();
+            }
+            catch (Exception ex)
+            {
+                CustomMessageBox.Show("Failed to delete profile: " + ex.Message);
+            }
+        }
+
+        private void RefreshProfileList()
+        {
+            bool wasStartup = startup;
+            startup = true;
+            try
+            {
+                CMB_profile.Items.Clear();
+                var profiles = JoystickProfileManager.ListProfiles();
+                foreach (var name in profiles)
+                    CMB_profile.Items.Add(name);
+
+                var active = JoystickProfileManager.ActiveProfile;
+                var match = string.IsNullOrEmpty(active)
+                    ? null
+                    : profiles.FirstOrDefault(p => string.Equals(p, active, StringComparison.OrdinalIgnoreCase));
+
+                if (match != null)
+                {
+                    CMB_profile.SelectedItem = match;
+                }
+                else if (profiles.Count > 0)
+                {
+                    CMB_profile.SelectedItem = profiles[0];
+                    JoystickProfileManager.ActiveProfile = profiles[0];
+                }
+            }
+            finally
+            {
+                startup = wasStartup;
+            }
+        }
+
+        private void LoadProfileInPlace(string name)
+        {
+            JoystickBase loader;
+            bool createdLoader = false;
+            if (MainV2.joystick != null)
+            {
+                loader = MainV2.joystick;
+            }
+            else
+            {
+                loader = JoystickBase.Create(() => MainV2.comPort);
+                createdLoader = true;
+            }
+
+            try
+            {
+                JoystickProfileManager.Load(loader, name);
+            }
+            finally
+            {
+                if (createdLoader)
+                    loader.Dispose();
+            }
+
+            RefreshUIAfterProfileLoad();
+            RefreshProfileList();
         }
     }
 }


### PR DESCRIPTION
## What

Adds a named profile manager on top of the `ExportConfig`/`ImportConfig` methods that landed in #3656. Users can save the current joystick configuration under a name, switch between profiles, and import/export profiles as `.joycfg` files for sharing.

## UI

A new row appears in `JoystickSetup`, below the device combo:

```
Profile: [dropdown]  [Create]  [Delete]
```

The existing Export and Import buttons are kept and now operate on the active profile (Export saves the active profile to a chosen path; Import asks for a name and registers the file as a new profile). Switching profiles from the dropdown reloads the form in place, no window close/reopen.

## Storage

Profiles are stored as `.joycfg` files in:

```
Documents/Mission Planner/joystick_profiles/
```

The `.joycfg` format from #3656 is reused as-is. The active profile name is persisted in `Settings` under the key `JoystickActiveProfile`.

## Migration

On first run with existing `joystickbutton*.xml` / `joystickaxis*.xml` in the user data directory, those files are packaged into a profile named `Default` and set as active. The Default profile cannot be deleted from the UI.

## Hardening of existing Export/Import

While in the area, two safety fixes:

- `ExportConfig` now writes to `<name>.tmp` and then atomically replaces the target file. A killed process can no longer leave a half-written `.joycfg`.
- `loadconfig` now logs XML deserialization failures via log4net instead of swallowing them in an empty `catch`.

## Files

- `ExtLibs/ArduPilot/Joystick/JoystickProfileManager.cs` (new)
- `ExtLibs/ArduPilot/Joystick/JoystickBase.cs`
- `Joystick/JoystickSetup.cs`
- `Joystick/JoystickSetup.Designer.cs`

## Out of scope

- Auto-binding profiles to vehicle type or sysid
- Profile preview without loading
- Changes to the `.joycfg` format (kept compatible with #3656)

## Testing

- Solution builds clean in Release with no new warnings or errors from the new code.
- Live tested on Windows 10 with a Radiomaster Zorro joystick:
  - First-run migration of existing XMLs into a Default profile
  - Create / Save / Switch / Delete cycles
  - Switch dialog with OK/Cancel, dropdown reverts on Cancel
  - Deleting the active profile asks for confirmation and auto-switches to the first remaining profile; the dropdown updates immediately
  - Default profile is protected from deletion
  - Import / Export round trip via `.joycfg` files
  - Stale `JoystickActiveProfile` in Settings (e.g. profile deleted between sessions) falls back to the first available profile via `EnsureDefault`