### PR TITLE
Fix event handler leaks in FlightData, FlightPlanner, and adsb

### DIFF
--- a/ExtLibs/Utilities/adsb.cs
+++ b/ExtLibs/Utilities/adsb.cs
@@ -142,10 +142,6 @@ namespace MissionPlanner.Utilities
                     {
                         // ADSB Exchange API format - see https://api.adsb.lol/docs
                         string url = "{0}/v2/point/{1}/{2}/{3}";
-                        Download.RequestModification += (u, request) => {
-                            // for future use if necessary: request.Headers.Add("X-API-Auth", "example");
-                            request.SetHeader("User-Agent", "Mission-Planner/" + ApplicationVersion);
-                        };
                         var delay = API_LOOP_DELAY_MILLISECONDS;
 
                         while (true)

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -819,6 +819,11 @@ namespace MissionPlanner.GCSViews
 
         protected override void Dispose(bool disposing)
         {
+            if (MainV2.comPort != null) MainV2.comPort.ParamListChanged -= FlightData_ParentChanged;
+            POI.POIModified -= POI_POIModified;
+            NoFly.NoFly.NoFlyEvent -= NoFly_NoFlyEvent;
+            if (MainV2.cam != null) MainV2.cam.camimage -= cam_camimage;
+
             base.Dispose(disposing);
 
             MainV2.comPort.logreadmode = false;

--- a/GCSViews/FlightPlanner.Designer.cs
+++ b/GCSViews/FlightPlanner.Designer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Forms;
 using MissionPlanner.Controls;
+using MissionPlanner.Utilities;
 
 namespace MissionPlanner.GCSViews
 {
@@ -16,6 +17,8 @@ namespace MissionPlanner.GCSViews
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
+            POI.POIModified -= POI_POIModified;
+
             if (disposing && (components != null))
             {
                 components.Dispose();


### PR DESCRIPTION
Event handlers were either never unsubscribed on disposal or accumulated unboundedly on a static event, preventing garbage collection of the affected objects.