### PR TITLE
Custom drawing in HUD from plugin

### DIFF
--- a/ExtLibs/Controls/HUD.cs
+++ b/ExtLibs/Controls/HUD.cs
@@ -249,6 +249,11 @@ namespace MissionPlanner.Controls
 
         internal bool started = false;
 
+        /// <summary>
+        /// Custom paint events that will be called after the default paint.
+        /// </summary>
+        public event Action<HUD> OnCustomPaint;
+
         static HUD()
         {
             log.Info("Static HUD ctor");
@@ -3053,6 +3058,10 @@ namespace MissionPlanner.Controls
                                 item.Header + hrs.ToString("00") + ":" + mins.ToString("00") + ":" +
                                 secs.ToString("00"), font, fontsize + 2, _whiteBrush, this.Width / 8, height);
                         }
+                        else if (item.Item.Name == "string")
+                        {
+                            drawstring(item.Header, font, fontsize + 2, _whiteBrush, this.Width / 8, height);
+                        }
                         else
                         {
                             drawstring(item.Header + item.GetValue.ToString("0.##"), font, fontsize + 2,
@@ -3291,6 +3300,7 @@ namespace MissionPlanner.Controls
                         }
                     }
                 }
+                OnCustomPaint?.Invoke(this);
 
                 if (DesignMode)
                 {


### PR DESCRIPTION
This PR allows from plugin API to draw on HUD part of Mission Planner.
It changes one existing option and adds a whole new feature to draw on HUD.

## Support for string-typed CustomItems
Current state of CustomItems allowed to display only a small subset of numeric values. This simple change:
```c#
      else if (item.Item.Name == "string")
      {
          drawstring(item.Header, font, fontsize + 2, _whiteBrush, this.Width / 8, height);
      }
```
introduces the ability to renders a free-form text label supplied via Header.

## OnCustomPaint event
Added new public event:
```c#
public event Action<HUD> OnCustomPaint;
```
that is called after all HUD drawing that allows to draw anything:
```c#
internal void doPaint() {
  // ....
 // at the end of the default paint routine
  OnCustomPaint?.Invoke(this);
 // ...
}
```

## Affect on Mission Planner
Changes don't affect Mission Planner, because by default there are no `OnCustomPaint` events then this is an empty command. Same for ` if (item.Item.Name == "string")`.

## Usage in plugin
In a custom plugin we can register a drawing event:
```c#
public override bool Loaded() {
            Host.MainForm.FlightData.hud1.OnCustomPaint += Hud1_OnCustomPaint;
}

private void Hud1_OnCustomPaint(HUD hud) {
   // ... do some math
   hud.DrawString(text, StatusFontSize, brush ?? _whiteBrush, LeftOfEkfX, StatusIconsY);
}
```

## Possible improvements
It would be nice to have some computed values from class `HUD` like:
- `_whiteBrush`, `_redBrush`, `_orangeBrush`, `_whitePen` - to use the same colors like in the core HUD; expecially the `__whiteBrush, _whitePen` mutates depending on connection,
- `int fontsize = this.Height / 30;`, ``int fontoffset = fontsize - 10;` - this is simple, but a getter/function for this would be nice, to not copy code,
- some computed positions like `Int32[] yPos`, `int textIdx`.

But all of this can be reconstructed and this is not so important.
