### PR TITLE
FlightPlanner: Clear the current mission before reflecting the data grid

### DIFF
--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -383,6 +383,7 @@ namespace MissionPlanner.GCSViews
             {
                 // get the command list from the datagrid
                 var commandlist = GetCommandList();
+                MainV2.comPort.MAV.wps.Clear();
                 MainV2.comPort.MAV.wps[0] = new Locationwp().Set(MainV2.comPort.MAV.cs.PlannedHomeLocation.Lat,
                     MainV2.comPort.MAV.cs.PlannedHomeLocation.Lng, MainV2.comPort.MAV.cs.PlannedHomeLocation.Alt, 0);
                 int a = 1;


### PR DESCRIPTION
FlightPlanner Ctrl+M shortcut should clear the current loaded mission before reflecting the data grid commands.