### PR TITLE
 Fix HttpClient misuse: reuse static instance, remove duplicate headers, add missing error handling

### DIFF
--- a/ExtLibs/Utilities/Download.cs
+++ b/ExtLibs/Utilities/Download.cs
@@ -303,10 +303,12 @@ namespace MissionPlanner.Utilities
         private static readonly ILog log =
             LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
+        static readonly HttpClient client = new HttpClient();
+
         public static async Task<string> PostAsync(string uri, string data)
         {
-            var httpClient = new HttpClient();
-            var response = await httpClient.PostAsync(uri, new StringContent(data));
+            var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = new StringContent(data) };
+            var response = await client.SendAsync(request);
 
             response.EnsureSuccessStatusCode();
 
@@ -316,8 +318,9 @@ namespace MissionPlanner.Utilities
 
         public static async Task<string> GetAsync(string uri)
         {
-            var httpClient = new HttpClient();
-            var content = await httpClient.GetStringAsync(uri);
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri));
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
             return await Task.Run(() => (content));
         }
 
@@ -332,8 +335,7 @@ namespace MissionPlanner.Utilities
         /// </summary>
         public static async Task<HTTPResult> GetAsyncWithStatus(string uri)
         {
-            var httpClient = new HttpClient();
-            var response = await httpClient.GetAsync(uri);
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri));
             var content = await response.Content.ReadAsStringAsync();
             return await Task.Run(() => (new HTTPResult() { content = content, status = response.StatusCode }));
         }
@@ -347,7 +349,6 @@ namespace MissionPlanner.Utilities
                 log.Info("Get " + url);
 
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
-
                 RequestModification?.Invoke(url, request);
 
                 using (var response = await client.SendAsync(request, completionOption: HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
@@ -444,18 +445,15 @@ namespace MissionPlanner.Utilities
         {
             if (!String.IsNullOrEmpty(Settings.Instance.UserAgent))
                 client.DefaultRequestHeaders.Add("User-Agent", Settings.Instance.UserAgent);
+            client.Timeout = TimeSpan.FromSeconds(30);
         }
 
-        static HttpClient client = new HttpClient();
         public static bool getFilefromNet(string url, string saveto, Action<int, string> status = null)
         {
             try
             {
                 lock (log)
                     log.Info(url);
-                var client = new HttpClient();
-                client.DefaultRequestHeaders.Add("User-Agent", Settings.Instance.UserAgent);
-                client.Timeout = TimeSpan.FromSeconds(30);
 
                 // Get the response.
                 var response = client.GetAsync(url, completionOption: HttpCompletionOption.ResponseHeadersRead).Result;
@@ -569,9 +567,6 @@ namespace MissionPlanner.Utilities
             if (url == null || url == "" || uri == null)
                 return false;
 
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.Add("User-Agent", Settings.Instance.UserAgent);
-            client.Timeout = TimeSpan.FromSeconds(30);
             var resp = client.SendAsync(new HttpRequestMessage(HttpMethod.Head, url)).Result;
             return resp.IsSuccessStatusCode;
 

--- a/ExtLibs/Utilities/Tracking.cs
+++ b/ExtLibs/Utilities/Tracking.cs
@@ -60,6 +60,7 @@ namespace MissionPlanner.Utilities
 
         static Tracking()
         {
+            client.Timeout = TimeSpan.FromSeconds(30);
         }
 
         public static void AddEvent(string cat, string action, string label, string value)
@@ -101,6 +102,8 @@ namespace MissionPlanner.Utilities
         {
             get; set;
         }
+
+        static readonly HttpClient client = new HttpClient();
 
         public static string productName
         {
@@ -297,10 +300,6 @@ namespace MissionPlanner.Utilities
 
             try
             {
-                var client = new HttpClient();
-                client.DefaultRequestHeaders.Add("User-Agent", productName + " " + productVersion + " (" + Environment.OSVersion.VersionString + ")");
-                client.Timeout = TimeSpan.FromSeconds(30);
-
                 string data = "";
 
                 List<KeyValuePair<string, string>> data1 = (List<KeyValuePair<string, string>>)temp;
@@ -321,7 +320,9 @@ namespace MissionPlanner.Utilities
 
                 log.Debug(data);
 
-                client.PostAsync(secureTrackingEndpoint, new StringContent(data));
+                var request = new HttpRequestMessage(HttpMethod.Post, secureTrackingEndpoint) { Content = new StringContent(data) };
+                request.Headers.TryAddWithoutValidation("User-Agent", productName + " " + productVersion + " (" + Environment.OSVersion.VersionString + ")");
+                client.SendAsync(request);
             }
             catch { }
         }

--- a/ExtLibs/Utilities/adsb.cs
+++ b/ExtLibs/Utilities/adsb.cs
@@ -142,10 +142,6 @@ namespace MissionPlanner.Utilities
                     {
                         // ADSB Exchange API format - see https://api.adsb.lol/docs
                         string url = "{0}/v2/point/{1}/{2}/{3}";
-                        Download.RequestModification += (u, request) => {
-                            // for future use if necessary: request.Headers.Add("X-API-Auth", "example");
-                            request.SetHeader("User-Agent", "Mission-Planner/" + ApplicationVersion);
-                        };
                         var delay = API_LOOP_DELAY_MILLISECONDS;
 
                         while (true)


### PR DESCRIPTION
HttpClient was being instantiated on every request across Download, Tracking, and adsb. This is a well-known anti-pattern that exhausts the system's socket pool under load (each disposed instance holds a socket in TIME_WAIT for up to 4 minutes).