### PR TITLE
FlightPlanner: add DO_RETURN_PATH_START to mission editor

### DIFF
--- a/ExtLibs/Maps/WPOverlay.cs
+++ b/ExtLibs/Maps/WPOverlay.cs
@@ -69,7 +69,8 @@ namespace MissionPlanner.ArduPilot
                     command != (ushort) MAVLink.MAV_CMD.CONTINUE_AND_CHANGE_ALT &&
                     command != (ushort) MAVLink.MAV_CMD.DELAY &&
                     command != (ushort) MAVLink.MAV_CMD.GUIDED_ENABLE
-                    || command == (ushort) MAVLink.MAV_CMD.DO_SET_ROI || command == (ushort)MAVLink.MAV_CMD.DO_LAND_START)
+                    || command == (ushort) MAVLink.MAV_CMD.DO_SET_ROI || command == (ushort)MAVLink.MAV_CMD.DO_LAND_START
+                    || command == (ushort)MAVLink.MAV_CMD.DO_RETURN_PATH_START)
                 {
                     // land can be 0,0 or a lat,lng
                     if ((command == (ushort)MAVLink.MAV_CMD.LAND || command == (ushort)MAVLink.MAV_CMD.VTOL_LAND) && item.lat == 0 && item.lng == 0)

--- a/ExtLibs/Xamarin/Xamarin/Resources/mavcmd.xml
+++ b/ExtLibs/Xamarin/Xamarin/Resources/mavcmd.xml
@@ -300,6 +300,15 @@
       <Y></Y>
       <Z></Z>
     </DO_LAND_START>
+    <DO_RETURN_PATH_START>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_RETURN_PATH_START>
     <DO_MOUNT_CONTROL>
       <P1>Pitch</P1>
       <P2>Roll</P2>
@@ -699,6 +708,15 @@
       <Y>Long</Y>
       <Z></Z>
     </DO_LAND_START>
+    <DO_RETURN_PATH_START>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z></Z>
+    </DO_RETURN_PATH_START>
     <DO_SET_ROI>
       <P1></P1>
       <P2></P2>

--- a/mavcmd.xml
+++ b/mavcmd.xml
@@ -309,6 +309,15 @@
       <Y></Y>
       <Z></Z>
     </DO_LAND_START>
+    <DO_RETURN_PATH_START>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X></X>
+      <Y></Y>
+      <Z></Z>
+    </DO_RETURN_PATH_START>
     <DO_MOUNT_CONTROL>
       <P1>Pitch</P1>
       <P2>Roll</P2>
@@ -735,6 +744,15 @@
       <Y>Long</Y>
       <Z></Z>
     </DO_LAND_START>
+    <DO_RETURN_PATH_START>
+      <P1></P1>
+      <P2></P2>
+      <P3></P3>
+      <P4></P4>
+      <X>Lat</X>
+      <Y>Long</Y>
+      <Z></Z>
+    </DO_RETURN_PATH_START>
     <DO_SET_ROI>
       <P1></P1>
       <P2></P2>


### PR DESCRIPTION
DO_RETURN_PATH_START (MAV_CMD 188) was missing from mavcmd.xml, so the mission editor showed it as UNKNOWN and failed to load missions containing it. Add it to the AC2 and APM sections (matching DO_LAND_START) in both the main and Xamarin command lists, and render it on the map as a located waypoint when it carries a lat/lng.