### PR TITLE
MavlinkInterface: Fix guided mode on copter to use alt reference frame 

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -4448,7 +4448,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                 else
                 {
                     setPositionTargetGlobalInt((byte) sysid, (byte) compid,
-                        true, false, false, false, MAVLink.MAV_FRAME.GLOBAL_RELATIVE_ALT_INT,
+                        true, false, false, false, (MAV_FRAME)gotohere.frame,
                         gotohere.lat, gotohere.lng, gotohere.alt, 0, 0, 0, 0, 0);
                 }
             }


### PR DESCRIPTION
Copter always used relative frame instead of the ref.frame set in the FlyToAlt window.