### PR TITLE
Add USB hot-plug AutoFlasher with bootloader interception + portable mode

### DIFF
--- a/GCSViews/ConfigurationView/AutoFlasher/AutoFlasherForm.cs
+++ b/GCSViews/ConfigurationView/AutoFlasher/AutoFlasherForm.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace MissionPlanner.GCSViews.ConfigurationView.AutoFlasher
+{
+    /// <summary>
+    /// Single-purpose dialog that drives the AutoFlasherService. Built entirely
+    /// in code so it requires no Designer.cs or .resx pipeline.
+    /// </summary>
+    public sealed class AutoFlasherForm : Form
+    {
+        private readonly Button _btnPickFirmware;
+        private readonly TextBox _txtFirmware;
+        private readonly Label _lblStatus;
+        private readonly ProgressBar _progress;
+        private readonly TextBox _log;
+        private readonly Button _btnCancel;
+
+        private AutoFlasherService _service;
+        private string _firmwarePath;
+
+        public AutoFlasherForm()
+        {
+            Text = "Auto-Flash Firmware (USB hot-plug)";
+            ClientSize = new Size(720, 420);
+            StartPosition = FormStartPosition.CenterParent;
+            MinimizeBox = false;
+            MaximizeBox = false;
+            FormBorderStyle = FormBorderStyle.Sizable;
+            MinimumSize = new Size(640, 360);
+
+            var top = new TableLayoutPanel
+            {
+                Dock = DockStyle.Top,
+                Height = 88,
+                ColumnCount = 3,
+                RowCount = 2,
+                Padding = new Padding(10)
+            };
+            top.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 100));
+            top.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+            top.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110));
+
+            var lblFw = new Label
+            {
+                Text = "Firmware :",
+                Anchor = AnchorStyles.Left | AnchorStyles.Right,
+                TextAlign = ContentAlignment.MiddleLeft,
+                AutoSize = false,
+            };
+            _txtFirmware = new TextBox
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = true,
+            };
+            _btnPickFirmware = new Button
+            {
+                Text = "Parcourir…",
+                Dock = DockStyle.Fill,
+            };
+            _btnPickFirmware.Click += BtnPickFirmware_Click;
+
+            _lblStatus = new Label
+            {
+                Text = "Sélectionne un firmware (.apj de préférence) puis branche la carte USB.",
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleLeft,
+                AutoEllipsis = true,
+            };
+            top.Controls.Add(lblFw, 0, 0);
+            top.Controls.Add(_txtFirmware, 1, 0);
+            top.Controls.Add(_btnPickFirmware, 2, 0);
+            top.Controls.Add(_lblStatus, 0, 1);
+            top.SetColumnSpan(_lblStatus, 3);
+
+            _progress = new ProgressBar
+            {
+                Dock = DockStyle.Top,
+                Height = 22,
+                Minimum = 0,
+                Maximum = 100,
+            };
+
+            _log = new TextBox
+            {
+                Dock = DockStyle.Fill,
+                Multiline = true,
+                ReadOnly = true,
+                ScrollBars = ScrollBars.Vertical,
+                Font = new Font(FontFamily.GenericMonospace, 8.5f),
+                BackColor = SystemColors.Window,
+            };
+
+            var bottom = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Bottom,
+                Height = 44,
+                FlowDirection = FlowDirection.RightToLeft,
+                Padding = new Padding(10),
+            };
+            _btnCancel = new Button { Text = "Fermer", Width = 100 };
+            _btnCancel.Click += (s, e) => Close();
+            bottom.Controls.Add(_btnCancel);
+
+            Controls.Add(_log);
+            Controls.Add(_progress);
+            Controls.Add(bottom);
+            Controls.Add(top);
+
+            FormClosed += (s, e) =>
+            {
+                try { _service?.Dispose(); } catch { }
+            };
+        }
+
+        private void BtnPickFirmware_Click(object sender, EventArgs e)
+        {
+            using (var ofd = new OpenFileDialog
+            {
+                Title = "Choisir le firmware ArduPilot",
+                Filter = "ArduPilot firmware (*.apj;*.px4;*.hex)|*.apj;*.px4;*.hex|All files (*.*)|*.*",
+            })
+            {
+                if (ofd.ShowDialog(this) != DialogResult.OK) return;
+                if (!File.Exists(ofd.FileName)) return;
+
+                _firmwarePath = ofd.FileName;
+                _txtFirmware.Text = _firmwarePath;
+                StartListening();
+            }
+        }
+
+        private void StartListening()
+        {
+            try
+            {
+                try { _service?.Dispose(); } catch { }
+
+                _service = new AutoFlasherService(_firmwarePath);
+                _service.Status += s => InvokeIfNeeded(() =>
+                {
+                    _lblStatus.Text = s;
+                    AppendLog(s);
+                });
+                _service.Progress += pct => InvokeIfNeeded(() =>
+                {
+                    var v = (int)Math.Max(0, Math.Min(100, pct));
+                    _progress.Value = v;
+                });
+                _service.Completed += (ok, msg) => InvokeIfNeeded(() =>
+                {
+                    _lblStatus.Text = msg;
+                    AppendLog((ok ? "[OK] " : "[FAIL] ") + msg);
+                    _progress.Value = ok ? 100 : 0;
+                    _btnPickFirmware.Enabled = true;
+                });
+
+                _btnPickFirmware.Enabled = false;
+                _service.Start();
+                AppendLog("Listener USB armé. Branche la carte maintenant.");
+            }
+            catch (Exception ex)
+            {
+                AppendLog("Erreur : " + ex.Message);
+                _btnPickFirmware.Enabled = true;
+            }
+        }
+
+        private void InvokeIfNeeded(Action a)
+        {
+            if (IsDisposed) return;
+            if (InvokeRequired) BeginInvoke((Action)(() => { try { a(); } catch { } }));
+            else { try { a(); } catch { } }
+        }
+
+        private void AppendLog(string line)
+        {
+            if (string.IsNullOrEmpty(line)) return;
+            var stamped = DateTime.Now.ToString("HH:mm:ss.fff") + "  " + line + Environment.NewLine;
+            if (_log.IsDisposed) return;
+            _log.AppendText(stamped);
+        }
+    }
+}

--- a/GCSViews/ConfigurationView/AutoFlasher/AutoFlasherService.cs
+++ b/GCSViews/ConfigurationView/AutoFlasher/AutoFlasherService.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Ports;
+using System.Threading;
+using System.Threading.Tasks;
+using log4net;
+using px4uploader;
+
+namespace MissionPlanner.GCSViews.ConfigurationView.AutoFlasher
+{
+    /// <summary>
+    /// Orchestrates: pick firmware -> wait for USB plug -> race to open the
+    /// virtual COM port and run the px4 bootloader sync before the user
+    /// firmware boots and steals the port.
+    /// </summary>
+    public sealed class AutoFlasherService : IDisposable
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof(AutoFlasherService));
+
+        private readonly string _firmwarePath;
+        private UsbPlugListener _listener;
+        private CancellationTokenSource _cts;
+        private int _busy;
+
+        public event Action<string> Status;
+        public event Action<double> Progress; // 0..100
+        public event Action<bool, string> Completed;
+
+        public AutoFlasherService(string firmwarePath)
+        {
+            if (string.IsNullOrWhiteSpace(firmwarePath))
+                throw new ArgumentException("firmware path required", nameof(firmwarePath));
+            if (!File.Exists(firmwarePath))
+                throw new FileNotFoundException("Firmware file not found", firmwarePath);
+            _firmwarePath = firmwarePath;
+        }
+
+        public void Start()
+        {
+            _cts = new CancellationTokenSource();
+            _listener = new UsbPlugListener();
+            _listener.DeviceArrived += OnArrived;
+            Status?.Invoke("En attente du branchement USB de la carte…");
+        }
+
+        public void Cancel()
+        {
+            try { _cts?.Cancel(); } catch { }
+            try { _listener?.Dispose(); } catch { }
+        }
+
+        public void Dispose() => Cancel();
+
+        private async void OnArrived(object sender, UsbDeviceArrivedEventArgs e)
+        {
+            // Single-shot guard: many WMI/WM_DEVICECHANGE events can fire in a row.
+            if (Interlocked.CompareExchange(ref _busy, 1, 0) != 0) return;
+
+            try
+            {
+                Status?.Invoke($"Détecté : {e.Match.Description}. Tentative d'interception bootloader…");
+                log.Info($"AutoFlasher arrived: {e.Match} comPort={e.ComPort} deviceId={e.DeviceId}");
+
+                var token = _cts?.Token ?? CancellationToken.None;
+                await Task.Run(() => RunFlash(e, token), token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Completed?.Invoke(false, "Annulé.");
+            }
+            catch (TimeoutException)
+            {
+                Completed?.Invoke(false,
+                    "Le bootloader n'a pas répondu à temps. Débranche, attends 2 s, rebranche.");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Completed?.Invoke(false,
+                    "Le port est déjà ouvert par une autre application. Ferme toute connexion MAVLink puis réessaie.");
+            }
+            catch (Exception ex)
+            {
+                log.Error("AutoFlasher fatal", ex);
+                Completed?.Invoke(false, $"Erreur : {ex.Message}");
+            }
+            finally
+            {
+                try { _listener?.Dispose(); } catch { }
+            }
+        }
+
+        private void RunFlash(UsbDeviceArrivedEventArgs e, CancellationToken ct)
+        {
+            Firmware fw = Firmware.ProcessFirmware(_firmwarePath);
+
+            // Window in which the bootloader is reachable on the virtual COM port
+            // before user firmware boots and possibly hangs the link.
+            var deadline = DateTime.UtcNow.AddSeconds(8);
+            Uploader uploader = null;
+            string winningPort = null;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var ports = SerialPort.GetPortNames();
+                Array.Sort(ports);
+
+                // Prefer the port pre-resolved from the registry if present.
+                if (!string.IsNullOrEmpty(e.ComPort))
+                {
+                    if (TryIdentify(e.ComPort, out uploader))
+                    {
+                        winningPort = e.ComPort;
+                        break;
+                    }
+                }
+
+                foreach (var p in ports)
+                {
+                    if (string.Equals(p, e.ComPort, StringComparison.OrdinalIgnoreCase)) continue;
+                    ct.ThrowIfCancellationRequested();
+                    if (TryIdentify(p, out uploader))
+                    {
+                        winningPort = p;
+                        break;
+                    }
+                }
+
+                if (uploader != null) break;
+                Thread.Sleep(150);
+            }
+
+            if (uploader == null)
+                throw new TimeoutException("Bootloader unreachable.");
+
+            using (uploader)
+            {
+                Status?.Invoke($"Bootloader synchronisé sur {winningPort} (board_id={uploader.board_type}). Flash en cours…");
+
+                if (uploader.board_type != fw.board_id)
+                {
+                    if (!(uploader.board_type == 33 && fw.board_id == 9))
+                    {
+                        throw new InvalidOperationException(
+                            $"Firmware incompatible : board={uploader.board_type}, fw={fw.board_id}");
+                    }
+                }
+
+                uploader.ProgressEvent += pct => Progress?.Invoke(pct * 100.0);
+                uploader.LogEvent += (msg, lvl) => log.Info($"[uploader] {msg}");
+                uploader.ConfirmEvent += msg => true; // auto-confirm in autoflasher mode
+
+                uploader.upload(fw);
+
+                Completed?.Invoke(true, $"Flash terminé sur {winningPort}.");
+            }
+        }
+
+        private static bool TryIdentify(string portName, out Uploader uploader)
+        {
+            uploader = null;
+            try
+            {
+                var up = new Uploader(portName, 115200);
+                try
+                {
+                    up.identify();
+                    uploader = up;
+                    return true;
+                }
+                catch
+                {
+                    try { up.close(); } catch { }
+                    try { up.Dispose(); } catch { }
+                    return false;
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Port grabbed by Windows; let the bootloader window proceed and retry.
+                return false;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[AutoFlasher] identify failed on {portName}: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/GCSViews/ConfigurationView/AutoFlasher/BootloaderTargets.cs
+++ b/GCSViews/ConfigurationView/AutoFlasher/BootloaderTargets.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace MissionPlanner.GCSViews.ConfigurationView.AutoFlasher
+{
+    public sealed class UsbId
+    {
+        public ushort Vid { get; }
+        public ushort Pid { get; }
+        public string Description { get; }
+
+        public UsbId(ushort vid, ushort pid, string description)
+        {
+            Vid = vid;
+            Pid = pid;
+            Description = description;
+        }
+
+        public override string ToString() => $"VID_{Vid:X4}&PID_{Pid:X4} ({Description})";
+    }
+
+    public static class BootloaderTargets
+    {
+        public static readonly IReadOnlyList<UsbId> Known = new[]
+        {
+            new UsbId(0x26AC, 0x0011, "PX4 FMU v2 bootloader"),
+            new UsbId(0x26AC, 0x0001, "PX4 IO bootloader"),
+            new UsbId(0x26AC, 0x0010, "PX4 FMU"),
+            new UsbId(0x26AC, 0x0016, "Pixhawk Mini bootloader"),
+            new UsbId(0x26AC, 0x0017, "Pixracer bootloader"),
+            new UsbId(0x2DAE, 0x1001, "Cube Black bootloader"),
+            new UsbId(0x2DAE, 0x1011, "Cube Orange bootloader"),
+            new UsbId(0x2DAE, 0x1016, "Cube Orange+ bootloader"),
+            new UsbId(0x2DAE, 0x1101, "Cube+ bootloader"),
+            new UsbId(0x1209, 0x5740, "ArduPilot generic bootloader"),
+            new UsbId(0x1209, 0x5741, "ArduPilot generic"),
+            new UsbId(0x0483, 0xDF11, "STM32 DFU"),
+        };
+    }
+}

--- a/GCSViews/ConfigurationView/AutoFlasher/UsbPlugListener.cs
+++ b/GCSViews/ConfigurationView/AutoFlasher/UsbPlugListener.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Management;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace MissionPlanner.GCSViews.ConfigurationView.AutoFlasher
+{
+    public sealed class UsbDeviceArrivedEventArgs : EventArgs
+    {
+        public UsbId Match { get; }
+        public string ComPort { get; }
+        public string DeviceId { get; }
+
+        public UsbDeviceArrivedEventArgs(UsbId match, string com, string deviceId)
+        {
+            Match = match;
+            ComPort = com;
+            DeviceId = deviceId;
+        }
+    }
+
+    /// <summary>
+    /// Hybrid USB plug listener: native WM_DEVICECHANGE for instant arrival
+    /// notification + 250 ms WMI safety poll for cases where the device was
+    /// already enumerated before subscription. All callbacks are dispatched on
+    /// the SynchronizationContext captured at construction (UI thread).
+    /// </summary>
+    public sealed class UsbPlugListener : IDisposable
+    {
+        private const int WM_DEVICECHANGE = 0x0219;
+        private const int DBT_DEVICEARRIVAL = 0x8000;
+        private const int DBT_DEVTYP_DEVICEINTERFACE = 0x00000005;
+
+        private static readonly Guid GUID_DEVINTERFACE_USB_DEVICE =
+            new Guid("A5DCBF10-6530-11D2-901F-00C04FB951ED");
+
+        private readonly NotifyWindow _window;
+        private readonly SynchronizationContext _sync;
+        private readonly System.Threading.Timer _safetyPoll;
+        private readonly object _gate = new object();
+        private string _lastDeviceIdRaised;
+        private bool _disposed;
+
+        public event EventHandler<UsbDeviceArrivedEventArgs> DeviceArrived;
+
+        public UsbPlugListener()
+        {
+            _sync = SynchronizationContext.Current ?? new SynchronizationContext();
+            _window = new NotifyWindow(OnNativeDeviceChange);
+            _window.CreateHandle(new CreateParams());
+            try { RegisterForUsbNotifications(_window.Handle); }
+            catch (Exception ex) { Debug.WriteLine($"[AutoFlasher] RegisterDeviceNotification failed: {ex.Message}"); }
+
+            _safetyPoll = new System.Threading.Timer(_ => SafeScan(), null, 250, 250);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try { _safetyPoll?.Dispose(); } catch { }
+            try { _window?.DestroyHandle(); } catch { }
+        }
+
+        private void OnNativeDeviceChange(int wParam)
+        {
+            if (wParam != DBT_DEVICEARRIVAL) return;
+            // Never block the message pump with WMI work.
+            Task.Run(() => SafeScan());
+        }
+
+        private void SafeScan()
+        {
+            try
+            {
+                if (_disposed) return;
+                ScanForBootloader();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[AutoFlasher] scan error: {ex.Message}");
+            }
+        }
+
+        private void ScanForBootloader()
+        {
+            using (var searcher = new ManagementObjectSearcher(
+                "SELECT DeviceID FROM Win32_PnPEntity WHERE DeviceID LIKE 'USB%'"))
+            using (var collection = searcher.Get())
+            {
+                foreach (ManagementObject mo in collection)
+                {
+                    var deviceId = mo["DeviceID"] as string ?? "";
+                    var match = MatchVidPid(deviceId);
+                    if (match == null) continue;
+
+                    lock (_gate)
+                    {
+                        if (deviceId == _lastDeviceIdRaised) return;
+                        _lastDeviceIdRaised = deviceId;
+                    }
+
+                    var com = TryGetComPort(deviceId);
+                    RaiseArrived(match, com, deviceId);
+                    return;
+                }
+            }
+        }
+
+        private static UsbId MatchVidPid(string deviceId)
+        {
+            var m = Regex.Match(deviceId, @"VID_([0-9A-F]{4})&PID_([0-9A-F]{4})",
+                RegexOptions.IgnoreCase);
+            if (!m.Success) return null;
+
+            ushort vid = Convert.ToUInt16(m.Groups[1].Value, 16);
+            ushort pid = Convert.ToUInt16(m.Groups[2].Value, 16);
+
+            // FirstOrDefault — never First — to avoid "Sequence contains no elements".
+            return BootloaderTargets.Known.FirstOrDefault(t => t.Vid == vid && t.Pid == pid);
+        }
+
+        private static string TryGetComPort(string deviceId)
+        {
+            try
+            {
+                using (var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                    $@"SYSTEM\CurrentControlSet\Enum\{deviceId}\Device Parameters"))
+                {
+                    return key?.GetValue("PortName") as string;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void RaiseArrived(UsbId match, string com, string deviceId)
+        {
+            var handler = DeviceArrived;
+            if (handler == null) return;
+            _sync.Post(_ => handler(this, new UsbDeviceArrivedEventArgs(match, com, deviceId)), null);
+        }
+
+        private static void RegisterForUsbNotifications(IntPtr hwnd)
+        {
+            var dbi = new DEV_BROADCAST_DEVICEINTERFACE
+            {
+                dbcc_size = Marshal.SizeOf(typeof(DEV_BROADCAST_DEVICEINTERFACE)),
+                dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE,
+                dbcc_classguid = GUID_DEVINTERFACE_USB_DEVICE
+            };
+            var buffer = Marshal.AllocHGlobal(dbi.dbcc_size);
+            try
+            {
+                Marshal.StructureToPtr(dbi, buffer, true);
+                RegisterDeviceNotification(hwnd, buffer, 0);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DEV_BROADCAST_DEVICEINTERFACE
+        {
+            public int dbcc_size;
+            public int dbcc_devicetype;
+            public int dbcc_reserved;
+            public Guid dbcc_classguid;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 1)]
+            public string dbcc_name;
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr RegisterDeviceNotification(IntPtr hRecipient,
+            IntPtr notificationFilter, int flags);
+
+        private sealed class NotifyWindow : NativeWindow
+        {
+            private readonly Action<int> _onDeviceChange;
+            public NotifyWindow(Action<int> onDeviceChange) { _onDeviceChange = onDeviceChange; }
+            protected override void WndProc(ref Message m)
+            {
+                if (m.Msg == WM_DEVICECHANGE) _onDeviceChange((int)m.WParam);
+                base.WndProc(ref m);
+            }
+        }
+    }
+}

--- a/GCSViews/ConfigurationView/ConfigFirmware.cs
+++ b/GCSViews/ConfigurationView/ConfigFirmware.cs
@@ -29,6 +29,41 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         public ConfigFirmware()
         {
             InitializeComponent();
+
+            // ---- AutoFlasher entry point (added for MP_AutoFlasher build) ----
+            // We attach a code-only LinkLabel so we don't have to touch the
+            // Designer.cs / .resx pipeline for every locale.
+            try
+            {
+                var autoFlashLink = new LinkLabel
+                {
+                    Text = "Auto-Flash (USB hot-plug)",
+                    AutoSize = true,
+                    Location = new System.Drawing.Point(8, 8),
+                    LinkBehavior = LinkBehavior.HoverUnderline,
+                    Anchor = AnchorStyles.Top | AnchorStyles.Left,
+                    Tag = "AutoFlasherLink",
+                };
+                autoFlashLink.LinkClicked += (s, e) =>
+                {
+                    try
+                    {
+                        using (var f = new AutoFlasher.AutoFlasherForm())
+                            f.ShowDialog(this.FindForm());
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Error("AutoFlasher launch failed", ex);
+                        CustomMessageBox.Show("AutoFlasher: " + ex.Message, "Erreur");
+                    }
+                };
+                this.Controls.Add(autoFlashLink);
+                autoFlashLink.BringToFront();
+            }
+            catch (Exception ex)
+            {
+                log.Warn("AutoFlasher link not added: " + ex.Message);
+            }
         }
 
         public void Activate()

--- a/Program.cs
+++ b/Program.cs
@@ -125,6 +125,27 @@ namespace MissionPlanner
         public static void Start(string[] args)
         {
             Program.args = args;
+
+            // ---- AutoFlasher build: force portable mode ------------------------
+            // Redirect ALL user-writable state into <exe>\PortableData\Mission Planner\
+            // so this build cannot touch the user's regular MP install
+            // (Documents\Mission Planner, AppData, ProgramData).
+            // This MUST run before any Settings.* call.
+            try
+            {
+                var portableRoot = System.IO.Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory, "PortableData");
+                System.IO.Directory.CreateDirectory(portableRoot);
+                MissionPlanner.Utilities.Settings.CustomUserDataDirectory = portableRoot;
+                Environment.SetEnvironmentVariable("APPDATA", portableRoot);
+                Environment.SetEnvironmentVariable("LOCALAPPDATA", portableRoot);
+                Console.WriteLine("Portable mode active. Data dir: " + portableRoot);
+            }
+            catch (Exception portEx)
+            {
+                Console.WriteLine("Portable mode setup failed: " + portEx.Message);
+            }
+
             Console.WriteLine(
                 "If your error is about Microsoft.DirectX.DirectInput, please install the latest directx redist from here http://www.microsoft.com/en-us/download/details.aspx?id=35 \n\n");
             Console.WriteLine("Debug under mono    MONO_LOG_LEVEL=debug mono MissionPlanner.exe");


### PR DESCRIPTION
## Summary

Adds a QGroundControl-style firmware flasher that **intercepts the STM32 bootloader on USB plug** instead of requiring the user to pre-select a COM port. The user picks the firmware first; on plug, a `WM_DEVICECHANGE` listener (plus a 250 ms WMI safety poll) races to open the virtual COM port and run `px4uploader.Uploader.identify()` before the user firmware boots and grabs the link.

The motivating use case is the recurring "comms timeout" failure mode on Cube Black / Pixhawk 2.1 where the existing flow can't catch the bootloader window reliably.

Also adds a **portable mode** that redirects all user-writable state to `<exe>\PortableData\` so this build can coexist with a regular Mission Planner install without polluting `Documents\Mission Planner`, `%APPDATA%`, or `%PROGRAMDATA%`.

## What changed

**New files** (auto-included by the SDK-style csproj, no .csproj edit needed):
- `GCSViews/ConfigurationView/AutoFlasher/BootloaderTargets.cs` — VID/PID table (3DR PX4, Cube Black/Orange/Orange+, ArduPilot generic, STM32 DFU)
- `GCSViews/ConfigurationView/AutoFlasher/UsbPlugListener.cs` — native `WM_DEVICECHANGE` via hidden `NativeWindow` + 250 ms WMI safety poll, callbacks dispatched on the captured `SynchronizationContext`
- `GCSViews/ConfigurationView/AutoFlasher/AutoFlasherService.cs` — orchestrator: on plug → 8-second bootloader window with port race + `Uploader.identify()` + `Uploader.upload(fw)`
- `GCSViews/ConfigurationView/AutoFlasher/AutoFlasherForm.cs` — code-only WinForms UI (no Designer.cs / .resx churn)

**Modified**:
- `Program.cs` — sets `Settings.CustomUserDataDirectory` and overrides `APPDATA`/`LOCALAPPDATA` at the very top of `Start()`, before any `Settings.*` call
- `GCSViews/ConfigurationView/ConfigFirmware.cs` — adds an `Auto-Flash (USB hot-plug)` `LinkLabel` via the constructor

## Why

The current `Firmware.UploadPX4` path depends on `AttemptRebootToBootloader()` succeeding, which fails when MAVLink is already broken. By inverting the flow (firmware first, then watch for the plug event), we can catch the bootloader during the natural fresh-boot window after a physical replug — the same approach QGC uses.

## Reviewer notes (please read)

- **This has not been tested against real hardware.** The build compiles cleanly via `MSBuild MissionPlanner.csproj /p:Configuration=Release`, but I do not have a Pixhawk on hand to validate the timing of the bootloader race. Consider this an RFC/draft until someone with hardware can verify the 8-second window is enough for Cube Black specifically.
- The `MissionPlanner.sln` build still depends on the `mono` submodule; this PR builds the main `MissionPlanner.csproj` directly, which is sufficient for the produced exe.
- The `LinkLabel` is added at `(8, 8)` in code; on some screen sizes it may overlap an existing `ImageLabel`. Trivial to reposition once the layout is reviewed.
- Defensive coding choices motivated by past `Sequence contains no elements` issues: `FirstOrDefault` on every VID/PID match, `TryIdentify` swallows `UnauthorizedAccessException` / `IOException` and retries other ports, WMI scans run on `Task.Run` (never on the message pump).
- Portable mode is **always on** in this branch. If merged as-is it would change behavior for everyone — the maintainer may want to gate it behind a sentinel file (e.g. `portable.txt` in startup dir) before merging.

## Test plan

- [ ] Compile: `MSBuild MissionPlanner.csproj /p:Configuration=Release` (verified locally, exit 0)
- [ ] Smoke launch: GUI starts, `PortableData\Mission Planner\` is created next to the exe
- [ ] Open *Initial Setup → Install Firmware*: confirm the new `Auto-Flash (USB hot-plug)` link is visible
- [ ] **Hardware test (not yet done)**: pick a `.apj`, click the link, replug a Cube Black, verify bootloader sync + flash within 8 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)