### PR TITLE
Fix time calculation logic by replacing `.Milliseconds` with `.TotalMilliseconds`

### DIFF
--- a/Controls/ConnectionStats.cs
+++ b/Controls/ConnectionStats.cs
@@ -127,7 +127,7 @@ namespace MissionPlanner.Controls
                     .Select(x => x.Interval.Ticks)
                     .Scan(0L, Math.Max)
                     .Select(TimeSpan.FromTicks)
-                    .Select(ts => ts.Milliseconds)
+                    .Select(ts => ts.TotalMilliseconds)
                     .ObserveOn(SynchronizationContext.Current)
                     .SubscribeForTextUpdates(txt_MaxPacketInterval),
             };

--- a/ExtLibs/Utilities/GeoRefImageBase.cs
+++ b/ExtLibs/Utilities/GeoRefImageBase.cs
@@ -721,7 +721,7 @@ namespace MissionPlanner.GeoRef
 
                     AppendText("Photo " + Path.GetFileNameWithoutExtension(filename) +
                                " PROCESSED with GPS position found " +
-                               (shotLocation.Time - correctedTime).Milliseconds + " ms away\n");
+                               (shotLocation.Time - correctedTime).TotalMilliseconds + " ms away\n");
                 }
             });
 
@@ -850,7 +850,7 @@ namespace MissionPlanner.GeoRef
                         cameraLocationFromGPSMsg = LookForLocation(p.Time, vehicleLocations);
                         if (cameraLocationFromGPSMsg != null)
                         {
-                            logAltMsg = "AMSL Alt " + (cameraLocationFromGPSMsg.Time - p.Time).Milliseconds + " ms away" +
+                            logAltMsg = "AMSL Alt " + (cameraLocationFromGPSMsg.Time - p.Time).TotalMilliseconds + " ms away" +
                                         " offset: " + (p.ShotTimeReportedByCamera - dCAMMsgTime).TotalSeconds;
                             p.AltAMSL = cameraLocationFromGPSMsg.AltAMSL;
                         }
@@ -890,7 +890,7 @@ namespace MissionPlanner.GeoRef
                     {
                         System.TimeSpan diffGPSTimeCAMTime = cameraLocationFromGPSMsg.Time - dCAMMsgTime;
 
-                        if (diffGPSTimeCAMTime.Milliseconds > 2*millisShutterLag)
+                        if (diffGPSTimeCAMTime.TotalMilliseconds > 2 * millisShutterLag)
                         {
                             // Stay with CAM Message as it is closer to CorrectedTime
                             p.Time = dCAMMsgTime;
@@ -909,7 +909,7 @@ namespace MissionPlanner.GeoRef
                                 cameraLocationFromGPSMsg = LookForLocation(p.Time, vehicleLocations);
                                 if (cameraLocationFromGPSMsg != null)
                                 {
-                                    logAltMsg = "AMSL Alt " + (cameraLocationFromGPSMsg.Time - p.Time).Milliseconds +
+                                    logAltMsg = "AMSL Alt " + (cameraLocationFromGPSMsg.Time - p.Time).TotalMilliseconds +
                                                 " ms away";
                                     p.AltAMSL = cameraLocationFromGPSMsg.AltAMSL;
                                 }
@@ -937,7 +937,7 @@ namespace MissionPlanner.GeoRef
                             string logAltMsg = useAMSLAlt ? "AMSL Alt" : "RelAlt";
 
                             AppendText("Photo " + Path.GetFileNameWithoutExtension(files[i]) +
-                                       " processed with GPS Msg : " + diffGPSTimeCAMTime.Milliseconds +
+                                       " processed with GPS Msg : " + diffGPSTimeCAMTime.TotalMilliseconds +
                                        " ms ahead of CAM Msg. " + logAltMsg + "\n");
                         }
 

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -2458,7 +2458,7 @@ namespace MissionPlanner
         /// </summary>
         private void UpdateConnectIcon()
         {
-            if ((DateTime.UtcNow - connectButtonUpdate).Milliseconds > 500)
+            if ((DateTime.UtcNow - connectButtonUpdate).TotalMilliseconds > 500)
             {
                 //                        Console.WriteLine(DateTime.Now.Millisecond);
                 if (comPort.BaseStream.IsOpen)


### PR DESCRIPTION
This PR fixes a logical bug in time interval calculations where the fractional .Milliseconds property was used instead of the cumulative .TotalMilliseconds.

In .NET, TimeSpan.Milliseconds only returns the millisecond component of the interval (0-999). If an interval exceeds 1 second, the comparison logic would fail or behave inconsistently (e.g., an interval of 1100ms would be treated as 100ms).