### PR TITLE
Mavlink: update MAG_CAL_STATUS failure enums

### DIFF
--- a/ExtLibs/Mavlink/Mavlink.cs
+++ b/ExtLibs/Mavlink/Mavlink.cs
@@ -6012,12 +6012,21 @@ public partial class MAVLink
         ///<summary>  | </summary>
         [Description("")]
         MAG_CAL_FAILED=5, 
-        ///<summary>  | </summary>
-        [Description("")]
-        MAG_CAL_BAD_ORIENTATION=6, 
-        ///<summary>  | </summary>
-        [Description("")]
-        MAG_CAL_BAD_RADIUS=7, 
+        ///<summary> Compass calibration failed: the vehicle orientation is outside the required tolerance. | </summary>
+        [Description("Compass calibration failed: the vehicle orientation is outside the required tolerance.")]
+        MAG_CAL_FAILED_ORIENTATION=6, 
+        ///<summary> Compass calibration failed: the radius of the fitted sphere is unrealistically small or large. | </summary>
+        [Description("Compass calibration failed: the radius of the fitted sphere is unrealistically small or large.")]
+        MAG_CAL_FAILED_RADIUS=7, 
+        ///<summary> Compass calibration failed: offset magnitude too large. | </summary>
+        [Description("Compass calibration failed: offset magnitude too large.")]
+        MAG_CAL_FAILED_OFFSETS=8, 
+        ///<summary> Compass calibration failed: diagonal or off-diagonal scaling values out of valid range. | </summary>
+        [Description("Compass calibration failed: diagonal or off-diagonal scaling values out of valid range.")]
+        MAG_CAL_FAILED_DIAG_SCALING=9, 
+        ///<summary> Compass calibration failed: fitness (RMS residual) exceeds tolerance. | </summary>
+        [Description("Compass calibration failed: fitness (RMS residual) exceeds tolerance.")]
+        MAG_CAL_FAILED_RESIDUALS_HIGH=10, 
         
     };
     

--- a/ExtLibs/Mavlink/message_definitions/common.xml
+++ b/ExtLibs/Mavlink/message_definitions/common.xml
@@ -4142,8 +4142,21 @@
       <entry value="3" name="MAG_CAL_RUNNING_STEP_TWO"/>
       <entry value="4" name="MAG_CAL_SUCCESS"/>
       <entry value="5" name="MAG_CAL_FAILED"/>
-      <entry value="6" name="MAG_CAL_BAD_ORIENTATION"/>
-      <entry value="7" name="MAG_CAL_BAD_RADIUS"/>
+      <entry value="6" name="MAG_CAL_FAILED_ORIENTATION">
+        <description>Compass calibration failed: the vehicle orientation is outside the required tolerance.</description>
+      </entry>
+      <entry value="7" name="MAG_CAL_FAILED_RADIUS">
+        <description>Compass calibration failed: the radius of the fitted sphere is unrealistically small or large.</description>
+      </entry>
+      <entry value="8" name="MAG_CAL_FAILED_OFFSETS">
+        <description>Compass calibration failed: offset magnitude too large.</description>
+      </entry>
+      <entry value="9" name="MAG_CAL_FAILED_DIAG_SCALING">
+        <description>Compass calibration failed: diagonal or off-diagonal scaling values out of valid range.</description>
+      </entry>
+      <entry value="10" name="MAG_CAL_FAILED_RESIDUALS_HIGH">
+        <description>Compass calibration failed: fitness (RMS residual) exceeds tolerance.</description>
+      </entry>
     </enum>
     <enum name="CAN_FILTER_OP">
       <entry value="0" name="CAN_FILTER_REPLACE"/>


### PR DESCRIPTION
## Context

[AP_Compass: report specific failure reason when fit rejected (ardupilot#32757)](https://github.com/ArduPilot/ardupilot/pull/32757) extended ArduPilot's compass calibrator to emit a specific failure code in MAG_CAL_REPORT.cal_status instead of always returning the generic MAG_CAL_FAILED. Three new status values were added (8 = FAILED_OFFSETS, 9 = FAILED_DIAG_SCALING, 10 = FAILED_RESIDUALS_HIGH).

That required the MAVLink spec and every toolchain downstream of it to be updated:

1. **[mavlink/mavlink#2478](https://github.com/mavlink/mavlink/pull/2478)** — common.xml: rename MAG_CAL_BAD_ORIENTATION → MAG_CAL_FAILED_ORIENTATION, MAG_CAL_BAD_RADIUS → MAG_CAL_FAILED_RADIUS, add FAILED_OFFSETS / FAILED_DIAG_SCALING / FAILED_RESIDUALS_HIGH. **Merged Jun 2.**
2. **[ArduPilot/mavlink#506](https://github.com/ArduPilot/mavlink/pull/506)** — Sync the same change into the ArduPilot MAVLink fork. **Merged 2 weeks ago.**
3. **[ardupilot#33642](https://github.com/ArduPilot/ardupilot/pull/33642)** — Bump the ArduPilot mavlink submodule pointer to pick up the new enums. **Merged 2 weeks ago.**
4. **This PR** — Apply the same common.xml change to Mission Planner's vendored copy and update the generated Mavlink.cs enum block, so the GCS shows descriptive names instead of raw integers.

## Changes

- ExtLibs/Mavlink/message_definitions/common.xml — apply the 17-line diff from mavlink/mavlink#2478
- ExtLibs/Mavlink/Mavlink.cs — update the MAG_CAL_STATUS enum block to match

No other files are touched.

## Verification

dotnet build MissionPlanner.csproj -c Debug succeeds with 0 errors.