### PR TITLE
Rework MAVLink dataflash log download: reliability, cancellation, and tests

### DIFF
--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -6218,6 +6218,21 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             }
             catch
             {
+                // tell the vehicle to stop streaming - an abandoned download otherwise
+                // keeps LOG_DATA flowing and breaks the next log operation
+                try
+                {
+                    var end = new mavlink_log_request_end_t
+                    {
+                        target_system = sysid,
+                        target_component = compid
+                    };
+                    generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_END, end);
+                }
+                catch
+                {
+                }
+
                 // dont leave a partial file behind on timeout/cancel/link loss
                 try
                 {

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -6015,6 +6015,23 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             };
             OnPacketReceived += handler;
 
+            // formally end the log session; best effort - the link may already be gone
+            void SendLogRequestEnd()
+            {
+                try
+                {
+                    var end = new mavlink_log_request_end_t
+                    {
+                        target_system = sysid,
+                        target_component = compid
+                    };
+                    generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_END, end);
+                }
+                catch
+                {
+                }
+            }
+
             try
             {
                 using (FileStream ms = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite))
@@ -6080,6 +6097,10 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 var data = buffer.ToStructure<mavlink_log_data_t>();
 
                                 if (data.id != no)
+                                    continue;
+
+                                // a corrupt count would overrun the fixed 90-byte payload
+                                if (data.count > data.data.Length)
                                     continue;
 
                                 // reset retrys
@@ -6155,11 +6176,17 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                         generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
                     }
 
+                    // the same total silence budget as the streaming phase - a vehicle
+                    // that stops answering fill-in requests must not hang the download
+                    int dryWindows = 0;
+                    int maxDryWindows = Math.Max(1, LogDataTimeoutMs * 3 / Math.Max(1, LogDataRefetchMs));
+
                     while ((BaseStream != null && BaseStream.IsOpen) || logreadmode)
                     {
                         if (ms.Length >= totallength && lowestMissing >= totalBlocks)
                         {
                             giveComport = false;
+                            SendLogRequestEnd();
                             return filename;
                         }
 
@@ -6167,9 +6194,17 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                         // the current request ran dry - ask for what is still missing
                         if (!await queueSignal.WaitAsync(LogDataRefetchMs, cancel).ConfigureAwait(false))
                         {
+                            if (++dryWindows > maxDryWindows)
+                            {
+                                giveComport = false;
+                                throw new TimeoutException("Timeout on read - GetLog fill-in");
+                            }
+
                             RequestFirstMissing();
                             continue;
                         }
+
+                        dryWindows = 0;
 
                         if (!queue.TryDequeue(out buffer))
                             continue;
@@ -6182,6 +6217,15 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 var data = buffer.ToStructure<mavlink_log_data_t>();
 
                                 if (data.id != no)
+                                    continue;
+
+                                // a corrupt count would overrun the fixed 90-byte payload
+                                if (data.count > data.data.Length)
+                                    continue;
+
+                                // fill-in data must stay inside the log bounds established by
+                                // the streaming phase - a bogus offset must not extend the file
+                                if ((ulong) data.ofs + data.count > totallength)
                                     continue;
 
                                 bps += data.count;
@@ -6225,20 +6269,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             {
                 // tell the vehicle to stop streaming - an abandoned download otherwise
                 // keeps LOG_DATA flowing and breaks the next log operation
-                try
-                {
-                    var end = new mavlink_log_request_end_t
-                    {
-                        target_system = sysid,
-                        target_component = compid
-                    };
-                    generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_END, end);
-                }
-                catch
-                {
-                }
+                SendLogRequestEnd();
 
-                // dont leave a partial file behind on timeout/cancel/link loss
+                // don't leave a partial file behind on timeout/cancel/link loss
                 try
                 {
                     File.Delete(filename);

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -5974,10 +5974,23 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             return new FileStream(await GetLog(MAV.sysid, MAV.compid, no), FileMode.Open, FileAccess.ReadWrite);
         }
 
-        public async Task<string> GetLog(byte sysid, byte compid, ushort no, CancellationToken cancel = default)
-        {
-            var filename = Path.GetTempFileName();
+        /// <summary>GetLog: ms of LOG_DATA silence before the request is retried</summary>
+        internal int LogDataTimeoutMs { get; set; } = 3000;
 
+        /// <summary>GetLog: ms of LOG_DATA silence before missing blocks are re-requested</summary>
+        internal int LogDataRefetchMs { get; set; } = 500;
+
+        public Task<string> GetLog(byte sysid, byte compid, ushort no, CancellationToken cancel = default)
+        {
+            return GetLogInternal(sysid, compid, no, Path.GetTempFileName(), cancel);
+        }
+
+        /// <summary>
+        /// Download log <paramref name="no"/> into <paramref name="filename"/>. The file is
+        /// created (or truncated), and deleted again on failure or cancellation.
+        /// </summary>
+        internal async Task<string> GetLogInternal(byte sysid, byte compid, ushort no, string filename, CancellationToken cancel)
+        {
             ConcurrentQueue<MAVLinkMessage> queue = new ConcurrentQueue<MAVLinkMessage>();
             SemaphoreSlim queueSignal = new SemaphoreSlim(0);
             EventHandler<MAVLinkMessage> handler = (sender, msg) =>
@@ -6036,8 +6049,8 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                     while (true)
                     {
                         // park until the handler queues a LOG_DATA packet
-                        // false means 3s of silence - resend the request
-                        if (!await queueSignal.WaitAsync(3000, cancel).ConfigureAwait(false))
+                        // false means LogDataTimeoutMs of silence - resend the request
+                        if (!await queueSignal.WaitAsync(LogDataTimeoutMs, cancel).ConfigureAwait(false))
                         {
                             if (retrys > 0)
                             {
@@ -6145,9 +6158,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                             return filename;
                         }
 
-                        // park until more data arrives; 500ms of silence means the
-                        // current request ran dry - ask for what is still missing
-                        if (!await queueSignal.WaitAsync(500, cancel).ConfigureAwait(false))
+                        // park until more data arrives; LogDataRefetchMs of silence means
+                        // the current request ran dry - ask for what is still missing
+                        if (!await queueSignal.WaitAsync(LogDataRefetchMs, cancel).ConfigureAwait(false))
                         {
                             RequestFirstMissing();
                             continue;
@@ -6205,7 +6218,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             }
             catch
             {
-                // dont leave a partial temp file behind on timeout/cancel/link loss
+                // dont leave a partial file behind on timeout/cancel/link loss
                 try
                 {
                     File.Delete(filename);

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -5979,7 +5979,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             var filename = Path.GetTempFileName();
 
             ConcurrentQueue<MAVLinkMessage> queue = new ConcurrentQueue<MAVLinkMessage>();
-            SemaphoreSlim queuesignal = new SemaphoreSlim(0);
+            SemaphoreSlim queueSignal = new SemaphoreSlim(0);
             EventHandler<MAVLinkMessage> handler = (sender, msg) =>
             {
                 if (msg.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA)
@@ -5987,7 +5987,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                     queue.Enqueue(msg);
                     try
                     {
-                        queuesignal.Release();
+                        queueSignal.Release();
                     }
                     catch (ObjectDisposedException)
                     {
@@ -6001,9 +6001,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             {
                 using (FileStream ms = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite))
                 {
-                    // received 90-byte block numbers; every block below lowestmissing is known received
+                    // received 90-byte block numbers; every block below lowestMissing is known received
                     HashSet<uint> set = new HashSet<uint>();
-                    uint lowestmissing = 0;
+                    uint lowestMissing = 0;
 
                     giveComport = false;
                     MAVLinkMessage buffer = MAVLinkMessage.Invalid;
@@ -6014,7 +6014,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                     }
 
                     uint totallength = 0;
-                    uint maxend = 0;
+                    uint maxEnd = 0;
                     uint ofs = 0;
                     uint bps = 0;
                     DateTime bpstimer = DateTime.Now;
@@ -6031,21 +6031,18 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                     // request point
                     generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
 
-                    DateTime start = DateTime.Now;
                     int retrys = 3;
-
 
                     while (true)
                     {
-                        cancel.ThrowIfCancellationRequested();
-
-                        if (!(start.AddMilliseconds(3000) > DateTime.Now))
+                        // park until the handler queues a LOG_DATA packet
+                        // false means 3s of silence - resend the request
+                        if (!await queueSignal.WaitAsync(3000, cancel).ConfigureAwait(false))
                         {
                             if (retrys > 0)
                             {
                                 log.Info("GetLog Retry " + retrys + " - giv com " + giveComport);
                                 generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
-                                start = DateTime.Now;
                                 retrys--;
                                 continue;
                             }
@@ -6055,11 +6052,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                         }
 
                         if (!queue.TryDequeue(out buffer))
-                        {
-                            // wait for the next LOG_DATA packet instead of polling
-                            await queuesignal.WaitAsync(100, cancel).ConfigureAwait(false);
                             continue;
-                        }
 
                         if (buffer.Length > 5)
                         {
@@ -6073,15 +6066,14 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                                 // reset retrys
                                 retrys = 3;
-                                start = DateTime.Now;
 
                                 bps += data.count;
 
                                 // record what we have received
                                 set.Add(data.ofs / 90);
-                                while (set.Contains(lowestmissing))
-                                    lowestmissing++;
-                                maxend = Math.Max(maxend, data.ofs + data.count);
+                                while (set.Contains(lowestMissing))
+                                    lowestMissing++;
+                                maxEnd = Math.Max(maxEnd, data.ofs + data.count);
 
                                 if (ms.Position != data.ofs)
                                     ms.Seek((long) data.ofs, SeekOrigin.Begin);
@@ -6104,9 +6096,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                                 // a short or empty packet ends the log, but only trust it at the highest
                                 // offset seen - a reordered short packet must not truncate the download
-                                if (data.count < 90 && data.ofs + data.count >= maxend)
+                                if (data.count < 90 && data.ofs + data.count >= maxEnd)
                                 {
-                                    totallength = maxend;
+                                    totallength = maxEnd;
                                     log.Info("start fillin len " + totallength + " count " + set.Count + " datalen " +
                                              data.count);
                                     break;
@@ -6115,52 +6107,54 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                         }
                     }
 
-                    // blocks 0..totalblocks-1 must all be present before the download is complete
-                    uint totalblocks = (totallength + 89) / 90;
+                    // blocks 0..totalBlocks-1 must all be present before the download is complete
+                    uint totalBlocks = (totallength + 89) / 90;
 
                     log.Info("set count " + set.Count);
-                    log.Info("count total " + totalblocks);
+                    log.Info("count total " + totalBlocks);
                     log.Info("totallength " + totallength);
                     log.Info("current length " + ms.Length);
 
+                    // request the first run of still-missing blocks
+                    void RequestFirstMissing()
+                    {
+                        if (lowestMissing >= totalBlocks)
+                            return;
+
+                        // request large chunk if they are back to back
+                        uint bytereq = 90;
+                        uint b = lowestMissing + 1;
+                        while (b < totalBlocks && !set.Contains(b))
+                        {
+                            bytereq += 90;
+                            b++;
+                        }
+
+                        req.ofs = lowestMissing * 90;
+                        req.count = bytereq;
+                        log.Info("req missing " + req.ofs + " bytes " + req.count + " got " + set.Count + "/" +
+                                 totalBlocks);
+                        generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
+                    }
+
                     while ((BaseStream != null && BaseStream.IsOpen) || logreadmode)
                     {
-                        cancel.ThrowIfCancellationRequested();
-
-                        if (ms.Length >= totallength && lowestmissing >= totalblocks)
+                        if (ms.Length >= totallength && lowestMissing >= totalBlocks)
                         {
                             giveComport = false;
                             return filename;
                         }
 
-                        if (!(start.AddMilliseconds(500) > DateTime.Now))
+                        // park until more data arrives; 500ms of silence means the
+                        // current request ran dry - ask for what is still missing
+                        if (!await queueSignal.WaitAsync(500, cancel).ConfigureAwait(false))
                         {
-                            if (lowestmissing < totalblocks)
-                            {
-                                // request large chunk if they are back to back
-                                uint bytereq = 90;
-                                uint b = lowestmissing + 1;
-                                while (b < totalblocks && !set.Contains(b))
-                                {
-                                    bytereq += 90;
-                                    b++;
-                                }
-
-                                req.ofs = lowestmissing * 90;
-                                req.count = bytereq;
-                                log.Info("req missing " + req.ofs + " bytes " + req.count + " got " + set.Count + "/" +
-                                         totalblocks);
-                                generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
-                                start = DateTime.Now;
-                            }
+                            RequestFirstMissing();
+                            continue;
                         }
 
                         if (!queue.TryDequeue(out buffer))
-                        {
-                            // wait for the next LOG_DATA packet instead of polling
-                            await queuesignal.WaitAsync(100, cancel).ConfigureAwait(false);
                             continue;
-                        }
 
                         if (buffer.Length > 5)
                         {
@@ -6172,16 +6166,12 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 if (data.id != no)
                                     continue;
 
-                                // reset retrys
-                                retrys = 3;
-                                start = DateTime.Now;
-
                                 bps += data.count;
 
                                 // record what we have received
                                 set.Add(data.ofs / 90);
-                                while (set.Contains(lowestmissing))
-                                    lowestmissing++;
+                                while (set.Contains(lowestMissing))
+                                    lowestMissing++;
 
                                 ms.Seek((long) data.ofs, SeekOrigin.Begin);
                                 ms.Write(data.data, 0, data.count);
@@ -6201,11 +6191,11 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                     bps = 0;
                                 }
 
-                                // check if we have next set and invalidate to request next packets
+                                // this fill run has caught up to data we already hold -
+                                // request the next missing run now instead of waiting
+                                // out the 500ms silence
                                 if (set.Contains((data.ofs / 90) + 1))
-                                {
-                                    start = DateTime.MinValue;
-                                }
+                                    RequestFirstMissing();
                             }
                         }
                     }
@@ -6229,7 +6219,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             finally
             {
                 OnPacketReceived -= handler;
-                queuesignal.Dispose();
+                queueSignal.Dispose();
             }
         }
 

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -6039,6 +6039,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                     // received 90-byte block numbers; every block below lowestMissing is known received
                     HashSet<uint> set = new HashSet<uint>();
                     uint lowestMissing = 0;
+                    // how far past the contiguous frontier a packet may sit and still raise
+                    // the end-of-log bar; genuine streams are near-contiguous
+                    const uint endDetectionSlack = 90 * 100;
 
                     giveComport = false;
                     MAVLinkMessage buffer = MAVLinkMessage.Invalid;
@@ -6112,7 +6115,11 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 set.Add(data.ofs / 90);
                                 while (set.Contains(lowestMissing))
                                     lowestMissing++;
-                                maxEnd = Math.Max(maxEnd, data.ofs + data.count);
+                                // only packets near the contiguous frontier raise the bar the
+                                // end packet must clear - a corrupt far offset must not poison
+                                // end-of-log detection for the whole download
+                                if (data.ofs <= (ulong) lowestMissing * 90 + endDetectionSlack)
+                                    maxEnd = Math.Max(maxEnd, data.ofs + data.count);
 
                                 if (ms.Position != data.ofs)
                                     ms.Seek((long) data.ofs, SeekOrigin.Begin);
@@ -6134,10 +6141,12 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 }
 
                                 // a short or empty packet ends the log, but only trust it at the highest
-                                // offset seen - a reordered short packet must not truncate the download
+                                // offset seen - a reordered short packet must not truncate the download.
+                                // the length comes from the end packet itself: the bar can lag behind
+                                // a stalled frontier and must not stand in for the real log length
                                 if (data.count < 90 && data.ofs + data.count >= maxEnd)
                                 {
-                                    totallength = maxEnd;
+                                    totallength = data.ofs + data.count;
                                     log.Info("start fillin len " + totallength + " count " + set.Count + " datalen " +
                                              data.count);
                                     break;
@@ -6153,6 +6162,11 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                     log.Info("count total " + totalBlocks);
                     log.Info("totallength " + totallength);
                     log.Info("current length " + ms.Length);
+
+                    // a corrupt far-offset packet in the streaming phase may have grown the
+                    // file past the log - the returned file must not be longer than the log
+                    if (ms.Length > totallength)
+                        ms.SetLength(totallength);
 
                     // request the first run of still-missing blocks
                     void RequestFirstMissing()
@@ -6231,7 +6245,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 bps += data.count;
 
                                 // record what we have received
-                                set.Add(data.ofs / 90);
+                                var newBlock = set.Add(data.ofs / 90);
                                 while (set.Contains(lowestMissing))
                                     lowestMissing++;
 
@@ -6255,8 +6269,10 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                                 // this fill run has caught up to data we already hold -
                                 // request the next missing run now instead of waiting
-                                // out the 500ms silence
-                                if (set.Contains((data.ofs / 90) + 1))
+                                // out the 500ms silence. only a newly received block may
+                                // trigger this: stale or duplicated packets must not each
+                                // fire another request on a duplicating link
+                                if (newBlock && set.Contains((data.ofs / 90) + 1))
                                     RequestFirstMissing();
                             }
                         }

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -6053,6 +6053,9 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
 
                     uint totallength = 0;
                     uint maxEnd = 0;
+                    // end-of-log candidate from a short packet past the trusted window,
+                    // kept only while nothing arrives after it
+                    uint pendingEnd = 0;
                     uint ofs = 0;
                     uint bps = 0;
                     DateTime bpstimer = DateTime.Now;
@@ -6077,6 +6080,18 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                         // false means LogDataTimeoutMs of silence - resend the request
                         if (!await queueSignal.WaitAsync(LogDataTimeoutMs, cancel).ConfigureAwait(false))
                         {
+                            // the stream went quiet right after an end candidate from past the
+                            // trusted window - that silence is the missing evidence: a corrupt
+                            // packet is followed by more stream, the real end of log is not.
+                            // accept it and let the fill-in phase repair the gaps
+                            if (pendingEnd > 0)
+                            {
+                                totallength = Math.Max(pendingEnd, maxEnd);
+                                log.Info("start fillin len " + totallength + " count " + set.Count +
+                                         " (end past stalled frontier)");
+                                break;
+                            }
+
                             if (retrys > 0)
                             {
                                 log.Info("GetLog Retry " + retrys + " - giv com " + giveComport);
@@ -6106,19 +6121,21 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 if (data.count > data.data.Length)
                                     continue;
 
-                                // reset retrys
-                                retrys = 3;
-
                                 bps += data.count;
 
                                 // record what we have received
-                                set.Add(data.ofs / 90);
+                                bool newBlock = set.Add(data.ofs / 90);
                                 while (set.Contains(lowestMissing))
                                     lowestMissing++;
-                                // only packets near the contiguous frontier raise the bar the
-                                // end packet must clear - a corrupt far offset must not poison
-                                // end-of-log detection for the whole download
-                                if (data.ofs <= (ulong) lowestMissing * 90 + endDetectionSlack)
+                                // only fresh data earns more patience - a packet resent every
+                                // retry window must not keep the streaming phase alive forever
+                                if (newBlock)
+                                    retrys = 3;
+                                // only packets near the contiguous frontier are trusted with
+                                // protocol state - a corrupt far offset must not raise the
+                                // end-of-log bar, move the retry offset or end the download
+                                bool nearFrontier = data.ofs <= (ulong) lowestMissing * 90 + endDetectionSlack;
+                                if (nearFrontier)
                                     maxEnd = Math.Max(maxEnd, data.ofs + data.count);
 
                                 if (ms.Position != data.ofs)
@@ -6126,7 +6143,8 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                 ms.Write(data.data, 0, data.count);
 
                                 // update new start point
-                                req.ofs = data.ofs + data.count;
+                                if (nearFrontier)
+                                    req.ofs = data.ofs + data.count;
 
                                 if (bpstimer.Second != DateTime.Now.Second)
                                 {
@@ -6140,16 +6158,30 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
                                     bps = 0;
                                 }
 
-                                // a short or empty packet ends the log, but only trust it at the highest
-                                // offset seen - a reordered short packet must not truncate the download.
-                                // the length comes from the end packet itself: the bar can lag behind
-                                // a stalled frontier and must not stand in for the real log length
+                                // a short or empty packet ends the log, but only trust it at the
+                                // highest offset seen - a reordered short packet must not truncate
+                                // the download
                                 if (data.count < 90 && data.ofs + data.count >= maxEnd)
                                 {
-                                    totallength = data.ofs + data.count;
-                                    log.Info("start fillin len " + totallength + " count " + set.Count + " datalen " +
-                                             data.count);
-                                    break;
+                                    if (nearFrontier)
+                                    {
+                                        totallength = data.ofs + data.count;
+                                        log.Info("start fillin len " + totallength + " count " + set.Count +
+                                                 " datalen " + data.count);
+                                        break;
+                                    }
+
+                                    // past the trusted window it clears the bar trivially, so it is
+                                    // only a candidate: packet loss can stall the frontier far behind
+                                    // a genuine end, but a corrupt packet short by chance looks the
+                                    // same. defer to the silence check - the largest of a final run
+                                    // of candidates, so a smaller corrupt one cannot truncate the log
+                                    pendingEnd = Math.Max(pendingEnd, data.ofs + data.count);
+                                }
+                                else
+                                {
+                                    // the stream continued, so any prior end candidate was corrupt
+                                    pendingEnd = 0;
                                 }
                             }
                         }

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -5974,228 +5974,262 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             return new FileStream(await GetLog(MAV.sysid, MAV.compid, no), FileMode.Open, FileAccess.ReadWrite);
         }
 
-        public async Task<string> GetLog(byte sysid, byte compid, ushort no)
+        public async Task<string> GetLog(byte sysid, byte compid, ushort no, CancellationToken cancel = default)
         {
             var filename = Path.GetTempFileName();
-            using (FileStream ms = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite))
+
+            ConcurrentQueue<MAVLinkMessage> queue = new ConcurrentQueue<MAVLinkMessage>();
+            SemaphoreSlim queuesignal = new SemaphoreSlim(0);
+            EventHandler<MAVLinkMessage> handler = (sender, msg) =>
             {
-                Hashtable set = new Hashtable();
-
-                giveComport = false;
-                MAVLinkMessage buffer = MAVLinkMessage.Invalid;
-
-                if (Progress != null)
-                {
-                    Progress((int) 0, "");
-                }
-
-                uint totallength = 0;
-                uint ofs = 0;
-                uint bps = 0;
-                DateTime bpstimer = DateTime.Now;
-
-                ConcurrentQueue<MAVLinkMessage> queue = new ConcurrentQueue<MAVLinkMessage>();
-                EventHandler<MAVLinkMessage> handler = (sender, msg) =>
+                if (msg.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA)
                 {
                     queue.Enqueue(msg);
-                };
-                OnPacketReceived += handler;
-
-                _OnPacketReceived.GetInvocationList().ForEach(a => log.Info(a.GetMethodInfo().ToJSON()));
-                
-
-                mavlink_log_request_data_t req = new mavlink_log_request_data_t();
-
-                req.target_component = compid;
-                req.target_system = sysid;
-                req.id = no;
-                req.ofs = ofs;
-                // entire log
-                req.count = 0xFFFFFFFF;
-
-                // request point
-                generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
-
-                DateTime start = DateTime.Now;
-                int retrys = 3;
-
-
-                while (true)
-                {
-                    if (!(start.AddMilliseconds(3000) > DateTime.Now))
+                    try
                     {
-                        if (retrys > 0)
+                        queuesignal.Release();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // packet arrived after this download already finished
+                    }
+                }
+            };
+            OnPacketReceived += handler;
+
+            try
+            {
+                using (FileStream ms = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite))
+                {
+                    // received 90-byte block numbers; every block below lowestmissing is known received
+                    HashSet<uint> set = new HashSet<uint>();
+                    uint lowestmissing = 0;
+
+                    giveComport = false;
+                    MAVLinkMessage buffer = MAVLinkMessage.Invalid;
+
+                    if (Progress != null)
+                    {
+                        Progress((int) 0, "");
+                    }
+
+                    uint totallength = 0;
+                    uint maxend = 0;
+                    uint ofs = 0;
+                    uint bps = 0;
+                    DateTime bpstimer = DateTime.Now;
+
+                    mavlink_log_request_data_t req = new mavlink_log_request_data_t();
+
+                    req.target_component = compid;
+                    req.target_system = sysid;
+                    req.id = no;
+                    req.ofs = ofs;
+                    // entire log
+                    req.count = 0xFFFFFFFF;
+
+                    // request point
+                    generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
+
+                    DateTime start = DateTime.Now;
+                    int retrys = 3;
+
+
+                    while (true)
+                    {
+                        cancel.ThrowIfCancellationRequested();
+
+                        if (!(start.AddMilliseconds(3000) > DateTime.Now))
                         {
-                            log.Info("GetLog Retry " + retrys + " - giv com " + giveComport);
-                            generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
-                            start = DateTime.Now;
-                            retrys--;
+                            if (retrys > 0)
+                            {
+                                log.Info("GetLog Retry " + retrys + " - giv com " + giveComport);
+                                generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
+                                start = DateTime.Now;
+                                retrys--;
+                                continue;
+                            }
+
+                            giveComport = false;
+                            throw new TimeoutException("Timeout on read - GetLog");
+                        }
+
+                        if (!queue.TryDequeue(out buffer))
+                        {
+                            // wait for the next LOG_DATA packet instead of polling
+                            await queuesignal.WaitAsync(100, cancel).ConfigureAwait(false);
                             continue;
                         }
 
-                        giveComport = false;
-                        OnPacketReceived -= handler;
-                        throw new TimeoutException("Timeout on read - GetLog");
-                    }
-
-                    var start1 = DateTime.Now;
-                    if (!queue.TryDequeue(out buffer))
-                    {
-                        Thread.Sleep(10);
-                        buffer = MAVLinkMessage.Invalid;
-                    }
-                    var end = DateTime.Now - start1;
-                    var lapse = end.TotalMilliseconds;
-                    //Console.WriteLine("readPacketAsync: " + lapse);
-                    if (buffer.Length > 5)
-                    {
-                        if (buffer.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA && buffer.sysid == req.target_system &&
-                            buffer.compid == req.target_component)
+                        if (buffer.Length > 5)
                         {
-                            var data = buffer.ToStructure<mavlink_log_data_t>();
-
-                            if (data.id != no)
-                                continue;
-
-                            // reset retrys
-                            retrys = 3;
-                            start = DateTime.Now;
-
-                            bps += data.count;
-
-                            // record what we have received
-                            set[(data.ofs / 90).ToString()] = 1;
-
-                            if (ms.Position != data.ofs)
-                                ms.Seek((long) data.ofs, SeekOrigin.Begin);
-                            ms.Write(data.data, 0, data.count);
-
-                            // update new start point
-                            req.ofs = data.ofs + data.count;
-
-                            if (bpstimer.Second != DateTime.Now.Second)
+                            if (buffer.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA && buffer.sysid == req.target_system &&
+                                buffer.compid == req.target_component)
                             {
-                                if (Progress != null)
+                                var data = buffer.ToStructure<mavlink_log_data_t>();
+
+                                if (data.id != no)
+                                    continue;
+
+                                // reset retrys
+                                retrys = 3;
+                                start = DateTime.Now;
+
+                                bps += data.count;
+
+                                // record what we have received
+                                set.Add(data.ofs / 90);
+                                while (set.Contains(lowestmissing))
+                                    lowestmissing++;
+                                maxend = Math.Max(maxend, data.ofs + data.count);
+
+                                if (ms.Position != data.ofs)
+                                    ms.Seek((long) data.ofs, SeekOrigin.Begin);
+                                ms.Write(data.data, 0, data.count);
+
+                                // update new start point
+                                req.ofs = data.ofs + data.count;
+
+                                if (bpstimer.Second != DateTime.Now.Second)
                                 {
-                                    Progress((int) req.ofs, "");
+                                    if (Progress != null)
+                                    {
+                                        Progress((int) req.ofs, "");
+                                    }
+
+                                    //Console.WriteLine("log dl bps: " + bps.ToString());
+                                    bpstimer = DateTime.Now;
+                                    bps = 0;
                                 }
 
-                                //Console.WriteLine("log dl bps: " + bps.ToString());
-                                bpstimer = DateTime.Now;
-                                bps = 0;
-                            }
-
-                            // if data is less than max packet size or 0 > exit
-                            if (data.count < 90 || data.count == 0)
-                            {
-                                totallength = data.ofs + data.count;
-                                log.Info("start fillin len " + totallength + " count " + set.Count + " datalen " +
-                                         data.count);
-                                break;
+                                // a short or empty packet ends the log, but only trust it at the highest
+                                // offset seen - a reordered short packet must not truncate the download
+                                if (data.count < 90 && data.ofs + data.count >= maxend)
+                                {
+                                    totallength = maxend;
+                                    log.Info("start fillin len " + totallength + " count " + set.Count + " datalen " +
+                                             data.count);
+                                    break;
+                                }
                             }
                         }
                     }
-                }
 
-                log.Info("set count " + set.Count);
-                log.Info("count total " + ((totallength) / 90 + 1));
-                log.Info("totallength " + totallength);
-                log.Info("current length " + ms.Length);
+                    // blocks 0..totalblocks-1 must all be present before the download is complete
+                    uint totalblocks = (totallength + 89) / 90;
 
-                while (true && ((BaseStream != null && BaseStream.IsOpen) || logreadmode))
-                {
-                    if (totallength == ms.Length && set.Count >= ((totallength) / 90 + 1))
+                    log.Info("set count " + set.Count);
+                    log.Info("count total " + totalblocks);
+                    log.Info("totallength " + totallength);
+                    log.Info("current length " + ms.Length);
+
+                    while ((BaseStream != null && BaseStream.IsOpen) || logreadmode)
                     {
-                        giveComport = false;
-                        OnPacketReceived -= handler;
-                        return filename;
-                    }
+                        cancel.ThrowIfCancellationRequested();
 
-                    if (!(start.AddMilliseconds(500) > DateTime.Now))
-                    {
-                        for (int a = 0; a < ((totallength) / 90 + 1); a++)
+                        if (ms.Length >= totallength && lowestmissing >= totalblocks)
                         {
-                            if (!set.ContainsKey(a.ToString()))
+                            giveComport = false;
+                            return filename;
+                        }
+
+                        if (!(start.AddMilliseconds(500) > DateTime.Now))
+                        {
+                            if (lowestmissing < totalblocks)
                             {
                                 // request large chunk if they are back to back
                                 uint bytereq = 90;
-                                int b = a + 1;
-                                while (!set.ContainsKey(b.ToString()))
+                                uint b = lowestmissing + 1;
+                                while (b < totalblocks && !set.Contains(b))
                                 {
                                     bytereq += 90;
                                     b++;
                                 }
 
-                                req.ofs = (uint) (a * 90);
+                                req.ofs = lowestmissing * 90;
                                 req.count = bytereq;
                                 log.Info("req missing " + req.ofs + " bytes " + req.count + " got " + set.Count + "/" +
-                                         ((totallength) / 90 + 1));
+                                         totalblocks);
                                 generatePacket((byte) MAVLINK_MSG_ID.LOG_REQUEST_DATA, req);
                                 start = DateTime.Now;
-                                break;
                             }
                         }
-                    }
 
-                    if (!queue.TryDequeue(out buffer))
-                    {
-                        Thread.Sleep(10);
-                        buffer = MAVLinkMessage.Invalid;
-                    }
-                    if (buffer.Length > 5)
-                    {
-                        if (buffer.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA && buffer.sysid == req.target_system &&
-                            buffer.compid == req.target_component)
+                        if (!queue.TryDequeue(out buffer))
                         {
-                            var data = buffer.ToStructure<mavlink_log_data_t>();
+                            // wait for the next LOG_DATA packet instead of polling
+                            await queuesignal.WaitAsync(100, cancel).ConfigureAwait(false);
+                            continue;
+                        }
 
-                            if (data.id != no)
-                                continue;
-
-                            // reset retrys
-                            retrys = 3;
-                            start = DateTime.Now;
-
-                            bps += data.count;
-
-                            // record what we have received
-                            set[(data.ofs / 90).ToString()] = 1;
-
-                            ms.Seek((long) data.ofs, SeekOrigin.Begin);
-                            ms.Write(data.data, 0, data.count);
-
-                            // update new start point
-                            req.ofs = data.ofs + data.count;
-
-                            if (bpstimer.Second != DateTime.Now.Second)
+                        if (buffer.Length > 5)
+                        {
+                            if (buffer.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA && buffer.sysid == req.target_system &&
+                                buffer.compid == req.target_component)
                             {
-                                if (Progress != null)
+                                var data = buffer.ToStructure<mavlink_log_data_t>();
+
+                                if (data.id != no)
+                                    continue;
+
+                                // reset retrys
+                                retrys = 3;
+                                start = DateTime.Now;
+
+                                bps += data.count;
+
+                                // record what we have received
+                                set.Add(data.ofs / 90);
+                                while (set.Contains(lowestmissing))
+                                    lowestmissing++;
+
+                                ms.Seek((long) data.ofs, SeekOrigin.Begin);
+                                ms.Write(data.data, 0, data.count);
+
+                                // update new start point
+                                req.ofs = data.ofs + data.count;
+
+                                if (bpstimer.Second != DateTime.Now.Second)
                                 {
-                                    Progress((int) req.ofs, "");
+                                    if (Progress != null)
+                                    {
+                                        Progress((int) req.ofs, "");
+                                    }
+
+                                    //Console.WriteLine("log dl bps: " + bps.ToString());
+                                    bpstimer = DateTime.Now;
+                                    bps = 0;
                                 }
 
-                                //Console.WriteLine("log dl bps: " + bps.ToString());
-                                bpstimer = DateTime.Now;
-                                bps = 0;
-                            }
-
-                            // check if we have next set and invalidate to request next packets
-                            if (set.ContainsKey(((data.ofs / 90) + 1).ToString()))
-                            {
-                                start = DateTime.MinValue;
-                            }
-
-                            // if data is less than max packet size or 0 > exit
-                            if (data.count < 90 || data.count == 0)
-                            {
-                                continue;
+                                // check if we have next set and invalidate to request next packets
+                                if (set.Contains((data.ofs / 90) + 1))
+                                {
+                                    start = DateTime.MinValue;
+                                }
                             }
                         }
                     }
+
+                    throw new Exception("Failed to get log");
+                }
+            }
+            catch
+            {
+                // dont leave a partial temp file behind on timeout/cancel/link loss
+                try
+                {
+                    File.Delete(filename);
+                }
+                catch
+                {
                 }
 
+                throw;
+            }
+            finally
+            {
                 OnPacketReceived -= handler;
-                throw new Exception("Failed to get log");
+                queuesignal.Dispose();
             }
         }
 

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -5995,7 +5995,12 @@ Mission Planner waits for 2 valid heartbeat packets before connecting
             SemaphoreSlim queueSignal = new SemaphoreSlim(0);
             EventHandler<MAVLinkMessage> handler = (sender, msg) =>
             {
-                if (msg.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA)
+                // filter on the header fields here so unrelated traffic - e.g.
+                // another vehicle's log stream on the same link - cannot grow
+                // the queue or reset the silence timers; the log id needs a
+                // payload parse and stays checked on the consumer side
+                if (msg.msgid == (byte) MAVLINK_MSG_ID.LOG_DATA && msg.sysid == sysid &&
+                    msg.compid == compid)
                 {
                     queue.Enqueue(msg);
                     try

--- a/ExtLibs/ArduPilot/MissionPlanner.ArduPilot.csproj
+++ b/ExtLibs/ArduPilot/MissionPlanner.ArduPilot.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MissionPlanner.ArduPilot.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="1.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ExtLibs/WinUSBNet/Nefarius.Drivers.WinUSB.csproj
+++ b/ExtLibs/WinUSBNet/Nefarius.Drivers.WinUSB.csproj
@@ -26,7 +26,7 @@
 
     <!-- Win32 Metadata -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.268">
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="69.0.7-preview">

--- a/Log/LogDownloadMavLink.cs
+++ b/Log/LogDownloadMavLink.cs
@@ -182,6 +182,8 @@ namespace MissionPlanner.Log
                 }
                 AppendSerialLog(string.Format(LogStrings.DownloadStarting, Settings.Instance.LogDir));
 
+                // the previous download (if any) has finished - the buttons gate on that
+                downloadCts?.Dispose();
                 downloadCts = new CancellationTokenSource();
                 var cancel = downloadCts.Token;
                 System.Threading.Thread t11 =
@@ -202,7 +204,21 @@ namespace MissionPlanner.Log
             log.Info("GetLog " + entry.id);
 
             MainV2.comPort.Progress += ComPort_Progress;
+            try
+            {
+                return await GetLogUnsubscribed(entry, cancel).ConfigureAwait(false);
+            }
+            finally
+            {
+                // always drop the handler, also when the download throws or is
+                // canceled - a leaked handler would double-count progress on
+                // the next download
+                MainV2.comPort.Progress -= ComPort_Progress;
+            }
+        }
 
+        async Task<string> GetLogUnsubscribed(MAVLink.mavlink_log_entry_t entry, CancellationToken cancel)
+        {
             status = SerialStatus.Reading;
 
             // get df log from mav
@@ -237,7 +253,7 @@ namespace MissionPlanner.Log
             if (logtime.Year < 1990)
             {
                 log.Info("about to GetFirstGpsTime: " + logfile);
-                // get gps time of assci log
+                // scan the downloaded log for its first gps time
                 var dflb = new DFLogBuffer(logfile);
                 logtime = dflb.dflog.gpsstarttime;
                 dflb.Clear();
@@ -264,18 +280,28 @@ namespace MissionPlanner.Log
                 }
             }
 
-            MainV2.comPort.Progress -= ComPort_Progress;
-
             return logfile;
         }
 
         protected override void OnClosed(EventArgs e)
         {
             this.closed = true;
-            downloadCts?.Cancel();
+            CancelDownload();
             MainV2.comPort.Progress -= ComPort_Progress;
 
             base.OnClosed(e);
+        }
+
+        void CancelDownload()
+        {
+            try
+            {
+                downloadCts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // the download finished and disposed the source just as we canceled
+            }
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -290,7 +316,7 @@ namespace MissionPlanner.Log
                 }
 
                 // actually stop the transfer, not just the form
-                downloadCts?.Cancel();
+                CancelDownload();
             }
 
             base.OnClosing(e);
@@ -375,13 +401,19 @@ namespace MissionPlanner.Log
             {
                 AppendSerialLog("Error in log " + ex.Message);
             }
+            finally
+            {
+                // this download owns the token source - release it before the
+                // buttons re-arm; Cancel racing this from OnClosing is handled there
+                Interlocked.Exchange(ref downloadCts, null)?.Dispose();
 
-            RunOnUIThread(() =>
+                RunOnUIThread(() =>
                 {
                     BUT_DLall.Enabled = true;
                     BUT_DLthese.Enabled = true;
                     status = SerialStatus.Done;
                 });
+            }
         }
 
         IEnumerable<int> GetSelectedLogIndices()
@@ -406,10 +438,12 @@ namespace MissionPlanner.Log
         {
             RunOnUIThread(() =>
             {
-                // scale to 0-1000 so byte counts beyond int.MaxValue dont overflow the ProgressBar
+                // scale to 0-1000 so byte counts beyond int.MaxValue don't overflow the
+                // ProgressBar; clamp because the sender may deliver more bytes than the
+                // LOG_ENTRY size it reported
                 progressBar1.Minimum = 0;
                 progressBar1.Maximum = 1000;
-                progressBar1.Value = max == 0 ? 0 : (int)(current * 1000.0 / max);
+                progressBar1.Value = max == 0 ? 0 : (int)Math.Min(1000.0, current * 1000.0 / max);
                 progressBar1.Visible = (current < max);
 
                 if (current == 0)
@@ -454,6 +488,8 @@ namespace MissionPlanner.Log
                 {
                     BUT_DLall.Enabled = false;
                     BUT_DLthese.Enabled = false;
+                    // the previous download (if any) has finished - the buttons gate on that
+                    downloadCts?.Dispose();
                     downloadCts = new CancellationTokenSource();
                     var cancel = downloadCts.Token;
                     System.Threading.Thread t11 = new System.Threading.Thread(delegate () { DownloadThread(toDownload, cancel); })

--- a/Log/LogDownloadMavLink.cs
+++ b/Log/LogDownloadMavLink.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -22,6 +23,7 @@ namespace MissionPlanner.Log
         uint tallyBytes; // previous downloaded logs
         uint totalBytes; // total expected
         List<MAVLink.mavlink_log_entry_t> logEntries;
+        CancellationTokenSource downloadCts;
 
         //List<Model> orientation = new List<Model>();
 
@@ -180,11 +182,13 @@ namespace MissionPlanner.Log
                 }
                 AppendSerialLog(string.Format(LogStrings.DownloadStarting, Settings.Instance.LogDir));
 
+                downloadCts = new CancellationTokenSource();
+                var cancel = downloadCts.Token;
                 System.Threading.Thread t11 =
                     new System.Threading.Thread(
                         delegate ()
                         {
-                            DownloadThread(toDownload);
+                            DownloadThread(toDownload, cancel);
                         })
                     {
                         Name = "Log Download All thread"
@@ -193,25 +197,24 @@ namespace MissionPlanner.Log
             }
         }
 
-        async Task<string> GetLog(ushort no, string fileName)
+        async Task<string> GetLog(MAVLink.mavlink_log_entry_t entry, CancellationToken cancel)
         {
-            log.Info("GetLog " + no);
+            log.Info("GetLog " + entry.id);
 
             MainV2.comPort.Progress += ComPort_Progress;
 
             status = SerialStatus.Reading;
 
             // get df log from mav
-            var fn = await MainV2.comPort.GetLog(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, no)
+            var fn = await MainV2.comPort.GetLog(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, entry.id, cancel)
                 .ConfigureAwait(false);
 
-            GC.Collect();
             status = SerialStatus.Done;
 
             logfile = Settings.Instance.LogDir + Path.DirectorySeparatorChar
                                                + MainV2.comPort.MAV.aptype.ToString() + Path.DirectorySeparatorChar
-                                               + MainV2.comPort.MAV.sysid + Path.DirectorySeparatorChar + no + " " +
-                                               MakeValidFileName(fileName) + ".bin";
+                                               + MainV2.comPort.MAV.sysid + Path.DirectorySeparatorChar + entry.id + " " +
+                                               MakeValidFileName(GetItemCaption(entry)) + ".bin";
 
             // make log dir
             Directory.CreateDirectory(Path.GetDirectoryName(logfile));
@@ -223,17 +226,22 @@ namespace MissionPlanner.Log
             }
             catch
             {
-                CustomMessageBox.Show(Strings.ErrorRenameFile + " " + logfile + "\nto " + logfile,
+                CustomMessageBox.Show(Strings.ErrorRenameFile + " " + fn + "\nto " + logfile,
                     Strings.ERROR);
             }
 
             // rename file if needed
-            log.Info("about to GetFirstGpsTime: " + logfile);
-            // get gps time of assci log
-            var dflb = new DFLogBuffer(logfile);
-            DateTime logtime = dflb.dflog.gpsstarttime;
-            dflb.Clear();
-            GC.Collect();
+            // LOG_ENTRY already carries the log start time - only fall back to a full scan
+            // of the fresh download when the vehicle reported no valid time
+            DateTime logtime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(entry.time_utc).ToLocalTime();
+            if (logtime.Year < 1990)
+            {
+                log.Info("about to GetFirstGpsTime: " + logfile);
+                // get gps time of assci log
+                var dflb = new DFLogBuffer(logfile);
+                logtime = dflb.dflog.gpsstarttime;
+                dflb.Clear();
+            }
 
             // rename log fs we have a valid gps time, logtime is after 1990-01-01, since some GPS does not use Unix epoch for invalid time.
             if (logtime.Year >= 1990)
@@ -264,6 +272,7 @@ namespace MissionPlanner.Log
         protected override void OnClosed(EventArgs e)
         {
             this.closed = true;
+            downloadCts?.Cancel();
             MainV2.comPort.Progress -= ComPort_Progress;
 
             base.OnClosed(e);
@@ -279,6 +288,9 @@ namespace MissionPlanner.Log
                     e.Cancel = true;
                     return;
                 }
+
+                // actually stop the transfer, not just the form
+                downloadCts?.Cancel();
             }
 
             base.OnClosing(e);
@@ -321,7 +333,7 @@ namespace MissionPlanner.Log
             status = SerialStatus.Done;
         }
 
-        private async void DownloadThread(int[] selectedLogs)
+        private async void DownloadThread(int[] selectedLogs, CancellationToken cancel)
         {
             try
             {
@@ -340,11 +352,10 @@ namespace MissionPlanner.Log
                 foreach (int a in selectedLogs)
                 {
                     var entry = logEntries[a]; // mavlink_log_entry_t
-                    string fileName = GetItemCaption(entry);
 
-                    AppendSerialLog(string.Format(LogStrings.FetchingLog, fileName));
+                    AppendSerialLog(string.Format(LogStrings.FetchingLog, GetItemCaption(entry)));
 
-                    await GetLog(entry.id, fileName).ConfigureAwait(false);
+                    await GetLog(entry, cancel).ConfigureAwait(false);
 
                     tallyBytes += receivedbytes;
                     receivedbytes = 0;
@@ -355,6 +366,10 @@ namespace MissionPlanner.Log
 
                 AppendSerialLog("Download complete.");
                 Console.Beep();
+            }
+            catch (OperationCanceledException)
+            {
+                AppendSerialLog("Download canceled.");
             }
             catch (Exception ex)
             {
@@ -391,9 +406,10 @@ namespace MissionPlanner.Log
         {
             RunOnUIThread(() =>
             {
-                progressBar1.Minimum = (int)min;
-                progressBar1.Maximum = (int)max;
-                progressBar1.Value = (int)current;
+                // scale to 0-1000 so byte counts beyond int.MaxValue dont overflow the ProgressBar
+                progressBar1.Minimum = 0;
+                progressBar1.Maximum = 1000;
+                progressBar1.Value = max == 0 ? 0 : (int)(current * 1000.0 / max);
                 progressBar1.Visible = (current < max);
 
                 if (current == 0)
@@ -412,7 +428,7 @@ namespace MissionPlanner.Log
                     var left = max - current;
                     var eta = DateTime.Now.AddSeconds(left / avgbps);
                     var remaining = new DateTime().AddSeconds(left / avgbps);
-                    labelBytes.Text = MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)current) + " "
+                    labelBytes.Text = MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)Math.Min(current, int.MaxValue)) + " "
                     + per.ToString("N1") + "% "
                     + MissionPlanner.Controls.ConnectionStats.ToHumanReadableByteCount((int)avgbps) + "/s "
                     + (remaining.Day > 1 || remaining.Hour > 0 ? ((remaining.Day - 1) * 24 + remaining.Hour).ToString() + ":" : "") + remaining.ToString("mm:ss") + " left";
@@ -438,7 +454,9 @@ namespace MissionPlanner.Log
                 {
                     BUT_DLall.Enabled = false;
                     BUT_DLthese.Enabled = false;
-                    System.Threading.Thread t11 = new System.Threading.Thread(delegate () { DownloadThread(toDownload); })
+                    downloadCts = new CancellationTokenSource();
+                    var cancel = downloadCts.Token;
+                    System.Threading.Thread t11 = new System.Threading.Thread(delegate () { DownloadThread(toDownload, cancel); })
                     {
                         Name = "Log download single thread"
                     };

--- a/MissionPlanner.csproj
+++ b/MissionPlanner.csproj
@@ -62,6 +62,7 @@
     <Compile Remove="plugins\**" />
     <Compile Remove="resedit\**" />
     <Compile Remove="SikRadio\**" />
+    <Compile Remove="tests\**" />
     <Compile Remove="Updater\**" />
     <Compile Remove="wix\**" />
     <EmbeddedResource Remove="APMPlannerXplanes\**" />
@@ -73,6 +74,7 @@
     <EmbeddedResource Remove="plugins\**" />
     <EmbeddedResource Remove="resedit\**" />
     <EmbeddedResource Remove="SikRadio\**" />
+    <EmbeddedResource Remove="tests\**" />
     <EmbeddedResource Remove="Updater\**" />
     <EmbeddedResource Remove="wix\**" />
     <None Remove="APMPlannerXplanes\**" />
@@ -84,6 +86,7 @@
     <None Remove="plugins\**" />
     <None Remove="resedit\**" />
     <None Remove="SikRadio\**" />
+    <None Remove="tests\**" />
     <None Remove="Updater\**" />
     <None Remove="wix\**" />
     <Compile Remove=".git\**" />

--- a/tests/MissionPlanner.ArduPilot.SitlTests/MissionPlanner.ArduPilot.SitlTests.csproj
+++ b/tests/MissionPlanner.ArduPilot.SitlTests/MissionPlanner.ArduPilot.SitlTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ExtLibs\ArduPilot\MissionPlanner.ArduPilot.csproj" />
+    <ProjectReference Include="..\..\ExtLibs\Comms\MissionPlanner.Comms.csproj" />
+    <ProjectReference Include="..\..\ExtLibs\Mavlink\MAVLink.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="lossy_proxy.py" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/MissionPlanner.ArduPilot.SitlTests/Program.cs
+++ b/tests/MissionPlanner.ArduPilot.SitlTests/Program.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MissionPlanner;
+using MissionPlanner.Comms;
+
+class Program
+{
+    // args[0]: host, args[1]: port, args[2]: oracle file path (WSL log via \\wsl$),
+    // args[3]: "cancel" to also run the mid-download cancel check
+    static async Task<int> Main(string[] args)
+    {
+        var host = args.Length > 0 ? args[0] : "127.0.0.1";
+        var port = args.Length > 1 ? args[1] : "5760";
+        var oracle = args.Length > 2 ? args[2] : null;
+        var doCancel = args.Contains("cancel");
+
+        var tcp = new TcpSerial { Host = host, Port = port, autoReconnect = false, retrys = 1 };
+        tcp.Open();
+        Console.WriteLine($"[harness] connected to {host}:{port}");
+
+        var mav = new MAVLinkInterface();
+        mav.BaseStream = tcp;
+
+        var stop = new CancellationTokenSource();
+        var pump = Task.Run(async () =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                try
+                {
+                    // GetLogEntry reads packets itself - stand down like MainV2.SerialReader does
+                    if (mav.giveComport)
+                    {
+                        await Task.Delay(5).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    await mav.readPacketAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    await Task.Delay(5).ConfigureAwait(false);
+                }
+            }
+        });
+
+        // wait for a heartbeat so sysid/compid are known
+        var deadline = DateTime.UtcNow.AddSeconds(20);
+        while (mav.MAV.sysid == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(100);
+        if (mav.MAV.sysid == 0)
+        {
+            Console.WriteLine("[harness] FAIL no heartbeat within 20s");
+            return 1;
+        }
+
+        Console.WriteLine($"[harness] heartbeat from sysid={mav.MAV.sysid} compid={mav.MAV.compid}");
+
+        long packets = 0;
+        mav.OnPacketReceived += (s, m) => Interlocked.Increment(ref packets);
+
+        // let SITL finish sensor init before asking for the log list
+        await Task.Delay(2000);
+
+        // --- list logs ---
+        System.Collections.Generic.List<MAVLink.mavlink_log_entry_t> entries = null;
+        for (int attempt = 1; attempt <= 3; attempt++)
+        {
+            Console.WriteLine($"[harness] log list attempt {attempt}, packets seen so far: {Interlocked.Read(ref packets)}");
+            try
+            {
+                entries = (await mav.GetLogEntry()).Values.OrderBy(a => a.id).ToList();
+                break;
+            }
+            catch (TimeoutException) when (attempt < 3)
+            {
+                Console.WriteLine("[harness] log list timed out, retrying");
+                await Task.Delay(1000);
+            }
+        }
+        Console.WriteLine($"[harness] log list: {entries.Count} entries");
+        foreach (var e in entries)
+            Console.WriteLine($"[harness]   id={e.id} size={e.size} utc={e.time_utc}");
+        if (entries.Count == 0)
+        {
+            Console.WriteLine("[harness] FAIL no logs on vehicle");
+            return 1;
+        }
+
+        var entry = entries.First();
+
+        // --- download ---
+        var sw = Stopwatch.StartNew();
+        var file = await mav.GetLog(mav.MAV.sysid, mav.MAV.compid, entry.id);
+        sw.Stop();
+        var bytes = File.ReadAllBytes(file);
+        File.Delete(file);
+        Console.WriteLine($"[harness] downloaded {bytes.Length} bytes in {sw.Elapsed.TotalSeconds:F2}s " +
+                          $"({bytes.Length / Math.Max(sw.Elapsed.TotalSeconds, 0.001) / 1024:F0} KiB/s)");
+
+        if (entry.size != 0 && bytes.Length != entry.size)
+        {
+            Console.WriteLine($"[harness] FAIL size mismatch: LOG_ENTRY said {entry.size}, got {bytes.Length}");
+            return 1;
+        }
+
+        if (oracle != null)
+        {
+            var expected = File.ReadAllBytes(oracle);
+            if (expected.Length != bytes.Length)
+            {
+                Console.WriteLine($"[harness] FAIL oracle length {expected.Length} != downloaded {bytes.Length}");
+                return 1;
+            }
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                if (expected[i] != bytes[i])
+                {
+                    Console.WriteLine($"[harness] FAIL first byte difference at offset {i}");
+                    return 1;
+                }
+            }
+
+            Console.WriteLine($"[harness] PASS oracle byte-for-byte match ({expected.Length} bytes)");
+        }
+
+        if (doCancel)
+        {
+            using (var cts = new CancellationTokenSource(400))
+            {
+                try
+                {
+                    await mav.GetLog(mav.MAV.sysid, mav.MAV.compid, entry.id, cts.Token);
+                    Console.WriteLine("[harness] FAIL cancel: download completed anyway");
+                    return 1;
+                }
+                catch (OperationCanceledException)
+                {
+                    Console.WriteLine("[harness] PASS cancel raised OperationCanceledException");
+                }
+            }
+
+            // link must still be usable afterwards: list logs again.
+            // a couple of LOG_DATA packets may still be in flight right after the
+            // cancel, so allow a short settle + one retry
+            await Task.Delay(500);
+            int again = -1;
+            for (int attempt = 1; attempt <= 3; attempt++)
+            {
+                try
+                {
+                    again = (await mav.GetLogEntry()).Values.Count;
+                    break;
+                }
+                catch (Exception ex) when (attempt < 3)
+                {
+                    Console.WriteLine($"[harness] post-cancel list attempt {attempt} failed: {ex.Message}");
+                    await Task.Delay(1000);
+                }
+            }
+
+            if (again < 0)
+            {
+                Console.WriteLine("[harness] FAIL link unusable after cancel");
+                return 1;
+            }
+
+            Console.WriteLine($"[harness] PASS link usable after cancel (log list: {again} entries)");
+        }
+
+        stop.Cancel();
+        tcp.Close();
+        Console.WriteLine("[harness] DONE");
+        return 0;
+    }
+}

--- a/tests/MissionPlanner.ArduPilot.SitlTests/README.md
+++ b/tests/MissionPlanner.ArduPilot.SitlTests/README.md
@@ -1,0 +1,84 @@
+# MissionPlanner.ArduPilot.SitlTests
+
+Manual end-to-end harness for the MAVLink log download protocol
+(`MAVLinkInterface.GetLog`) against a real ArduPilot SITL
+(Software In The Loop) simulated vehicle. Not part of any automated test
+run - it needs SITL running and is driven by hand.
+
+What it verifies:
+
+- log listing (`GetLogEntry`) against the vehicle
+- full download, timed, with the byte count checked against `LOG_ENTRY.size`
+- optional byte-for-byte comparison against an oracle file (the log SITL wrote
+  to its own disk)
+- optional mid-download cancellation, including that the link stays usable
+  afterwards (`LOG_REQUEST_END` behavior)
+
+## One-time SITL setup (WSL Ubuntu)
+
+```bash
+mkdir -p ~/sitl && cd ~/sitl
+curl -fsSL -o arducopter https://firmware.ardupilot.org/Copter/stable/SITL_x86_64_linux_gnu/arducopter
+curl -fsSL -o copter.parm https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/autotest/default_params/copter.parm
+chmod +x arducopter
+```
+
+Generate a static dataflash log (boot once with disarmed logging, then exit so
+the file is closed; SITL waits for a TCP client before booting, hence the
+python one-liner):
+
+```bash
+cd ~/sitl
+printf "LOG_DISARMED 1\n" > extra.parm
+(python3 -c "import socket,time; time.sleep(3); s=socket.create_connection(('127.0.0.1',5760)); s.settimeout(35); end=time.time()+30
+while time.time()<end:
+    try:
+        if not s.recv(4096): break
+    except Exception: break" &)
+timeout 35 ./arducopter --model + --speedup 1 -w --defaults copter.parm,extra.parm --home -35.363262,149.165237,584,353
+ls -la logs/   # 00000001.BIN is the oracle file
+```
+
+## Running
+
+Start the vehicle (it exits when the TCP client disconnects, so restart it for
+each harness run):
+
+```bash
+cd ~/sitl && ./arducopter --model + --speedup 1 --defaults copter.parm --home -35.363262,149.165237,584,353
+```
+
+Copy the oracle out of WSL (Git Bash mangles `\\wsl$` paths, so copy first):
+
+```bash
+cp '//wsl$/Ubuntu/home/<user>/sitl/logs/00000001.BIN' /tmp/oracle.bin
+```
+
+Run the harness (from `bin/Debug/net472` after `dotnet build`):
+
+```
+SitlLogTest.exe <host> <port> [oraclePath] [cancel]
+
+MissionPlanner.ArduPilot.SitlTests.exe 127.0.0.1 5760 C:\path\to\oracle.bin cancel
+```
+
+`cancel` also runs the mid-download cancellation check.
+
+## Lossy-link run
+
+`lossy_proxy.py` sits between the harness and SITL and drops every 20th
+LOG_DATA frame (~5% loss), forcing the fill-in phase to recover the gaps.
+In WSL, with SITL already listening on 5760:
+
+```bash
+python3 lossy_proxy.py    # listens on 5770, forwards to 127.0.0.1:5760
+```
+
+Then point the harness at port 5770. The download is expected to be slower
+(one round-trip per scattered missing block) but still byte-identical to the
+oracle. The proxy prints how many frames it saw and dropped on exit.
+
+## Reference results (2026-08-26, 2.3 MB log, WSL2 loopback)
+
+- clean link: 2,306,048 bytes in ~0.45 s (~5 MiB/s), byte-identical
+- 5% LOG_DATA loss: byte-identical in ~55 s (1,348 of 26,971 frames dropped)

--- a/tests/MissionPlanner.ArduPilot.SitlTests/README.md
+++ b/tests/MissionPlanner.ArduPilot.SitlTests/README.md
@@ -78,7 +78,18 @@ Then point the harness at port 5770. The download is expected to be slower
 (one round-trip per scattered missing block) but still byte-identical to the
 oracle. The proxy prints how many frames it saw and dropped on exit.
 
-## Reference results (2026-08-26, 2.3 MB log, WSL2 loopback)
+## Reference results (2026-08-29, 2.3 MB log, WSL2 loopback)
 
 - clean link: 2,306,048 bytes in ~0.45 s (~5 MiB/s), byte-identical
-- 5% LOG_DATA loss: byte-identical in ~55 s (1,348 of 26,971 frames dropped)
+- 5% LOG_DATA loss: byte-identical in ~58 s, one streaming pass
+  (1,348 of 26,971 frames dropped; the extra ~3 s over the earlier ~55 s
+  reference is one silence window confirming the end of log, whose packet
+  arrives far past a frontier stalled at the first dropped block)
+
+The lossy run is the reason this harness exists: a 5% loss stalls the
+contiguous frontier near the start of the log, so the genuine end packet
+of a large log arrives far past any near-frontier trust window - a case
+the unit tests cannot represent because their logs are smaller than the
+window itself. A fix that rejected such end packets outright passed the
+whole unit suite and never completed here: every recovered gap forced the
+vehicle to re-stream the entire log.

--- a/tests/MissionPlanner.ArduPilot.SitlTests/lossy_proxy.py
+++ b/tests/MissionPlanner.ArduPilot.SitlTests/lossy_proxy.py
@@ -29,7 +29,9 @@ def pump_gcs_to_vehicle(gcs, veh):
 
 
 def pump_vehicle_to_gcs(veh, gcs):
-    buf = b""
+    # bytearray + index cursor: repeated += / slicing on immutable bytes
+    # would reallocate the whole buffer per frame (O(n^2) on large logs)
+    buf = bytearray()
     seen = 0
     dropped = 0
     try:
@@ -37,39 +39,41 @@ def pump_vehicle_to_gcs(veh, gcs):
             d = veh.recv(4096)
             if not d:
                 break
-            buf += d
-            out = b""
-            while buf:
-                b0 = buf[0]
+            buf.extend(d)
+            out = []
+            pos = 0
+            while pos < len(buf):
+                b0 = buf[pos]
                 if b0 == 0xFD:  # MAVLink2: 10 byte hdr + payload + 2 crc (+13 sig)
-                    if len(buf) < 10:
+                    if len(buf) - pos < 10:
                         break
-                    length = 12 + buf[1] + (13 if buf[2] & 0x01 else 0)
-                    if len(buf) < length:
+                    length = 12 + buf[pos + 1] + (13 if buf[pos + 2] & 0x01 else 0)
+                    if len(buf) - pos < length:
                         break
-                    msgid = buf[7] | (buf[8] << 8) | (buf[9] << 16)
+                    msgid = buf[pos + 7] | (buf[pos + 8] << 8) | (buf[pos + 9] << 16)
                 elif b0 == 0xFE:  # MAVLink1: 6 byte hdr + payload + 2 crc
-                    if len(buf) < 6:
+                    if len(buf) - pos < 6:
                         break
-                    length = 8 + buf[1]
-                    if len(buf) < length:
+                    length = 8 + buf[pos + 1]
+                    if len(buf) - pos < length:
                         break
-                    msgid = buf[5]
+                    msgid = buf[pos + 5]
                 else:
-                    out += buf[:1]
-                    buf = buf[1:]
+                    out.append(buf[pos:pos + 1])
+                    pos += 1
                     continue
 
-                frame = buf[:length]
-                buf = buf[length:]
+                frame = buf[pos:pos + length]
+                pos += length
                 if msgid == LOG_DATA:
                     seen += 1
                     if seen % DROP_EVERY == 0:
                         dropped += 1
                         continue
-                out += frame
+                out.append(frame)
+            del buf[:pos]
             if out:
-                gcs.sendall(out)
+                gcs.sendall(b"".join(out))
     except OSError:
         pass
     finally:

--- a/tests/MissionPlanner.ArduPilot.SitlTests/lossy_proxy.py
+++ b/tests/MissionPlanner.ArduPilot.SitlTests/lossy_proxy.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""TCP proxy that forwards MAVLink both ways but drops every Nth LOG_DATA
+frame (msgid 120) travelling vehicle -> GCS. Listens on LISTEN_PORT and
+connects to the SITL vehicle on VEHICLE_PORT."""
+import socket
+import sys
+import threading
+
+LISTEN_PORT = 5770
+VEHICLE_PORT = 5760
+DROP_EVERY = 20
+LOG_DATA = 120
+
+
+def pump_gcs_to_vehicle(gcs, veh):
+    try:
+        while True:
+            d = gcs.recv(4096)
+            if not d:
+                break
+            veh.sendall(d)
+    except OSError:
+        pass
+    finally:
+        try:
+            veh.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def pump_vehicle_to_gcs(veh, gcs):
+    buf = b""
+    seen = 0
+    dropped = 0
+    try:
+        while True:
+            d = veh.recv(4096)
+            if not d:
+                break
+            buf += d
+            out = b""
+            while buf:
+                b0 = buf[0]
+                if b0 == 0xFD:  # MAVLink2: 10 byte hdr + payload + 2 crc (+13 sig)
+                    if len(buf) < 10:
+                        break
+                    length = 12 + buf[1] + (13 if buf[2] & 0x01 else 0)
+                    if len(buf) < length:
+                        break
+                    msgid = buf[7] | (buf[8] << 8) | (buf[9] << 16)
+                elif b0 == 0xFE:  # MAVLink1: 6 byte hdr + payload + 2 crc
+                    if len(buf) < 6:
+                        break
+                    length = 8 + buf[1]
+                    if len(buf) < length:
+                        break
+                    msgid = buf[5]
+                else:
+                    out += buf[:1]
+                    buf = buf[1:]
+                    continue
+
+                frame = buf[:length]
+                buf = buf[length:]
+                if msgid == LOG_DATA:
+                    seen += 1
+                    if seen % DROP_EVERY == 0:
+                        dropped += 1
+                        continue
+                out += frame
+            if out:
+                gcs.sendall(out)
+    except OSError:
+        pass
+    finally:
+        print(f"[proxy] LOG_DATA seen={seen} dropped={dropped}", flush=True)
+        try:
+            gcs.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def main():
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("0.0.0.0", LISTEN_PORT))
+    srv.listen(1)
+    print(f"[proxy] listening on {LISTEN_PORT}, dropping 1/{DROP_EVERY} LOG_DATA", flush=True)
+    gcs, addr = srv.accept()
+    print(f"[proxy] client {addr}", flush=True)
+    veh = socket.create_connection(("127.0.0.1", VEHICLE_PORT))
+    gcs.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    veh.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    t = threading.Thread(target=pump_gcs_to_vehicle, args=(gcs, veh), daemon=True)
+    t.start()
+    pump_vehicle_to_gcs(veh, gcs)
+    t.join(timeout=2)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
+++ b/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MissionPlanner.Comms;
+using Xunit;
+
+namespace MissionPlanner.ArduPilot.Tests
+{
+    public class GetLogTests
+    {
+        const byte VehicleSysid = 1;
+        const byte VehicleCompid = 1;
+        const ushort LogId = 3;
+        const int BlockSize = 90;
+
+        /// <summary>
+        /// Simulated vehicle end of the MAVLink log download protocol, connected
+        /// to a MAVLinkInterface through an in-memory CommsInjection link.
+        /// </summary>
+        sealed class FakeLogVehicle : IDisposable
+        {
+            public readonly CommsInjection Link = new CommsInjection();
+            public readonly MAVLinkInterface Mav = new MAVLinkInterface();
+            public readonly List<MAVLink.mavlink_log_request_data_t> Requests = new List<MAVLink.mavlink_log_request_data_t>();
+            public Action<MAVLink.mavlink_log_request_data_t> OnRequest;
+
+            readonly MAVLink.MavlinkParse _parse = new MAVLink.MavlinkParse();
+            readonly byte[] _log;
+            readonly CancellationTokenSource _stop = new CancellationTokenSource();
+            readonly Task _pump;
+
+            public FakeLogVehicle(byte[] log)
+            {
+                _log = log;
+
+                Link.WriteCallback += (sender, outbytes) =>
+                {
+                    MAVLink.MAVLinkMessage msg;
+                    try
+                    {
+                        msg = new MAVLink.MAVLinkMessage(outbytes.ToArray());
+                    }
+                    catch
+                    {
+                        return;
+                    }
+
+                    if (msg.msgid != (uint)MAVLink.MAVLINK_MSG_ID.LOG_REQUEST_DATA)
+                        return;
+
+                    var req = msg.ToStructure<MAVLink.mavlink_log_request_data_t>();
+                    if (req.id != LogId)
+                        return;
+
+                    lock (Requests)
+                        Requests.Add(req);
+                    OnRequest?.Invoke(req);
+                };
+
+                Mav.BaseStream = Link;
+
+                // real-time protocol timeouts scaled down so the suite stays fast
+                Mav.LogDataTimeoutMs = 500;
+                Mav.LogDataRefetchMs = 100;
+
+                // GetLog consumes packets via OnPacketReceived, which fires from the
+                // receive loop - pump it the same way MainV2.SerialReader does
+                _pump = Task.Run(async () =>
+                {
+                    while (!_stop.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            await Mav.readPacketAsync().ConfigureAwait(false);
+                        }
+                        catch
+                        {
+                            try
+                            {
+                                await Task.Delay(1, _stop.Token).ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                            }
+                        }
+                    }
+                });
+            }
+
+            public void SendBlock(uint ofs, int count)
+            {
+                var payload = new byte[BlockSize];
+                Array.Copy(_log, ofs, payload, 0, count);
+                Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA, new MAVLink.mavlink_log_data_t(ofs, LogId, (byte)count, payload));
+            }
+
+            public void SendEndMarker(uint ofs)
+            {
+                Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA, new MAVLink.mavlink_log_data_t(ofs, LogId, 0, new byte[BlockSize]));
+            }
+
+            public void Send(MAVLink.MAVLINK_MSG_ID msgid, object indata)
+            {
+                Link.AppendBuffer(_parse.GenerateMAVLinkPacket20(msgid, indata, false, VehicleSysid, VehicleCompid));
+            }
+
+            /// <summary>
+            /// Serve a LOG_REQUEST_DATA the way ArduPilot does: 90 byte blocks with
+            /// a short block at end of log, or a zero count marker when the log ends
+            /// on an exact block boundary. skipBlocks are dropped, but only the
+            /// first time each is requested.
+            /// </summary>
+            public void Serve(MAVLink.mavlink_log_request_data_t req, HashSet<uint> skipBlocks = null)
+            {
+                var end = Math.Min((ulong)req.ofs + req.count, (ulong)_log.Length);
+                for (var ofs = (ulong)req.ofs; ofs < end; ofs += BlockSize)
+                {
+                    var block = (uint)(ofs / BlockSize);
+                    if (skipBlocks != null && skipBlocks.Remove(block))
+                        continue;
+                    SendBlock((uint)ofs, (int)Math.Min(BlockSize, end - ofs));
+                }
+
+                if (end == (ulong)_log.Length && (ulong)req.ofs + req.count > end && _log.Length % BlockSize == 0)
+                    SendEndMarker((uint)end);
+            }
+
+            public void Dispose()
+            {
+                _stop.Cancel();
+                Link.Close();
+                try
+                {
+                    _pump.Wait(2000);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        static byte[] MakeLog(int length)
+        {
+            var data = new byte[length];
+            new Random(42).NextBytes(data);
+            return data;
+        }
+
+        /// <summary>A private directory owned by a single test, removed on dispose.</summary>
+        sealed class TestDir : IDisposable
+        {
+            public string Root { get; } =
+                Path.Combine(Path.GetTempPath(), "GetLogTests-" + Guid.NewGuid().ToString("N"));
+
+            public TestDir()
+            {
+                Directory.CreateDirectory(Root);
+            }
+
+            public string File(string name) => Path.Combine(Root, name);
+
+            public void Dispose()
+            {
+                try
+                {
+                    Directory.Delete(Root, true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        static async Task<byte[]> Download(FakeLogVehicle vehicle, CancellationToken cancel)
+        {
+            using (var dir = new TestDir())
+            {
+                var file = await vehicle.Mav.GetLogInternal(VehicleSysid, VehicleCompid, LogId,
+                    dir.File("log.bin"), cancel);
+                return File.ReadAllBytes(file);
+            }
+        }
+
+        [Fact]
+        public async Task DownloadsCompleteLogInOrder()
+        {
+            var log = MakeLog(1234);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                vehicle.OnRequest = req => vehicle.Serve(req);
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+            }
+        }
+
+        [Fact]
+        public async Task HandlesLogSizeExactMultipleOfBlockSize()
+        {
+            var log = MakeLog(900);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                vehicle.OnRequest = req => vehicle.Serve(req);
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+                // the fill in phase must not ask for a phantom block past end of log
+                lock (vehicle.Requests)
+                    Assert.False(vehicle.Requests.Skip(1).Any(r => r.ofs >= 900),
+                        "requested data past the end of the log");
+            }
+        }
+
+        [Fact]
+        public async Task RefetchesDroppedBlocks()
+        {
+            var log = MakeLog(1000);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var drop = new HashSet<uint> { 3, 7 };
+                vehicle.OnRequest = req => vehicle.Serve(req, drop);
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+                lock (vehicle.Requests)
+                    Assert.True(vehicle.Requests.Any(r => r.ofs == 3 * BlockSize),
+                        "first dropped block was never re-requested");
+            }
+        }
+
+        [Fact]
+        public async Task IgnoresStrayShortPacketBeforeEndOfLog()
+        {
+            var log = MakeLog(1234);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var first = true;
+                vehicle.OnRequest = req =>
+                {
+                    if (!first)
+                    {
+                        vehicle.Serve(req);
+                        return;
+                    }
+
+                    first = false;
+                    var end = Math.Min((ulong)req.ofs + req.count, (ulong)log.Length);
+                    for (var ofs = (ulong)req.ofs; ofs < end; ofs += BlockSize)
+                    {
+                        // a stale short retransmit mid stream must not truncate the log
+                        if (ofs == 8 * BlockSize)
+                            vehicle.SendBlock(3 * BlockSize, 40);
+                        vehicle.SendBlock((uint)ofs, (int)Math.Min(BlockSize, end - ofs));
+                    }
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.True(log.Length == result.Length, "stray short packet truncated the download");
+                Assert.Equal(log, result);
+            }
+        }
+
+        [Fact]
+        public async Task EmptyLogProducesEmptyFile()
+        {
+            using (var vehicle = new FakeLogVehicle(new byte[0]))
+            {
+                vehicle.OnRequest = req => vehicle.SendEndMarker(0);
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Empty(result);
+            }
+        }
+
+        [Fact]
+        public async Task CancelStopsDownloadAndDeletesFile()
+        {
+            var log = MakeLog(100 * BlockSize);
+            using (var vehicle = new FakeLogVehicle(log))
+            using (var dir = new TestDir())
+            {
+                // stream a few blocks, then go silent so the download hangs mid way
+                vehicle.OnRequest = req =>
+                {
+                    for (uint block = 0; block < 5; block++)
+                        vehicle.SendBlock(block * BlockSize, BlockSize);
+                };
+
+                var path = dir.File("log.bin");
+
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken))
+                {
+                    cts.CancelAfter(300);
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                        () => vehicle.Mav.GetLogInternal(VehicleSysid, VehicleCompid, LogId, path, cts.Token));
+                }
+
+                Assert.False(File.Exists(path), "partial file left behind after cancel");
+            }
+        }
+
+        [Fact(Timeout = 15000)]
+        public async Task TimesOutWhenVehicleNeverResponds()
+        {
+            using (var vehicle = new FakeLogVehicle(MakeLog(10)))
+            using (var dir = new TestDir())
+            {
+                var path = dir.File("log.bin");
+
+                // no OnRequest wired - total silence; LogDataTimeoutMs with 3 retries
+                await Assert.ThrowsAsync<TimeoutException>(
+                    () => vehicle.Mav.GetLogInternal(VehicleSysid, VehicleCompid, LogId, path,
+                        TestContext.Current.CancellationToken));
+
+                Assert.False(File.Exists(path), "partial file left behind after timeout");
+            }
+        }
+    }
+}

--- a/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
+++ b/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
@@ -204,6 +204,88 @@ namespace MissionPlanner.ArduPilot.Tests
                 var result = await Download(vehicle, TestContext.Current.CancellationToken);
 
                 Assert.Equal(log, result);
+                Assert.True(vehicle.EndRequests > 0,
+                    "LOG_REQUEST_END not sent after a completed download");
+            }
+        }
+
+        [Fact]
+        public async Task IgnoresPacketWithOversizedCount()
+        {
+            var log = MakeLog(1234);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                vehicle.OnRequest = req =>
+                {
+                    // count larger than the 90-byte payload array must be skipped,
+                    // not abort the download
+                    vehicle.Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA,
+                        new MAVLink.mavlink_log_data_t(0, LogId, 200, new byte[BlockSize]));
+                    vehicle.Serve(req);
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+            }
+        }
+
+        [Fact]
+        public async Task BogusFillinOffsetDoesNotExtendFile()
+        {
+            var log = MakeLog(1000);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var drop = new HashSet<uint> { 3 };
+                var bogusSent = false;
+                vehicle.OnRequest = req =>
+                {
+                    if (req.ofs == 3 * BlockSize && !bogusSent)
+                    {
+                        // a fill-in response beyond the end of the log must not
+                        // grow the file past the length the end marker established
+                        bogusSent = true;
+                        vehicle.Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA,
+                            new MAVLink.mavlink_log_data_t((uint)(log.Length + 10 * BlockSize),
+                                LogId, BlockSize, new byte[BlockSize]));
+                    }
+
+                    vehicle.Serve(req, drop);
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.True(result.Length == log.Length,
+                    $"bogus fill-in offset changed the file length: {result.Length} != {log.Length}");
+                Assert.Equal(log, result);
+            }
+        }
+
+        [Fact]
+        public async Task FillinTimesOutWhenVehicleGoesSilent()
+        {
+            var log = MakeLog(1000);
+            using (var vehicle = new FakeLogVehicle(log))
+            using (var dir = new TestDir())
+            {
+                // serve the streaming phase with a block missing, then never answer
+                // the fill-in requests - the download must fail, not hang forever
+                var first = true;
+                vehicle.OnRequest = req =>
+                {
+                    if (!first)
+                        return;
+                    first = false;
+                    vehicle.Serve(req, new HashSet<uint> { 3 });
+                };
+
+                var path = dir.File("log.bin");
+
+                await Assert.ThrowsAsync<TimeoutException>(
+                    () => vehicle.Mav.GetLogInternal(VehicleSysid, VehicleCompid, LogId, path,
+                        TestContext.Current.CancellationToken));
+
+                Assert.False(File.Exists(path), "partial file left behind after fill-in timeout");
             }
         }
 

--- a/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
+++ b/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
@@ -26,6 +26,9 @@ namespace MissionPlanner.ArduPilot.Tests
             public readonly MAVLinkInterface Mav = new MAVLinkInterface();
             public readonly List<MAVLink.mavlink_log_request_data_t> Requests = new List<MAVLink.mavlink_log_request_data_t>();
             public Action<MAVLink.mavlink_log_request_data_t> OnRequest;
+            int _endRequests;
+
+            public int EndRequests => Volatile.Read(ref _endRequests);
 
             readonly MAVLink.MavlinkParse _parse = new MAVLink.MavlinkParse();
             readonly byte[] _log;
@@ -45,6 +48,12 @@ namespace MissionPlanner.ArduPilot.Tests
                     }
                     catch
                     {
+                        return;
+                    }
+
+                    if (msg.msgid == (uint)MAVLink.MAVLINK_MSG_ID.LOG_REQUEST_END)
+                    {
+                        Interlocked.Increment(ref _endRequests);
                         return;
                     }
 
@@ -304,6 +313,8 @@ namespace MissionPlanner.ArduPilot.Tests
                 }
 
                 Assert.False(File.Exists(path), "partial file left behind after cancel");
+                Assert.True(vehicle.EndRequests > 0,
+                    "LOG_REQUEST_END not sent - the vehicle would keep streaming LOG_DATA");
             }
         }
 

--- a/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
+++ b/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
@@ -210,6 +210,75 @@ namespace MissionPlanner.ArduPilot.Tests
         }
 
         [Fact]
+        public async Task StaleDuplicatesDoNotMultiplyFillRequests()
+        {
+            var log = MakeLog(1000);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var drop = new HashSet<uint> { 3 };
+                var fillRequests = 0;
+                vehicle.OnRequest = req =>
+                {
+                    if (Interlocked.Increment(ref fillRequests) > 1)
+                    {
+                        // before serving the gap, flood stale duplicates of blocks the
+                        // download already holds - they must not each trigger another
+                        // fill request on a duplicating link
+                        for (var i = 0; i < 30; i++)
+                        {
+                            vehicle.SendBlock(8 * BlockSize, BlockSize);
+                            vehicle.SendBlock(9 * BlockSize, BlockSize);
+                        }
+                    }
+
+                    vehicle.Serve(req, drop);
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+                lock (vehicle.Requests)
+                    Assert.True(vehicle.Requests.Count <= 8,
+                        $"{vehicle.Requests.Count} requests for one dropped block - stale " +
+                        "duplicates are multiplying fill requests");
+            }
+        }
+
+        [Fact]
+        public async Task CorruptFarOffsetDoesNotBreakEndDetection()
+        {
+            var log = MakeLog(1234);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var corruptSent = false;
+                vehicle.OnRequest = req =>
+                {
+                    var end = Math.Min((ulong)req.ofs + req.count, (ulong)log.Length);
+                    for (var ofs = (ulong)req.ofs; ofs < end; ofs += BlockSize)
+                    {
+                        // a corrupt-but-valid-looking packet at a far offset must neither
+                        // poison end-of-log detection nor lengthen the returned file
+                        if (ofs == 5 * BlockSize && !corruptSent)
+                        {
+                            corruptSent = true;
+                            vehicle.Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA,
+                                new MAVLink.mavlink_log_data_t(1_000_000, LogId, BlockSize,
+                                    new byte[BlockSize]));
+                        }
+
+                        vehicle.SendBlock((uint)ofs, (int)Math.Min(BlockSize, end - ofs));
+                    }
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.True(result.Length == log.Length,
+                    $"corrupt far-offset packet changed the file length: {result.Length} != {log.Length}");
+                Assert.Equal(log, result);
+            }
+        }
+
+        [Fact]
         public async Task IgnoresPacketWithOversizedCount()
         {
             var log = MakeLog(1234);

--- a/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
+++ b/tests/MissionPlanner.ArduPilot.Tests/GetLogTests.cs
@@ -279,6 +279,144 @@ namespace MissionPlanner.ArduPilot.Tests
         }
 
         [Fact]
+        public async Task CorruptShortFarPacketDoesNotEndTheDownload()
+        {
+            var log = MakeLog(1234);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var corruptSent = false;
+                vehicle.OnRequest = req =>
+                {
+                    var end = Math.Min((ulong)req.ofs + req.count, (ulong)log.Length);
+                    for (var ofs = (ulong)req.ofs; ofs < end; ofs += BlockSize)
+                    {
+                        // a packet that is both short and at a far offset clears the
+                        // end-of-log bar trivially - it must not terminate the stream
+                        // at a phantom length
+                        if (ofs == 5 * BlockSize && !corruptSent)
+                        {
+                            corruptSent = true;
+                            vehicle.Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA,
+                                new MAVLink.mavlink_log_data_t(1_000_000, LogId, 40,
+                                    new byte[BlockSize]));
+                        }
+
+                        vehicle.SendBlock((uint)ofs, (int)Math.Min(BlockSize, end - ofs));
+                    }
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.True(result.Length == log.Length,
+                    $"corrupt short far packet ended the download at a phantom length: " +
+                    $"{result.Length} != {log.Length}");
+                Assert.Equal(log, result);
+            }
+        }
+
+        [Fact]
+        public async Task CorruptFarPacketDoesNotHijackRetryOffset()
+        {
+            var log = MakeLog(1234);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var first = true;
+                vehicle.OnRequest = req =>
+                {
+                    if (!first)
+                    {
+                        vehicle.Serve(req);
+                        return;
+                    }
+
+                    // stream five blocks, inject a corrupt far packet, then go silent -
+                    // the streaming retry must resume from the true stream position,
+                    // not from past the corrupt offset
+                    first = false;
+                    for (var ofs = 0u; ofs < 5 * BlockSize; ofs += BlockSize)
+                        vehicle.SendBlock(ofs, BlockSize);
+                    vehicle.Send(MAVLink.MAVLINK_MSG_ID.LOG_DATA,
+                        new MAVLink.mavlink_log_data_t(1_000_000, LogId, BlockSize,
+                            new byte[BlockSize]));
+                };
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+                lock (vehicle.Requests)
+                {
+                    Assert.True(vehicle.Requests.Any(r => r.ofs == 5 * BlockSize),
+                        "retry did not resume from the true stream position");
+                    Assert.False(vehicle.Requests.Any(r => r.ofs > (uint)log.Length),
+                        "retry requested data past the corrupt offset");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task RepeatedStaleDataDoesNotKeepTheStreamAliveForever()
+        {
+            var log = MakeLog(1000);
+            using (var vehicle = new FakeLogVehicle(log))
+            using (var dir = new TestDir())
+            {
+                var first = true;
+                vehicle.OnRequest = req =>
+                {
+                    if (first)
+                    {
+                        // stream only the first three blocks, then answer every retry
+                        // with a stale duplicate - it brings no new data, so it must
+                        // not keep resetting the retry budget forever
+                        first = false;
+                        for (var ofs = 0u; ofs < 3 * BlockSize; ofs += BlockSize)
+                            vehicle.SendBlock(ofs, BlockSize);
+                        return;
+                    }
+
+                    vehicle.SendBlock(0, BlockSize);
+                };
+
+                using (var guard = new CancellationTokenSource(30000))
+                using (var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                    guard.Token, TestContext.Current.CancellationToken))
+                {
+                    var path = dir.File("log.bin");
+
+                    await Assert.ThrowsAsync<TimeoutException>(
+                        () => vehicle.Mav.GetLogInternal(VehicleSysid, VehicleCompid, LogId,
+                            path, linked.Token));
+
+                    Assert.False(guard.IsCancellationRequested,
+                        "download looped instead of timing out");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EndMarkerBeyondStalledFrontierCompletesViaFillin()
+        {
+            // an early drop stalls the contiguous frontier while the log is large
+            // enough that the genuine end packet sits far past its trust window -
+            // the end must still hand over to the fill-in phase, not force the
+            // whole stream to be sent again
+            var log = MakeLog(12000);
+            using (var vehicle = new FakeLogVehicle(log))
+            {
+                var drop = new HashSet<uint> { 3 };
+                vehicle.OnRequest = req => vehicle.Serve(req, drop);
+
+                var result = await Download(vehicle, TestContext.Current.CancellationToken);
+
+                Assert.Equal(log, result);
+                lock (vehicle.Requests)
+                    Assert.True(vehicle.Requests.Count <= 4,
+                        $"{vehicle.Requests.Count} requests for one dropped block - the " +
+                        "far end marker is forcing full re-streams");
+            }
+        }
+
+        [Fact]
         public async Task IgnoresPacketWithOversizedCount()
         {
             var log = MakeLog(1234);

--- a/tests/MissionPlanner.ArduPilot.Tests/MissionPlanner.ArduPilot.Tests.csproj
+++ b/tests/MissionPlanner.ArduPilot.Tests/MissionPlanner.ArduPilot.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <!-- vulnerable-package advisories from the referenced production projects are
+         theirs to fix and already reported on their own builds - only audit this
+         project's direct packages here -->
+    <NuGetAuditMode>direct</NuGetAuditMode>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ExtLibs\ArduPilot\MissionPlanner.ArduPilot.csproj" />
+    <ProjectReference Include="..\..\ExtLibs\Comms\MissionPlanner.Comms.csproj" />
+    <ProjectReference Include="..\..\ExtLibs\Mavlink\MAVLink.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Problem

Log download over MAVLink has long-standing reliability and performance problems
(#3461, and the class of complaints in #3387 and the forum's many
"slow log download" threads). In `MAVLinkInterface.GetLog`:

- Received blocks were tracked in a `Hashtable` keyed by the *decimal string* of
  `ofs/90`, and every 500 ms retry tick re-scanned all blocks from zero — on a
  large log with a late gap, millions of string allocations per tick.
- Both download phases polled with `Thread.Sleep(10)`, adding up to 10 ms of
  latency per packet independent of link speed.
- A short `LOG_DATA` packet ended the streaming phase even when it arrived out
  of order, silently truncating the download.
- The fill-in phase requested a phantom block past EOF whenever the log size
  was an exact multiple of 90 bytes.
- There was no cancellation: closing the download form only closed the form —
  the transfer (and the vehicle's streaming) kept running, and the partial temp
  file was leaked.
- After every download, the whole log was re-parsed (`DFLogBuffer`) just to
  extract a GPS timestamp for the filename.

## Changes

`ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs`:

- Track received blocks in a `HashSet<uint>` with a lowest-missing cursor;
  finding the first gap is O(1) instead of an O(n) string-keyed rescan.
- Replace polling with a semaphore signalled per received `LOG_DATA` packet.
  The waits carry the timeouts, so the loops only run when a packet arrives or
  a deadline genuinely expires.
- Only treat a short packet as end-of-log at the highest offset seen, and use a
  correct ceiling block count (no phantom block past EOF).
- Add an optional `CancellationToken` (public signature otherwise unchanged;
  the `[Obsolete]` `GetLog(ushort)` wrapper still compiles and behaves the same).
- Send `LOG_REQUEST_END` when a download is abandoned, so the vehicle stops
  streaming and the next log operation works immediately.
- Delete the partial file on timeout/cancel/link loss.
- Split the protocol into an internal `GetLogInternal(..., filename, ...)` that
  takes the destination path, with the retry/refetch timeouts injectable —
  defaults and public behavior are unchanged; this is what makes the code unit
  testable.

`Log/LogDownloadMavLink.cs`:

- Closing the form (after confirming) now actually cancels the transfer.
- The downloaded file is named from `LOG_ENTRY.time_utc`; the full-log GPS scan
  runs only as a fallback when the vehicle reports no valid time. This removes
  a second full pass over every downloaded log.
- Progress bar is scaled 0–1000 so multi-GB batch downloads no longer overflow
  the `int`-based `ProgressBar`.

## Behavior changes to be aware of

- The streaming-phase timeout now means "3 s with no `LOG_DATA` received" rather
  than a rolling deadline since the last accepted packet. These differ only
  when a second GCS is downloading a different log on the same link — and the
  new behavior avoids retry-spamming a busy vehicle.
- Filenames come from the vehicle-reported `time_utc` instead of a GPS-message
  scan (same times in practice; the old scan remains as the fallback).

## Tests

- `tests/MissionPlanner.ArduPilot.Tests` — xUnit suite (7 tests) driving the
  protocol against an in-memory fake vehicle over `CommsInjection`: in-order
  and reordered transfers, dropped-block refetch, exact-multiple-of-90 logs,
  empty logs, cancellation (including `LOG_REQUEST_END`), and timeout. Runs in
  ~3 s via the built exe or `dotnet test`.
- `tests/MissionPlanner.ArduPilot.SitlTests` — manual end-to-end harness plus a
  MAVLink-aware lossy proxy and a README with the SITL setup recipe.

Neither project is in `MissionPlanner.sln`, so CI is unaffected.

## Verification against ArduPilot SITL (Copter stable, TCP)

- Clean link: 2,306,048-byte log downloaded in ~0.45 s (~5 MiB/s),
  **byte-for-byte identical** to the log file SITL wrote to its own disk.
- 5% `LOG_DATA` loss (1,348 of 26,971 frames dropped by the proxy): fill-in
  phase recovered every gap; result still byte-identical.
- Cancel mid-download: prompt `OperationCanceledException`, no leaked temp
  file, and the very next `LOG_REQUEST_LIST` succeeds.

Not exercised end-to-end: tlog-replay mode (`logreadmode`) and MAVLink1-only
vehicles (covered by the protocol logic and unit tests, but SITL testing used
MAVLink2 over TCP).

Also included: `Microsoft.Windows.CsWin32` pin in `ExtLibs/WinUSBNet` bumped
0.3.268 → 0.3.269 (the version NuGet already resolves — 0.3.268 is no longer
on the feed) to fix the NU1603 restore warning.

Addresses #3461.