### PR TITLE
gps base: fix Septentrio automatic configuration for RTK base station (port detection)

### DIFF
--- a/ExtLibs/Utilities/Septentrio.cs
+++ b/ExtLibs/Utilities/Septentrio.cs
@@ -90,10 +90,11 @@ namespace MissionPlanner.Utilities
             receiverPort.WriteTimeout = 200;
  
             string activePort = await ConfigureBaudAndDetectPort(receiverPort);
-            log.Info($"Detected active port: {activePort}"); // debugging only
+            log.Info($"Detected active port: {activePort}");
 
             await SendAck(receiverPort, "setPVTMode,Static,All,Auto\n");
-            await SendAck(receiverPort, $"setDataInOut,{activePort},Auto,RTCMv3\n");
+            // Append +RTCMv3 output to preserve any existing streams already configured on this port
+            await SendAck(receiverPort, $"setDataInOut,{activePort},Auto,+RTCMv3\n");
         }
 
         /// <summary>
@@ -169,9 +170,11 @@ namespace MissionPlanner.Utilities
         /// <exception cref="FailedAckException" />
         public static Task SetEnabledRTCM(ICommsSerial receiverPort, RTCMLevel level, RTCMSignals signals)
         {
+            string activePort = LastDetectedPort;
+
             int messageLevel;
             string messages = "RTCM1006+RTCM1033+RTCM1230";
-
+            
             switch (level)
             {
                 case RTCMLevel.Lite:
@@ -195,9 +198,6 @@ namespace MissionPlanner.Utilities
             if ((signals & RTCMSignals.Beidou) == RTCMSignals.Beidou)
                 messages += "+RTCM112" + messageLevel;
 
-            string activePort = LastDetectedPort;
-            log.Info($"RTCMv3 output on: {activePort} with {messages} messages"); // debugging only
-
             return SendAck(receiverPort, $"setRTCMv3Output,{activePort},{messages}\n");
         }
 
@@ -208,7 +208,6 @@ namespace MissionPlanner.Utilities
         /// <exception cref="IOException" />
         public static async Task<string> DetectPort(ICommsSerial receiverPort)
         {
-
             // Clear any stale unread incoming bytes
             if (receiverPort.BytesToRead > 0)
             {
@@ -217,7 +216,7 @@ namespace MissionPlanner.Utilities
 
             await receiverPort.BaseStream.FlushAsync();
 
-            // Send ping command (gecm: getEchoMessage)
+            // Send ping command (gecm / getEchoMessage)
             byte[] pingBytes = Encoding.ASCII.GetBytes("gecm\n");
             await receiverPort.BaseStream.WriteAsync(pingBytes, 0, pingBytes.Length);
 
@@ -265,8 +264,6 @@ namespace MissionPlanner.Utilities
                 // Prevent busy-waiting and wait for serial data 
                 await Task.Delay(20);
             }
-
-            log.Info("DetectPort ACK timeout"); // debugging only
 
             // Default fallback if no active port is detected within the timeout
             return LastDetectedPort;

--- a/ExtLibs/Utilities/Septentrio.cs
+++ b/ExtLibs/Utilities/Septentrio.cs
@@ -3,6 +3,7 @@ using MissionPlanner.Comms;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace MissionPlanner.Utilities
@@ -16,6 +17,11 @@ namespace MissionPlanner.Utilities
         /// An exception representing a missing acknowledgement.
         /// </summary>
         public class FailedAckException : Exception { }
+
+        /// <summary>
+        /// Cache of the last detected receiver port name. 
+        /// </summary>
+        public static string LastDetectedPort { get; set; } = "USB1+USB2+COM1+COM2";
 
         /// <summary>
         /// Selection of messages from what MSM level to output.
@@ -82,11 +88,12 @@ namespace MissionPlanner.Utilities
             receiverPort.BaudRate = 115200;
             receiverPort.ReadTimeout = 200;
             receiverPort.WriteTimeout = 200;
-
-            await ConfigureBaud(receiverPort);
+ 
+            string activePort = await ConfigureBaudAndDetectPort(receiverPort);
+            log.Info($"Detected active port: {activePort}"); // debugging only
 
             await SendAck(receiverPort, "setPVTMode,Static,All,Auto\n");
-            await SendAck(receiverPort, "setDataInOut,USB1+USB2+COM1+COM2+COM3,Auto,RTCMv3\n");
+            await SendAck(receiverPort, $"setDataInOut,{activePort},Auto,RTCMv3\n");
         }
 
         /// <summary>
@@ -113,12 +120,17 @@ namespace MissionPlanner.Utilities
         }
 
         /// <summary>
-        /// Configure the baud rate of the serial port. In case the receiver is connected over serial, this automatically sets the correct baud rate.
+        /// Configure the baud rate of the serial port and detect the active port on the receiver side. In case the receiver is connected over serial, this automatically sets the correct baud rate.
         /// </summary>
+        /// <returns>The detected active port name or the default port string if auto-detection falls back.</returns>
         /// <exception cref="FailedAckException" />
-        private static async Task ConfigureBaud(ICommsSerial receiverPort)
+        /// <exception cref="IOException" />
+        private static async Task<string> ConfigureBaudAndDetectPort(ICommsSerial receiverPort)
         {
             bool receiverAcknowledged = false;
+
+            // Default fallback ports we expect the receiver to be connected to
+            string detectedPort = LastDetectedPort;
 
             // All the baud rates we expect the receiver could be running at
             var bauds = new[] { receiverPort.BaudRate, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800 };
@@ -126,11 +138,19 @@ namespace MissionPlanner.Utilities
             foreach (var baud in bauds)
             {
                 receiverPort.BaudRate = baud;
-                
+
                 // Try to set the port settings on a best effort basis
                 try
                 {
-                    await SendAck(receiverPort, "setCOMSettings,COM1+COM2+COM3,baud"+DefaultBaudrate+",bits8,No,bit1,none\n");
+                    // Detect active port directly on established connection
+                    detectedPort = await DetectPort(receiverPort);
+
+                    // Skip setCOMSettings command for USB connections
+                    if (!detectedPort.Contains("USB"))
+                    {
+                        await SendAck(receiverPort, $"setCOMSettings,{detectedPort},baud{DefaultBaudrate},bits8,No,bit1,none\n");
+                    }
+
                     receiverAcknowledged = true;
                     break;
                 } catch { }
@@ -140,6 +160,7 @@ namespace MissionPlanner.Utilities
                 throw new FailedAckException();
 
             receiverPort.BaudRate = DefaultBaudrate;
+            return detectedPort;
         }
 
         /// <summary>
@@ -150,7 +171,7 @@ namespace MissionPlanner.Utilities
         {
             int messageLevel;
             string messages = "RTCM1006+RTCM1033+RTCM1230";
-            
+
             switch (level)
             {
                 case RTCMLevel.Lite:
@@ -174,7 +195,81 @@ namespace MissionPlanner.Utilities
             if ((signals & RTCMSignals.Beidou) == RTCMSignals.Beidou)
                 messages += "+RTCM112" + messageLevel;
 
-            return SendAck(receiverPort, $"setRTCMv3Output,COM1+COM2+COM3+USB1+USB2,{messages}\n");
+            string activePort = LastDetectedPort;
+            log.Info($"RTCMv3 output on: {activePort} with {messages} messages"); // debugging only
+
+            return SendAck(receiverPort, $"setRTCMv3Output,{activePort},{messages}\n");
+        }
+
+        /// <summary>
+        /// Detect the active port on the receiver side. 
+        /// </summary>
+        /// <returns>The detected active port name or the default port string if auto-detection falls back.</returns>
+        /// <exception cref="IOException" />
+        public static async Task<string> DetectPort(ICommsSerial receiverPort)
+        {
+
+            // Clear any stale unread incoming bytes
+            if (receiverPort.BytesToRead > 0)
+            {
+                receiverPort.DiscardInBuffer();
+            }
+
+            await receiverPort.BaseStream.FlushAsync();
+
+            // Send ping command (gecm: getEchoMessage)
+            byte[] pingBytes = Encoding.ASCII.GetBytes("gecm\n");
+            await receiverPort.BaseStream.WriteAsync(pingBytes, 0, pingBytes.Length);
+
+            Stopwatch sw = Stopwatch.StartNew();
+            StringBuilder buffer = new StringBuilder();
+            // 256 bytes should be enough to read the prompt and the active port name
+            byte[] readBuf = new byte[256];
+
+            while (sw.ElapsedMilliseconds < AckTimeout)
+            {
+                if (receiverPort.BytesToRead > 0)
+                {
+                    int bytesRead = await receiverPort.BaseStream.ReadAsync(readBuf, 0, readBuf.Length);
+                    if (bytesRead > 0)
+                    {
+                        // Clean up non-printable characters or null bytes if needed
+                        string incoming = Encoding.ASCII.GetString(readBuf, 0, bytesRead);
+                        buffer.Append(incoming);
+
+                        string currentText = buffer.ToString();
+                        int promptIdx = currentText.IndexOf('>');
+
+                        if (promptIdx >= 3)
+                        {
+                            // Look back 4 characters before '>'
+                            int start = Math.Max(0, promptIdx - 4);
+                            string candidate = currentText.Substring(start, promptIdx - start);
+
+                            // Limit the candidate to serial and USB port names (COMx or USBx)
+                            if (candidate.Contains("COM"))
+                            {
+                                int idx = candidate.IndexOf("COM");
+                                LastDetectedPort = candidate.Substring(idx);
+                                return LastDetectedPort;
+                            }
+                            else if (candidate.Contains("USB"))
+                            {
+                                int idx = candidate.IndexOf("USB");
+                                LastDetectedPort = candidate.Substring(idx);
+                                return LastDetectedPort;
+                            }
+                        }
+                    }
+                }
+                // Prevent busy-waiting and wait for serial data 
+                await Task.Delay(20);
+            }
+
+            log.Info("DetectPort ACK timeout"); // debugging only
+
+            // Default fallback if no active port is detected within the timeout
+            return LastDetectedPort;
         }
 
         /// <summary>

--- a/ExtLibs/Utilities/Septentrio.cs
+++ b/ExtLibs/Utilities/Septentrio.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace MissionPlanner.Utilities
@@ -237,27 +238,14 @@ namespace MissionPlanner.Utilities
                         buffer.Append(incoming);
 
                         string currentText = buffer.ToString();
-                        int promptIdx = currentText.IndexOf('>');
 
-                        if (promptIdx >= 3)
+                        // Match serial and USB port names (COMx or USBx) directly preceding the '>' prompt character
+                        var match = Regex.Match(currentText, @"(COM\d+|USB\d+)\s*>");
+                        if (match.Success)
                         {
-                            // Look back 4 characters before '>'
-                            int start = Math.Max(0, promptIdx - 4);
-                            string candidate = currentText.Substring(start, promptIdx - start);
-
-                            // Limit the candidate to serial and USB port names (COMx or USBx)
-                            if (candidate.Contains("COM"))
-                            {
-                                int idx = candidate.IndexOf("COM");
-                                LastDetectedPort = candidate.Substring(idx);
-                                return LastDetectedPort;
-                            }
-                            else if (candidate.Contains("USB"))
-                            {
-                                int idx = candidate.IndexOf("USB");
-                                LastDetectedPort = candidate.Substring(idx);
-                                return LastDetectedPort;
-                            }
+                            // Extract active port name (e.g., COM1 or USB1)
+                            LastDetectedPort = match.Groups[1].Value;
+                            return LastDetectedPort;
                         }
                     }
                 }
@@ -265,7 +253,7 @@ namespace MissionPlanner.Utilities
                 await Task.Delay(20);
             }
 
-            // Default fallback if no active port is detected within the timeout
+            // Fallback if no active port is detected within the timeout window
             return LastDetectedPort;
         }
 

--- a/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
+++ b/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
@@ -1548,12 +1548,6 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         /// <exception cref="InvalidOperationException" />
         private async Task UpdateSeptentrioRTCMSettings()
         { 
-
-            if (comPort == null || !comPort.IsOpen)
-            {
-                return;
-            }
-
             Utilities.Septentrio.RTCMSignals signals = Utilities.Septentrio.RTCMSignals.None;
             Utilities.Septentrio.RTCMLevel level;
             float rtcmInterval;

--- a/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
+++ b/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
@@ -554,6 +554,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             this.LogInfo("Setup Septentrio");
 
+            // Reset port cache before detecting a new connection
+            Utilities.Septentrio.LastDetectedPort = "USB1+USB2+COM1+COM2";
+
             try
             {
                 await Utilities.Septentrio.ConfigureBaseReceiver(comPort);
@@ -1544,7 +1547,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         /// <exception cref="FormatException" />
         /// <exception cref="InvalidOperationException" />
         private async Task UpdateSeptentrioRTCMSettings()
-        {
+        { 
+
+            if (comPort == null || !comPort.IsOpen)
+            {
+                return;
+            }
+
             Utilities.Septentrio.RTCMSignals signals = Utilities.Septentrio.RTCMSignals.None;
             Utilities.Septentrio.RTCMLevel level;
             float rtcmInterval;


### PR DESCRIPTION
## Issue 

This pull request resolves an issue with port availability disparities across different Septentrio receivers when automatically configuring a receiver as an RTK base station for injecting corrections.

This feature was originally introduced in [PR #3324](https://github.com/ArduPilot/MissionPlanner/pull/3324).

In the initial implementation, a static set of ports was defined for RTCM stream outputs (RTK correction data):
```
USB1+USB2+COM1+COM2+COM3
```

However, hard-coding this list of ports raises two issues: 
- **Hardware differences between receivers:** For example, Mosaic-H receivers provide serial ports `USB1+USB2+COM1+COM2+COM3+COM4`, whereas Mosaic-G5 receivers only support `USB1+USB2+COM1+COM2`. Attempting to target non-existent ports like `COM3` on a Mosaic-G5 receiver will result in a command error, causing the automatic configuration to fail.
- **Unnecessary multi-port output:** Only one port is actively used to stream corrections. Unnecessarily broadcasting RTCM messages across unused ports can interfere with ports already reserved for other communications or setups.

## Proposal 

This PR introduces dynamic port detection to identify the active port used by the receiver to communicate with Mission Planner. This ensures that auto-configuration works reliably across all Septentrio receivers, regardless of their specific hardware port layout.

To achieve this, a ping command (`gecm` / `getEchoMessage`) is sent to the receiver, and the active port name is parsed directly from the prompt line in the response (e.g., `USB1>`), which is structured as follows:
```
$R: gecm
  EchoMessage [...]
USB1>
```
Since detection is powered by regular expressions, port names containing single or multi-digit identifiers (e.g., `COM10`) are dynamically matched for future-proof compatibility.

The detected port name is cached in `LastDetectedPort` for the duration of the active connection session (initialized during base receiver setup). This eliminates redundant detection cycles during subsequent configuration calls (such as adjusting RTCM message intervals or constellation selections).

If dynamic port detection fails or times out during setup, it gracefully falls back to targeting:
```
USB1+USB2+COM1+COM2
```
These four interfaces cover the standard default ports across Septentrio Mosaic receivers.

## Testing executed

This fix has been tested and validated using the following hardware and software setup:
- **Flight controller:** Cube Orange+
- **Autopilot firmware:** ArduCopter v4.7.0
- **Ground control station:** Mission Planner v1.3.83 from the `fix-septentrio-base-autoconfig` branch
- **Primary receiver (vehicle):** Septentrio Mosaic-G5 
- **RTK base receivers tested (GCS serial/USB):** Septentrio Mosaic-G5 and Mosaic-H
