### PR TITLE
Maint/deepclone and dpi fixes

### DIFF
--- a/ExtLibs/solo/solo.csproj
+++ b/ExtLibs/solo/solo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -27,7 +27,7 @@
     <PackageReference Include="Flurl.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2024.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -778,16 +778,18 @@ namespace MissionPlanner.GCSViews
 
         public T DeepClone<T>(T obj)
         {
-            using (var ms = new MemoryStream())
+            if (ReferenceEquals(obj, null))
+                return default;
+
+            var settings = new JsonSerializerSettings
             {
-                var formatter = new BinaryFormatter();
+                ObjectCreationHandling = ObjectCreationHandling.Replace,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                TypeNameHandling = TypeNameHandling.All
+            };
 
-                formatter.Serialize(ms, obj);
-
-                ms.Position = 0;
-
-                return (T) formatter.Deserialize(ms);
-            }
+            var json = JsonConvert.SerializeObject(obj, settings);
+            return JsonConvert.DeserializeObject<T>(json, settings);
         }
 
         /// <summary>

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -237,10 +237,8 @@
     <PackageReference Include="SharpDX" version="4.1.0" targetFramework="net462" />
     <PackageReference Include="SharpDX.DirectInput" version="4.1.0" targetFramework="net462" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies">
-      <Version>2.80.2</Version>
-    </PackageReference>
-    <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.8" />
     <PackageReference Include="SSH.NET" Version="2024.2.0" />
     <PackageReference Include="System.CodeDom">
       <Version>8.0.0</Version>

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <ApplicationIcon>mpdesktop.ico</ApplicationIcon>
@@ -241,7 +241,7 @@
       <Version>2.80.2</Version>
     </PackageReference>
     <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
-    <PackageReference Include="SSH.NET" version="2020.0.2" targetFramework="net40" />
+    <PackageReference Include="SSH.NET" Version="2024.2.0" />
     <PackageReference Include="System.CodeDom">
       <Version>8.0.0</Version>
     </PackageReference>

--- a/MissionPlannerLib.csproj
+++ b/MissionPlannerLib.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -507,7 +507,7 @@
    <PackageReference Include="TimeZoneConverter" Version="3.2.0" />
    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
-    <PackageReference Include="SSH.NET" version="2020.0.2" /> 
+    <PackageReference Include="SSH.NET" Version="2024.2.0" /> 
 	 <PackageReference Include="SharpDX" version="4.1.0" />
     <PackageReference Include="SharpDX.DirectInput" version="4.1.0" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" /> <PackageReference Include="Crc32.NET">

--- a/MissionPlannerLib.csproj
+++ b/MissionPlannerLib.csproj
@@ -497,8 +497,8 @@
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
    </PackageReference>
    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.12" />
-   <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.80.2" />
-   <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.2" />
+    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.88.8" />
    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
    <PackageReference Include="System.Reactive.Linq" Version="4.4.1" />
    <PackageReference Include="System.Runtime" Version="4.3.1" />
@@ -510,7 +510,7 @@
     <PackageReference Include="SSH.NET" Version="2024.2.0" /> 
 	 <PackageReference Include="SharpDX" version="4.1.0" />
     <PackageReference Include="SharpDX.DirectInput" version="4.1.0" />
-    <PackageReference Include="SkiaSharp" Version="2.80.2" /> <PackageReference Include="Crc32.NET">
+    <PackageReference Include="SkiaSharp" Version="2.88.8" /> <PackageReference Include="Crc32.NET">
       <Version>1.2.0</Version>
     </PackageReference>
     <PackageReference Include="CSMatIO" version="1.0.20" targetFramework="netstandard2.0" requireReinstallation="true" />

--- a/app.config
+++ b/app.config
@@ -120,4 +120,8 @@
       </providers>
     </roleManager>
   </system.web>
+  <System.Windows.Forms.ApplicationConfigurationSection xmlns="http://schemas.microsoft.com/System/Windows/Forms/2017/ConfigurationSection">
+    <add key="DpiAwareness" value="PerMonitorV2" />
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+  </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>


### PR DESCRIPTION
### Summary
This PR applies several codebase maintenance and modernization updates to Mission Planner:

1. **SSH.NET Upgrade**: Upgraded from `2020.0.2` to `2024.2.0` to support modern secure SSH key exchange algorithms (e.g., Ed25519) on Edison/Solo companion computers and fix legacy configuration parameters.
2. **SkiaSharp Alignment**: Aligned all SkiaSharp view and rendering packages (including Linux dependencies) to version `2.88.8` across the solution projects to resolve runtime library conflicts and DLL load warnings.
3. **Obsolete API Replacement**: Replaced `BinaryFormatter` in `FlightPlanner.DeepClone<T>` with a safe `Newtonsoft.Json` serializer to prevent serialization exceptions on modern .NET runtimes.
4. **Native High DPI Scaling**: Configured per-monitor High DPI scaling V2 in `app.config` to prevent UI blurriness and truncated labels on modern high-resolution screens.

### Verification
- Verified code API compatibility for all updated libraries.
- Verified that all projects compile cleanly.
